### PR TITLE
Refactor citation handling and expose aggregates API

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,17 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
 from dash import Dash, html
+
+from calc.api import get_aggregates
 
 from .components import bubble, references, sankey, stacked
 
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+CFG_PATH = Path(__file__).resolve().parent.parent / "calc" / "config.yaml"
+
 
 def create_app() -> Dash:
+    aggregates, reference_keys = get_aggregates(DATA_DIR, CFG_PATH)
     app = Dash(__name__)
-    app.layout = html.Div([stacked.render(), bubble.render(), sankey.render(), references.render()])
+    app.layout = html.Div(
+        [
+            stacked.render(aggregates),
+            bubble.render(aggregates),
+            sankey.render(aggregates),
+            references.render(reference_keys),
+        ]
+    )
     return app
 
 
 def main(*, host: str = "0.0.0.0", port: int = 8050, debug: bool = False) -> Dash:
     app = create_app()
-    app.run_server(host=host, port=port, debug=debug)
+    app.run(host=host, port=port, debug=debug)
     return app
 
 

--- a/app/components/bubble.py
+++ b/app/components/bubble.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import Optional
+
 from dash import html
 
+from calc.api import Aggregates
 
-def render():
+
+def render(aggregates: Optional[Aggregates] = None) -> html.Div:
     return html.Div("bubble placeholder")

--- a/app/components/references.py
+++ b/app/components/references.py
@@ -1,5 +1,18 @@
+from __future__ import annotations
+
+from typing import Sequence
+
 from dash import html
 
+from calc import citations
 
-def render():
-    return html.Div("references placeholder")
+
+def render(reference_keys: Sequence[str]) -> html.Section:
+    refs = citations.references_for(reference_keys)
+    items = [
+        html.Li(citations.format_ieee(ref.numbered(idx)))
+        for idx, ref in enumerate(refs, start=1)
+    ]
+    if not items:
+        items = [html.Li("No references available.")]
+    return html.Section([html.H2("References"), html.Ul(items)])

--- a/app/components/sankey.py
+++ b/app/components/sankey.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import Optional
+
 from dash import html
 
+from calc.api import Aggregates
 
-def render():
+
+def render(aggregates: Optional[Aggregates] = None) -> html.Div:
     return html.Div("sankey placeholder")

--- a/app/components/stacked.py
+++ b/app/components/stacked.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import Optional
+
 from dash import html
 
+from calc.api import Aggregates
 
-def render():
+
+def render(aggregates: Optional[Aggregates] = None) -> html.Div:
     return html.Div("stacked placeholder")

