### PR TITLE
feat: add DAL abstraction for CSV backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ACX_DATA_BACKEND ?= csv
+
 .PHONY: install validate build app format lint test release migrate_v1_1
 
 install:
@@ -6,10 +8,10 @@ install:
 validate: lint test
 
 build:
-	PYTHONPATH=. poetry run python -m calc.derive
+        ACX_DATA_BACKEND=$(ACX_DATA_BACKEND) PYTHONPATH=. poetry run python -m calc.derive
 
 app:
-	PYTHONPATH=. poetry run python -m app.app
+        ACX_DATA_BACKEND=$(ACX_DATA_BACKEND) PYTHONPATH=. poetry run python -m app.app
 
 format:
 	PYTHONPATH=. poetry run black .

--- a/app/app.py
+++ b/app/app.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from dash import Dash, html
 
 from calc.api import get_aggregates
+from calc.dal import choose_backend
 
 from .components import bubble, references, sankey, stacked
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 CFG_PATH = Path(__file__).resolve().parent.parent / "calc" / "config.yaml"
+DS = choose_backend()
 
 
 def create_app() -> Dash:

--- a/calc/dal.py
+++ b/calc/dal.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from typing import Protocol, Sequence, List
+from pathlib import Path
+
+import pandas as pd
+
+from .schema import (
+    Activity,
+    EmissionFactor,
+    Profile,
+    ActivitySchedule,
+    GridIntensity,
+)
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def _load_csv(path: Path) -> List[dict]:
+    df = pd.read_csv(path, dtype=object)
+    df = df.where(pd.notnull(df), None)
+    return df.to_dict(orient="records")
+
+
+class DataStore(Protocol):
+    def load_activities(self) -> Sequence[Activity]: ...
+
+    def load_emission_factors(self) -> Sequence[EmissionFactor]: ...
+
+    def load_profiles(self) -> Sequence[Profile]: ...
+
+    def load_activity_schedule(self) -> Sequence[ActivitySchedule]: ...
+
+    def load_grid_intensity(self) -> Sequence[GridIntensity]: ...
+
+
+class CsvStore:
+    """CSV-backed implementation of DataStore (default)."""
+
+    def load_activities(self) -> Sequence[Activity]:
+        rows = _load_csv(DATA_DIR / "activities.csv")
+        return [Activity(**r) for r in rows]
+
+    def load_emission_factors(self) -> Sequence[EmissionFactor]:
+        rows = _load_csv(DATA_DIR / "emission_factors.csv")
+        return [EmissionFactor(**r) for r in rows]
+
+    def load_profiles(self) -> Sequence[Profile]:
+        rows = _load_csv(DATA_DIR / "profiles.csv")
+        return [Profile(**r) for r in rows]
+
+    def load_activity_schedule(self) -> Sequence[ActivitySchedule]:
+        rows = _load_csv(DATA_DIR / "activity_schedule.csv")
+        return [ActivitySchedule(**r) for r in rows]
+
+    def load_grid_intensity(self) -> Sequence[GridIntensity]:
+        rows = _load_csv(DATA_DIR / "grid_intensity.csv")
+        return [GridIntensity(**r) for r in rows]
+
+
+def choose_backend() -> DataStore:
+    backend = (os.getenv("ACX_DATA_BACKEND") or "csv").lower()
+    if backend == "csv":
+        return CsvStore()
+    # Future: elif backend == "sqlite": return SqlStore(...)
+    # Future: elif backend == "duckdb": return DuckStore(...)
+    # Future: elif backend == "postgres": return PgStore(...)
+    raise ValueError(f"Unsupported ACX_DATA_BACKEND={backend}")

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -2,7 +2,7 @@ from calc.derive import compute_emission, get_grid_intensity
 from calc.schema import ActivitySchedule, EmissionFactor, Profile
 
 
-def test_export_metadata_and_references(tmp_path, monkeypatch):
+def test_export_metadata_and_references(tmp_path):
     from pathlib import Path
     import json
     import shutil
