### PR TITLE
Implement data loader fixes and schedule support

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -9,8 +9,10 @@ def create_app() -> Dash:
     return app
 
 
-def main() -> None:
-    create_app()
+def main(*, host: str = "0.0.0.0", port: int = 8050, debug: bool = False) -> Dash:
+    app = create_app()
+    app.run_server(host=host, port=port, debug=debug)
+    return app
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update schema loaders to read the new CSV headers, validate grid aliases, and cache file reads with an invalidation hook
- extend the emission pipeline to handle v1.1 schedules, restore the Canada-average grid fallback, and keep export lookups using the cached data
- cache the figure configuration, refresh the Dash entrypoint to run the server, and adjust tests for the new schedule fields

## Testing
- PYTHONPATH=. poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b80471e0832c8e62fd80ad49720e