--- a/calc/api.py
+++ b/calc/api.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import yaml
+
+from . import citations, derive, schema
+
+
+@dataclass(frozen=True)
+class ActivityAggregate:
+    activity_id: str
+    activity_name: str | None
+    annual_emissions_g: float
+
+
+@dataclass(frozen=True)
+class Aggregates:
+    profile_id: str
+    activities: Tuple[ActivityAggregate, ...]
+    total_annual_emissions_g: float
+
+    @property
+    def by_activity(self) -> Dict[str, float]:
+        return {item.activity_id: item.annual_emissions_g for item in self.activities}
+
+
+def _load_config(cfg_path: Path) -> dict:
+    if not cfg_path.exists():
+        return {}
+    data = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise TypeError("Configuration must be a mapping")
+    return data
+
+
+def _resolve_profile_id(config: dict, profiles: Dict[str, schema.Profile], schedules: Iterable[schema.ActivitySchedule]) -> str:
+    profile_id = config.get("default_profile")
+    if profile_id in profiles:
+        return profile_id
+    for sched in schedules:
+        if sched.profile_id in profiles:
+            return sched.profile_id
+    if profiles:
+        return next(iter(profiles))
+    raise ValueError("No profiles available to aggregate")
+
+
+def _collect_activity_sources(
+    sched: schema.ActivitySchedule,
+    profile: schema.Profile,
+    ef: schema.EmissionFactor,
+    grid_by_region: Dict[str | schema.RegionCode, schema.GridIntensity],
+) -> List[str]:
+    sources: List[str] = []
+    if ef.source_id:
+        sources.append(str(ef.source_id))
+    if not ef.is_grid_indexed:
+        return sources
+
+    if sched.region_override is not None:
+        region = sched.region_override
+    elif sched.mix_region is not None:
+        region = sched.mix_region
+    elif sched.use_canada_average:
+        region = schema.RegionCode.CA
+    elif profile.default_grid_region is not None:
+        region = profile.default_grid_region
+    else:
+        region = None
+    if region is None:
+        return sources
+    key = region
+    grid = grid_by_region.get(key)
+    if grid is None and hasattr(region, "value"):
+        grid = grid_by_region.get(region.value)
+    if grid and grid.source_id:
+        sources.append(str(grid.source_id))
+    return sources
+
+
+def get_aggregates(data_dir: Path, cfg_path: Path) -> tuple[Aggregates, list[str]]:
+    """Load data, compute emissions and return aggregates plus reference keys."""
+
+    activities = {
+        activity.activity_id: activity
+        for activity in schema._load_csv(data_dir / "activities.csv", schema.Activity)
+    }
+    profiles = {
+        profile.profile_id: profile
+        for profile in schema._load_csv(data_dir / "profiles.csv", schema.Profile)
+    }
+    schedules = list(schema._load_csv(data_dir / "activity_schedule.csv", schema.ActivitySchedule))
+    emission_factors = {
+        ef.activity_id: ef
+        for ef in schema._load_csv(data_dir / "emission_factors.csv", schema.EmissionFactor)
+    }
+    grid_intensities = list(
+        schema._load_csv(data_dir / "grid_intensity.csv", schema.GridIntensity)
+    )
+    grid_lookup: Dict[str | schema.RegionCode, float | None] = {}
+    grid_by_region: Dict[str | schema.RegionCode, schema.GridIntensity] = {}
+    for gi in grid_intensities:
+        grid_lookup[gi.region] = gi.intensity_g_per_kwh
+        grid_by_region[gi.region] = gi
+        if hasattr(gi.region, "value"):
+            grid_lookup[gi.region.value] = gi.intensity_g_per_kwh
+            grid_by_region[gi.region.value] = gi
+
+
+    config = _load_config(cfg_path)
+    profile_id = _resolve_profile_id(config, profiles, schedules)
+    profile = profiles[profile_id]
+
+    by_activity: Dict[str, float] = {}
+    source_keys: List[str] = []
+
+    for sched in schedules:
+        if sched.profile_id != profile_id:
+            continue
+        ef = emission_factors.get(sched.activity_id)
+        if ef is None:
+            continue
+        emission = derive.compute_emission(sched, profile, ef, grid_lookup)
+        if emission is None:
+            continue
+        by_activity[sched.activity_id] = by_activity.get(sched.activity_id, 0.0) + emission
+        source_keys.extend(_collect_activity_sources(sched, profile, ef, grid_by_region))
+
+    activities_payload: List[ActivityAggregate] = []
+    for activity_id, total in sorted(by_activity.items(), key=lambda item: item[1], reverse=True):
+        activity = activities.get(activity_id)
+        activities_payload.append(
+            ActivityAggregate(
+                activity_id=activity_id,
+                activity_name=activity.name if activity else None,
+                annual_emissions_g=total,
+            )
+        )
+
+    aggregates = Aggregates(
+        profile_id=profile_id,
+        activities=tuple(activities_payload),
+        total_annual_emissions_g=sum(by_activity.values()),
+    )
+
+    references = citations.references_for(source_keys)
+    reference_keys = [ref.key for ref in references]
+    return aggregates, reference_keys
+
+
+__all__ = ["Aggregates", "ActivityAggregate", "get_aggregates"]

--- a/calc/citations.py
+++ b/calc/citations.py
@@ -1,14 +1,80 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
-from typing import Iterable, List
+from typing import List, Sequence
+import re
 
 REFERENCES_DIR = Path(__file__).parent / "references"
 
+_IEEE_NUMBER_PREFIX = re.compile(r"^\s*\[\d+\]\s*")
 
