### PR TITLE
fix(metadata): report resolved profile ids used in export (not config default)

### DIFF
--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -48,12 +48,20 @@ def test_export_metadata_and_references(tmp_path):
     derive_mod.export_view(FakeStore())
     csv_lines = (out_dir / "export_view.csv").read_text().splitlines()
     assert csv_lines[0].startswith("# generated_at: ")
-    assert csv_lines[1] == "# profile: PRO.TO.24_39.HYBRID.2025"
+    assert csv_lines[1] == "# profile: p1"
     assert csv_lines[2] == "# method: export_view"
+    assert (
+        csv_lines[3]
+        == "# profile_resolution: {'requested': 'PRO.TO.24_39.HYBRID.2025', 'used': ['p1']}"
+    )
 
     data = json.loads((out_dir / "export_view.json").read_text())
-    assert data["profile"] == "PRO.TO.24_39.HYBRID.2025"
+    assert data["profile"] == "p1"
     assert data["method"] == "export_view"
+    assert data["profile_resolution"] == {
+        "requested": "PRO.TO.24_39.HYBRID.2025",
+        "used": ["p1"],
+    }
     assert "generated_at" in data
     assert isinstance(data["data"], list)
     assert data["citation_keys"] == ["coffee", "streaming"]
@@ -67,6 +75,11 @@ def test_export_metadata_and_references(tmp_path):
     ]
     assert fig_payload["references"] == expected_refs
     assert fig_payload["citation_keys"] == ["coffee", "streaming"]
+    assert fig_payload["profile"] == "p1"
+    assert fig_payload["profile_resolution"] == {
+        "requested": "PRO.TO.24_39.HYBRID.2025",
+        "used": ["p1"],
+    }
     assert fig_payload["method"] == "figures.total_by_activity"
 
 

--- a/tests/test_metadata_profile_resolution.py
+++ b/tests/test_metadata_profile_resolution.py
@@ -1,0 +1,51 @@
+import functools
+import json
+import shutil
+from pathlib import Path
+
+import calc.derive as derive_mod
+import calc.figures as figures
+from calc.schema import ActivitySchedule, EmissionFactor, GridIntensity, Profile
+
+
+def test_export_metadata_reports_resolved_profiles(monkeypatch):
+    figures.invalidate_cache()
+    fake_loader = functools.lru_cache(maxsize=1)(lambda: {"default_profile": "WRONG"})
+    monkeypatch.setattr(figures, "_load_config", fake_loader)
+    monkeypatch.setattr(derive_mod.figures, "_load_config", fake_loader)
+
+    class FakeStore:
+        def load_emission_factors(self):
+            return [EmissionFactor(activity_id="coffee", value_g_per_unit=1)]
+
+        def load_profiles(self):
+            return [Profile(profile_id="p1", office_days_per_week=3, default_grid_region="CA-ON")]
+
+        def load_activity_schedule(self):
+            return [
+                ActivitySchedule(
+                    profile_id="p1", activity_id="coffee", freq_per_week=5, office_days_only=True
+                ),
+            ]
+
+        def load_grid_intensity(self):
+            return [GridIntensity(region="CA-ON", intensity_g_per_kwh=100)]
+
+        def load_activities(self):
+            return []
+
+    out_dir = Path("calc/outputs")
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+
+    try:
+        derive_mod.export_view(FakeStore())
+        data = json.loads((out_dir / "export_view.json").read_text())
+        assert data["profile"] == "p1"
+        assert data["profile_resolution"] == {
+            "requested": "WRONG",
+            "used": ["p1"],
+        }
+        assert data["profile_resolution"]["requested"] != data["profile_resolution"]["used"][0]
+    finally:
+        figures.invalidate_cache()


### PR DESCRIPTION
## Summary
- include resolved profile identifiers in generated metadata and record how they were chosen
- pass the resolved profile ids through the export pipeline so both CSV/JSON exports report the correct profile information
- add tests that cover the new metadata resolution details and ensure figures inherit the used profiles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7062b42d8832cb126abbe0774e09a