### PR TITLE
feat(calc): metadata headers and figure JSON with references

### DIFF
--- a/calc/figures.py
+++ b/calc/figures.py
@@ -1,7 +1,55 @@
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
 import pandas as pd
+import yaml
+
+from .citations import load_citations
+
+CONFIG_PATH = Path(__file__).parent / "config.yaml"
+
+
+def build_metadata(method: str) -> dict:
+    profile = yaml.safe_load(CONFIG_PATH.read_text()).get("default_profile")
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "profile": profile,
+        "method": method,
+    }
+
+
+def _write_csv_with_metadata(df: pd.DataFrame, path: Path, metadata: dict) -> None:
+    with path.open("w") as fh:
+        for key, value in metadata.items():
+            fh.write(f"# {key}: {value}\n")
+        df.to_csv(fh, index=False)
 
 
 def total_by_activity(df: pd.DataFrame) -> pd.DataFrame:
     return df.groupby("activity_id", as_index=False)["annual_emissions_g"].sum()
+
+
+def export_total_by_activity(
+    df: pd.DataFrame, out_dir: Path, citation_keys: List[str]
+) -> pd.DataFrame:
+    fig = total_by_activity(df)
+    metadata = build_metadata("figures.total_by_activity")
+    _write_csv_with_metadata(fig, out_dir / "figure_total_by_activity.csv", metadata)
+    payload = {
+        **metadata,
+        "references": load_citations(citation_keys),
+        "data": fig.to_dict(orient="records"),
+    }
+    (out_dir / "figure_total_by_activity.json").write_text(json.dumps(payload, indent=2))
+    return fig
+
+
+__all__ = [
+    "total_by_activity",
+    "export_total_by_activity",
+    "build_metadata",
+]

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -2,6 +2,64 @@ from calc.derive import compute_emission, get_grid_intensity
 from calc.schema import ActivitySchedule, EmissionFactor, Profile
 
 
+def test_export_metadata_and_references(tmp_path, monkeypatch):
+    from pathlib import Path
+    import json
+    import shutil
+
+    import calc.derive as derive_mod
+    from calc.schema import GridIntensity
+
+    def fake_load_emission_factors():
+        return [
+            EmissionFactor(activity_id="coffee", value_g_per_unit=1),
+            EmissionFactor(activity_id="stream", is_grid_indexed=True, electricity_kwh_per_unit=1),
+        ]
+
+    def fake_load_profiles():
+        return [Profile(profile_id="p1", office_days_per_week=3, default_grid_region="CA-ON")]
+
+    def fake_load_activity_schedule():
+        return [
+            ActivitySchedule(
+                profile_id="p1", activity_id="coffee", quantity_per_week=5, office_only=True
+            ),
+            ActivitySchedule(
+                profile_id="p1", activity_id="stream", quantity_per_week=14, office_only=False
+            ),
+        ]
+
+    def fake_load_grid_intensity():
+        return [GridIntensity(region="CA-ON", intensity_g_per_kwh=100)]
+
+    monkeypatch.setattr(derive_mod, "load_emission_factors", fake_load_emission_factors)
+    monkeypatch.setattr(derive_mod, "load_profiles", fake_load_profiles)
+    monkeypatch.setattr(derive_mod, "load_activity_schedule", fake_load_activity_schedule)
+    monkeypatch.setattr(derive_mod, "load_grid_intensity", fake_load_grid_intensity)
+
+    out_dir = Path("calc/outputs")
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    derive_mod.export_view()
+    csv_lines = (out_dir / "export_view.csv").read_text().splitlines()
+    assert csv_lines[0].startswith("# generated_at: ")
+    assert csv_lines[1] == "# profile: p1"
+    assert csv_lines[2] == "# method: export_view"
+
+    data = json.loads((out_dir / "export_view.json").read_text())
+    assert data["profile"] == "p1"
+    assert data["method"] == "export_view"
+    assert "generated_at" in data
+    assert isinstance(data["data"], list)
+
+    fig_payload = json.loads((out_dir / "figure_total_by_activity.json").read_text())
+    assert fig_payload["references"] == [
+        "[1] Coffee reference.",
+        "[2] Streaming reference.",
+    ]
+    assert fig_payload["method"] == "figures.total_by_activity"
+
+
 def test_emission_calculation_and_nulls():
     profile = Profile(profile_id="p1", office_days_per_week=3, default_grid_region="CA-ON")
     grid = {"CA-ON": 100}


### PR DESCRIPTION
## Summary
- prepend metadata headers and JSON payload for derived CSV/JSON exports
- include IEEE-style references and metadata in figure outputs
- test export metadata and references

## Testing
- `ruff check calc tests`
- `black --check calc tests`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689802aece84832caad4752f8181896a