-def load_citations(keys: Iterable[str]) -> List[str]:
-    citations: List[str] = []
-    for idx, key in enumerate(keys, start=1):
-        text = (REFERENCES_DIR / f"{key}.txt").read_text().strip()
-        citations.append(f"[{idx}] {text}")
-    return citations
+
+@dataclass(frozen=True)
+class Reference:
+    """Structured reference loaded from the repository."""
+
+    key: str
+    citation: str
+    index: int | None = None
+
+    def numbered(self, index: int) -> Reference:
+        """Return a copy of the reference with an explicit IEEE index."""
+
+        return Reference(key=self.key, citation=self.citation, index=index)
+
+
+@lru_cache(maxsize=None)
+def _load_reference(key: str) -> Reference:
+    path = REFERENCES_DIR / f"{key}.txt"
+    if not path.exists():
+        raise KeyError(f"Unknown reference: {key}")
+    text = path.read_text(encoding="utf-8").strip()
+    return Reference(key=key, citation=text)
+
+
+def _flatten(obj: object | None) -> List[str]:
+    if obj is None:
+        return []
+    if isinstance(obj, Reference):
+        return [obj.key]
+    if isinstance(obj, str):
+        return [obj]
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        keys: List[str] = []
+        for item in obj:
+            keys.extend(_flatten(item))
+        return keys
+    for attr in ("source_id", "source_ids", "reference_id", "reference_ids"):
+        if hasattr(obj, attr):
+            value = getattr(obj, attr)
+            if value is not None:
+                return _flatten(value)
+    return []
+
+
+def references_for(obj: object | None) -> List[Reference]:
+    """Resolve and de-duplicate references associated with an object."""
+
+    keys = _flatten(obj)
+    seen: set[str] = set()
+    references: List[Reference] = []
+    for key in keys:
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        references.append(_load_reference(key))
+    return references
+
+
+def format_ieee(ref: Reference) -> str:
+    """Return the IEEE formatted string for a numbered reference."""
+
+    if ref.index is None:
+        raise ValueError("Reference index required for IEEE formatting")
+    text = _IEEE_NUMBER_PREFIX.sub("", ref.citation).strip()
+    return f"[{ref.index}] {text}"
+
+
+__all__ = ["Reference", "format_ieee", "references_for"]

--- a/calc/config.yaml
+++ b/calc/config.yaml
@@ -1,1 +1,1 @@
-default_profile: p1
+default_profile: PRO.TO.24_39.HYBRID.2025

--- a/calc/figures.py
+++ b/calc/figures.py
@@ -9,7 +9,7 @@ from typing import List
 import pandas as pd
 import yaml
 
-from .citations import load_citations
+from . import citations
 
 CONFIG_PATH = Path(__file__).parent / "config.yaml"
 
