### PR TITLE
feat(data): units registry + unit validation

### DIFF
--- a/data/units.csv
+++ b/data/units.csv
@@ -1,0 +1,11 @@
+unit
+km
+hour
+kWh
+cup
+GB
+L
+m3
+participant-hour
+1k_tokens
+image

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -3,9 +3,7 @@ from calc.schema import ActivitySchedule, EmissionFactor, Profile
 
 
 def test_emission_calculation_and_nulls():
-    profile = Profile(
-        profile_id="p1", office_days_per_week=3, default_grid_region="CA-ON"
-    )
+    profile = Profile(profile_id="p1", office_days_per_week=3, default_grid_region="CA-ON")
     grid = {"CA-ON": 100}
     assert get_grid_intensity(profile, grid) == 100
 
@@ -25,7 +23,5 @@ def test_emission_calculation_and_nulls():
     emission_stream = compute_emission(sched_stream, profile, ef_stream, grid)
     assert emission_stream == 14 * 52 * 100
 
-    sched_null = ActivitySchedule(
-        profile_id="p1", activity_id="stream", quantity_per_week=None
-    )
+    sched_null = ActivitySchedule(profile_id="p1", activity_id="stream", quantity_per_week=None)
     assert compute_emission(sched_null, profile, ef_stream, grid) is None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,7 +2,7 @@ import pytest
 from datetime import date
 from pydantic import ValidationError
 
-from calc.schema import EmissionFactor, ActivitySchedule
+from calc.schema import EmissionFactor, ActivitySchedule, Activity
 
 
 def test_fixed_vs_grid_mutual_exclusion():
@@ -78,3 +78,13 @@ def test_region_and_scope_literals():
             value_g_per_unit=1,
             scope_boundary="bad",
         )
+
+
+def test_units_registry_validation():
+    Activity(activity_id="a", default_unit="km")
+    with pytest.raises(ValidationError):
+        Activity(activity_id="b", default_unit="badunit")
+
+    EmissionFactor(activity_id="c", unit="hour", value_g_per_unit=1)
+    with pytest.raises(ValidationError):
+        EmissionFactor(activity_id="d", unit="badunit", value_g_per_unit=1)


### PR DESCRIPTION
## Summary
- add canonical `data/units.csv` registry
- validate `Activity.default_unit` and `EmissionFactor.unit` against registry
- cover validation with tests

## Testing
- `PYTHONPATH=. poetry run ruff check .`
- `PYTHONPATH=. poetry run black --check .`
- `PYTHONPATH=. poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ff148218832c9eacde4da72e8408