@@ -10,37 +10,36 @@ def test_export_metadata_and_references(tmp_path, monkeypatch):
     import calc.derive as derive_mod
     from calc.schema import GridIntensity
 
-    def fake_load_emission_factors():
-        return [
-            EmissionFactor(activity_id="coffee", value_g_per_unit=1),
-            EmissionFactor(activity_id="stream", is_grid_indexed=True, electricity_kwh_per_unit=1),
-        ]
+    class FakeStore:
+        def load_emission_factors(self):
+            return [
+                EmissionFactor(activity_id="coffee", value_g_per_unit=1),
+                EmissionFactor(activity_id="stream", is_grid_indexed=True, electricity_kwh_per_unit=1),
+            ]
 
-    def fake_load_profiles():
-        return [Profile(profile_id="p1", office_days_per_week=3, default_grid_region="CA-ON")]
+        def load_profiles(self):
+            return [Profile(profile_id="p1", office_days_per_week=3, default_grid_region="CA-ON")]
 
-    def fake_load_activity_schedule():
-        return [
-            ActivitySchedule(
-                profile_id="p1", activity_id="coffee", freq_per_week=5, office_days_only=True
-            ),
-            ActivitySchedule(
-                profile_id="p1", activity_id="stream", freq_per_day=2
-            ),
-        ]
+        def load_activity_schedule(self):
+            return [
+                ActivitySchedule(
+                    profile_id="p1", activity_id="coffee", freq_per_week=5, office_days_only=True
+                ),
+                ActivitySchedule(
+                    profile_id="p1", activity_id="stream", freq_per_day=2
+                ),
+            ]
 
-    def fake_load_grid_intensity():
-        return [GridIntensity(region="CA-ON", intensity_g_per_kwh=100)]
+        def load_grid_intensity(self):
+            return [GridIntensity(region="CA-ON", intensity_g_per_kwh=100)]
 
-    monkeypatch.setattr(derive_mod, "load_emission_factors", fake_load_emission_factors)
-    monkeypatch.setattr(derive_mod, "load_profiles", fake_load_profiles)
-    monkeypatch.setattr(derive_mod, "load_activity_schedule", fake_load_activity_schedule)
-    monkeypatch.setattr(derive_mod, "load_grid_intensity", fake_load_grid_intensity)
+        def load_activities(self):
+            return []
 
     out_dir = Path("calc/outputs")
     if out_dir.exists():
         shutil.rmtree(out_dir)
-    derive_mod.export_view()
+    derive_mod.export_view(FakeStore())
     csv_lines = (out_dir / "export_view.csv").read_text().splitlines()
     assert csv_lines[0].startswith("# generated_at: ")
     assert csv_lines[1] == "# profile: PRO.TO.24_39.HYBRID.2025"

--- a/tests/test_dal.py
+++ b/tests/test_dal.py
@@ -1,0 +1,16 @@
+from calc.dal import CsvStore
+
+
+def test_csv_store_loads():
+    ds = CsvStore()
+    acts = ds.load_activities()
+    efs = ds.load_emission_factors()
+    profs = ds.load_profiles()
+    sched = ds.load_activity_schedule()
+    grid = ds.load_grid_intensity()
+    # Types: Pydantic models conforming to schema
+    assert all(hasattr(a, "activity_id") for a in acts)
+    assert all(hasattr(e, "activity_id") for e in efs)
+    assert all(hasattr(p, "profile_id") for p in profs)
+    assert all(hasattr(s, "activity_id") and hasattr(s, "profile_id") for s in sched)
+    assert all(hasattr(g, "region") for g in grid)


### PR DESCRIPTION
## Summary
- add a DataStore protocol plus CSV-backed implementation and update derive export flow to use the DAL
- add coverage for the CSV store and update existing calc tests to exercise the new interface
- import the DAL in the Dash app startup and allow ACX_DATA_BACKEND overrides via the Makefile

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6cd47a9dc832ca44d8f49ed6cffe0