### PR TITLE
feat(schema): strengthen validators (regions, scopes, bounds, mutual exclusion)

### DIFF
--- a/calc/derive.py
+++ b/calc/derive.py
@@ -10,6 +10,7 @@ from .schema import (
     ActivitySchedule,
     EmissionFactor,
     Profile,
+    RegionCode,
     load_activity_schedule,
     load_emission_factors,
     load_grid_intensity,
@@ -29,7 +30,7 @@ def get_grid_intensity(
     if mix_region:
         return grid_lookup.get(mix_region)
     if use_canada_average:
-        return grid_lookup.get("canada_average")
+        return grid_lookup.get(RegionCode.CA)
     if profile and profile.default_grid_region:
         return grid_lookup.get(profile.default_grid_region)
     return None

--- a/calc/schema.py
+++ b/calc/schema.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional
+from datetime import date
+from enum import Enum
+from typing import List, Optional, Literal
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -15,35 +17,86 @@ def _load_csv(path: Path, model: type[BaseModel]) -> List[BaseModel]:
     return [model(**row) for row in df.to_dict(orient="records")]
 
 
+class RegionCode(str, Enum):
+    CA_AB = "CA-AB"
+    CA_BC = "CA-BC"
+    CA_MB = "CA-MB"
+    CA_NB = "CA-NB"
+    CA_NL = "CA-NL"
+    CA_NS = "CA-NS"
+    CA_NT = "CA-NT"
+    CA_NU = "CA-NU"
+    CA_ON = "CA-ON"
+    CA_PE = "CA-PE"
+    CA_QC = "CA-QC"
+    CA_SK = "CA-SK"
+    CA_YT = "CA-YT"
+    CA = "CA"
+
+
+ScopeBoundary = Literal["WTT+TTW", "cradle-to-grave", "Electricity LCA", "gate-to-gate"]
+
+
 class EmissionFactor(BaseModel):
     activity_id: str
     value_g_per_unit: Optional[float] = None
     is_grid_indexed: Optional[bool] = None
     electricity_kwh_per_unit: Optional[float] = None
+    region: Optional[RegionCode] = None
+    scope_boundary: Optional[ScopeBoundary] = None
+    vintage_year: Optional[int] = None
+    uncert_low_g_per_unit: Optional[float] = None
+    uncert_high_g_per_unit: Optional[float] = None
 
     model_config = ConfigDict(extra="ignore")
 
     @model_validator(mode="after")
-    def check_bounds(self):
+    def check_bounds(self):  # noqa: C901 - simple validator
         has_value = self.value_g_per_unit is not None
         has_grid = bool(self.is_grid_indexed) or self.electricity_kwh_per_unit is not None
         if has_value and has_grid:
             raise ValueError("emission factor cannot be both fixed and grid indexed")
         if not has_value and not has_grid:
             raise ValueError("emission factor requires either fixed value or grid index")
-        if self.is_grid_indexed:
-            if self.electricity_kwh_per_unit is None:
-                raise ValueError("grid indexed factors need electricity_kwh_per_unit")
+        if has_grid:
+            if not self.is_grid_indexed:
+                raise ValueError("grid indexed factors must set is_grid_indexed=True")
+            if self.electricity_kwh_per_unit is None or self.electricity_kwh_per_unit <= 0:
+                raise ValueError(
+                    "grid indexed factors require electricity_kwh_per_unit > 0"
+                )
         else:
+            if self.is_grid_indexed:
+                raise ValueError("is_grid_indexed only allowed with grid indexed factors")
             if self.electricity_kwh_per_unit is not None:
-                raise ValueError("electricity_kwh_per_unit only allowed for grid indexed factors")
+                raise ValueError(
+                    "electricity_kwh_per_unit only allowed for grid indexed factors"
+                )
+
+        if self.uncert_low_g_per_unit is not None or self.uncert_high_g_per_unit is not None:
+            if (
+                self.value_g_per_unit is None
+                or self.uncert_low_g_per_unit is None
+                or self.uncert_high_g_per_unit is None
+            ):
+                raise ValueError("uncertainty bounds require value, low and high")
+            if not (
+                self.uncert_low_g_per_unit
+                <= self.value_g_per_unit
+                <= self.uncert_high_g_per_unit
+            ):
+                raise ValueError("value must be within uncertainty bounds")
+
+        if self.vintage_year is not None and self.vintage_year > date.today().year:
+            raise ValueError("vintage_year cannot be in the future")
+
         return self
 
 
 class Profile(BaseModel):
     profile_id: str
     office_days_per_week: Optional[float] = None
-    default_grid_region: Optional[str] = None
+    default_grid_region: Optional[RegionCode] = None
 
 
 class ActivitySchedule(BaseModel):
@@ -51,13 +104,24 @@ class ActivitySchedule(BaseModel):
     activity_id: str
     quantity_per_week: Optional[float] = None
     office_only: Optional[bool] = None
-    region_override: Optional[str] = None
-    mix_region: Optional[str] = None
+    freq_per_day: Optional[float] = None
+    freq_per_week: Optional[float] = None
+    office_days_only: Optional[bool] = None
+    region_override: Optional[RegionCode] = None
+    mix_region: Optional[RegionCode] = None
     use_canada_average: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def check_freq(self):
+        if self.freq_per_day is not None and self.freq_per_week is not None:
+            raise ValueError(
+                "cannot specify both freq_per_day and freq_per_week on same row"
+            )
+        return self
 
 
 class GridIntensity(BaseModel):
-    region: str
+    region: RegionCode
     intensity_g_per_kwh: Optional[float] = None
 
 

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -3,8 +3,10 @@ from calc.schema import ActivitySchedule, EmissionFactor, Profile
 
 
 def test_emission_calculation_and_nulls():
-    profile = Profile(profile_id="p1", office_days_per_week=3, default_grid_region="region_profile")
-    grid = {"region_profile": 100}
+    profile = Profile(
+        profile_id="p1", office_days_per_week=3, default_grid_region="CA-ON"
+    )
+    grid = {"CA-ON": 100}
     assert get_grid_intensity(profile, grid) == 100
 
     ef_coffee = EmissionFactor(activity_id="coffee", value_g_per_unit=1)
@@ -23,5 +25,7 @@ def test_emission_calculation_and_nulls():
     emission_stream = compute_emission(sched_stream, profile, ef_stream, grid)
     assert emission_stream == 14 * 52 * 100
 
-    sched_null = ActivitySchedule(profile_id="p1", activity_id="stream", quantity_per_week=None)
+    sched_null = ActivitySchedule(
+        profile_id="p1", activity_id="stream", quantity_per_week=None
+    )
     assert compute_emission(sched_null, profile, ef_stream, grid) is None

--- a/tests/test_grid_index.py
+++ b/tests/test_grid_index.py
@@ -3,14 +3,14 @@ from calc.schema import Profile
 
 
 def test_grid_precedence():
-    profile = Profile(profile_id="p1", default_grid_region="profile_region")
+    profile = Profile(profile_id="p1", default_grid_region="CA-ON")
     grid = {
-        "override_region": 1,
-        "mix_region": 2,
-        "canada_average": 3,
-        "profile_region": 4,
+        "CA-AB": 1,
+        "CA-BC": 2,
+        "CA": 3,
+        "CA-ON": 4,
     }
-    assert get_grid_intensity(profile, grid, region_override="override_region") == 1
-    assert get_grid_intensity(profile, grid, mix_region="mix_region") == 2
+    assert get_grid_intensity(profile, grid, region_override="CA-AB") == 1
+    assert get_grid_intensity(profile, grid, mix_region="CA-BC") == 2
     assert get_grid_intensity(profile, grid, use_canada_average=True) == 3
     assert get_grid_intensity(profile, grid) == 4

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,8 @@
 import pytest
+from datetime import date
 from pydantic import ValidationError
 
-from calc.schema import EmissionFactor
+from calc.schema import EmissionFactor, ActivitySchedule
 
 
 def test_fixed_vs_grid_mutual_exclusion():
@@ -24,3 +25,56 @@ def test_fixed_vs_grid_mutual_exclusion():
         EmissionFactor(activity_id="half", is_grid_indexed=True)
     with pytest.raises(ValidationError):
         EmissionFactor(activity_id="half2", electricity_kwh_per_unit=1)
+
+
+def test_uncert_bounds_and_vintage_year():
+    current_year = date.today().year
+    EmissionFactor(
+        activity_id="ok",
+        value_g_per_unit=5,
+        uncert_low_g_per_unit=1,
+        uncert_high_g_per_unit=10,
+        vintage_year=current_year,
+    )
+    with pytest.raises(ValidationError):
+        EmissionFactor(
+            activity_id="bad_bounds",
+            value_g_per_unit=5,
+            uncert_low_g_per_unit=6,
+            uncert_high_g_per_unit=7,
+        )
+    with pytest.raises(ValidationError):
+        EmissionFactor(
+            activity_id="future",
+            value_g_per_unit=1,
+            vintage_year=current_year + 1,
+        )
+
+
+def test_schedule_freq_mutual_exclusion():
+    ActivitySchedule(profile_id="p", activity_id="a", freq_per_day=1)
+    ActivitySchedule(profile_id="p", activity_id="b", freq_per_week=1)
+    with pytest.raises(ValidationError):
+        ActivitySchedule(
+            profile_id="p",
+            activity_id="c",
+            freq_per_day=1,
+            freq_per_week=1,
+        )
+
+
+def test_region_and_scope_literals():
+    EmissionFactor(
+        activity_id="region_ok",
+        value_g_per_unit=1,
+        region="CA-ON",
+        scope_boundary="gate-to-gate",
+    )
+    with pytest.raises(ValidationError):
+        EmissionFactor(activity_id="bad_region", value_g_per_unit=1, region="US-CA")
+    with pytest.raises(ValidationError):
+        EmissionFactor(
+            activity_id="bad_scope",
+            value_g_per_unit=1,
+            scope_boundary="bad",
+        )


### PR DESCRIPTION
## Summary
- add ISO-3166-2 region enum and scope boundary literal types
- enforce emission factor bounds, vintage year, and grid/value mutual exclusivity
- validate activity schedules for conflicting frequencies and use region codes for grid lookups

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897fb4fa800832cbd7ba11bbb7d6441