@@ -50,7 +50,10 @@ def export_total_by_activity(
     _write_csv_with_metadata(fig, out_dir / "figure_total_by_activity.csv", metadata)
     payload = {
         **metadata,
-        "references": load_citations(citation_keys),
+        "references": [
+            citations.format_ieee(ref.numbered(idx))
+            for idx, ref in enumerate(citations.references_for(citation_keys), start=1)
+        ],
         "data": fig.to_dict(orient="records"),
     }
     (out_dir / "figure_total_by_activity.json").write_text(json.dumps(payload, indent=2))

--- a/calc/references/SRC.DEMO.txt
+++ b/calc/references/SRC.DEMO.txt
@@ -1,0 +1,1 @@
+Demo, “Demonstration placeholder reference,” 2025. Available: https://example.org/demo.

--- a/calc/references/SRC.DIMPACT.2021.txt
+++ b/calc/references/SRC.DIMPACT.2021.txt
@@ -1,0 +1,1 @@
+Carbon Trust and DIMPACT, “The Carbon Impact of Video Streaming,” 2021. Available: https://dimpact.org/resources.

--- a/calc/references/SRC.IESO.2024.txt
+++ b/calc/references/SRC.IESO.2024.txt
@@ -1,0 +1,1 @@
+Independent Electricity System Operator (IESO), “Emissions and Grid Intensity (Ontario)—Data and Reports,” 2024. Available: https://www.ieso.ca/en/Power-Data/Data-Directory.

--- a/calc/schema.py
+++ b/calc/schema.py
@@ -83,6 +83,7 @@ class EmissionFactor(BaseModel):
     region: Optional[RegionCode] = None
     scope_boundary: Optional[ScopeBoundary] = None
     vintage_year: Optional[int] = None
+    source_id: Optional[str] = None
     uncert_low_g_per_unit: Optional[float] = None
     uncert_high_g_per_unit: Optional[float] = None
 
@@ -159,6 +160,7 @@ class ActivitySchedule(BaseModel):
 class GridIntensity(BaseModel):
     region: RegionCode = Field(alias="region_code")
     intensity_g_per_kwh: Optional[float] = Field(default=None, alias="g_per_kwh")
+    source_id: Optional[str] = None
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
 

--- a/data/emission_factors.csv
+++ b/data/emission_factors.csv
@@ -1,3 +1,3 @@
 ef_id,activity_id,unit,value_g_per_unit,is_grid_indexed,electricity_kwh_per_unit,electricity_kwh_per_unit_low,electricity_kwh_per_unit_high,region,scope_boundary,gwp_horizon,vintage_year,source_id,method_notes,uncert_low_g_per_unit,uncert_high_g_per_unit
 EF.DEMO.COFFEE.FIXED,FOOD.COFFEE.CUP.HOT,cup,1,,,,,,cradle-to-grave,GWP100 (AR6),2025,SRC.DEMO,,,
-EF.DEMO.STREAM,stream,,,TRUE,0.10,,,,,,,,,,
+EF.DEMO.STREAM,stream,,,TRUE,0.10,,,,,,,SRC.DIMPACT.2021,,,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -43,11 +43,11 @@ def test_export_metadata_and_references(tmp_path, monkeypatch):
     derive_mod.export_view()
     csv_lines = (out_dir / "export_view.csv").read_text().splitlines()
     assert csv_lines[0].startswith("# generated_at: ")
-    assert csv_lines[1] == "# profile: p1"
+    assert csv_lines[1] == "# profile: PRO.TO.24_39.HYBRID.2025"
     assert csv_lines[2] == "# method: export_view"
 
     data = json.loads((out_dir / "export_view.json").read_text())
-    assert data["profile"] == "p1"
+    assert data["profile"] == "PRO.TO.24_39.HYBRID.2025"
     assert data["method"] == "export_view"
     assert "generated_at" in data
     assert isinstance(data["data"], list)

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -1,6 +1,26 @@
-from calc.citations import load_citations
+from pathlib import Path
+import re
+
+from calc import citations
 
 
 def test_citation_ordering():
-    citations = load_citations(["coffee", "streaming"])
-    assert citations == ["[1] Coffee reference.", "[2] Streaming reference."]
+    refs = citations.references_for(["coffee", "streaming"])
+    formatted = [
+        citations.format_ieee(ref.numbered(idx))
+        for idx, ref in enumerate(refs, start=1)
+    ]
+    assert formatted == ["[1] Coffee reference.", "[2] Streaming reference."]
+
+
+def test_format_ieee_strips_existing_numbers():
+    ref = citations.Reference(key="demo", citation="[4] Demo reference.").numbered(7)
+    assert citations.format_ieee(ref) == "[7] Demo reference."
+
+
+def test_components_do_not_embed_ieee_citations():
+    component_dir = Path("app/components")
+    pattern = re.compile(r"\[\d+\]")
+    for path in component_dir.glob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        assert pattern.search(source) is None, f"{path} should not inline citations"


### PR DESCRIPTION
## Summary
- add calc.api.get_aggregates to load, compute and aggregate emissions data
- centralize citation loading/formatting with calc.citations and new reference records
- update Dash app components to consume the API and render references via shared citation utilities
- extend schema/data for source identifiers and refresh pytest coverage for citations and imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6b7a2f6fc832c859cbcae180e8990