### PR TITLE
feat(calc): add figures pipeline (stacked/bubble/sankey)

### DIFF
--- a/calc/api.py
+++ b/calc/api.py
@@ -39,7 +39,9 @@ def _load_config(cfg_path: Path) -> dict:
     return data
 
 
-def _resolve_profile_id(config: dict, profiles: Dict[str, schema.Profile], schedules: Iterable[schema.ActivitySchedule]) -> str:
+def _resolve_profile_id(
+    config: dict, profiles: Dict[str, schema.Profile], schedules: Iterable[schema.ActivitySchedule]
+) -> str:
     profile_id = config.get("default_profile")
     if profile_id in profiles:
         return profile_id
@@ -137,9 +139,7 @@ def get_aggregates(data_dir: Path, cfg_path: Path) -> tuple[Aggregates, list[str
         ef.activity_id: ef
         for ef in schema._load_csv(data_dir / "emission_factors.csv", schema.EmissionFactor)
     }
-    grid_intensities = list(
-        schema._load_csv(data_dir / "grid_intensity.csv", schema.GridIntensity)
-    )
+    grid_intensities = list(schema._load_csv(data_dir / "grid_intensity.csv", schema.GridIntensity))
     grid_lookup: Dict[str | schema.RegionCode, float | None] = {}
     grid_by_region: Dict[str | schema.RegionCode, schema.GridIntensity] = {}
     for gi in grid_intensities:
@@ -148,7 +148,6 @@ def get_aggregates(data_dir: Path, cfg_path: Path) -> tuple[Aggregates, list[str
         if hasattr(gi.region, "value"):
             grid_lookup[gi.region.value] = gi.intensity_g_per_kwh
             grid_by_region[gi.region.value] = gi
-
 
     config = _load_config(cfg_path)
     profile_id = _resolve_profile_id(config, profiles, schedules)

--- a/calc/derive.py
+++ b/calc/derive.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Mapping, Optional
 
 import json
+from datetime import datetime, timezone
+
 import pandas as pd
 
-from . import figures
+from . import citations, figures
 from .api import collect_activity_source_keys
 from .dal import DataStore, choose_backend
-from .schema import (
-    ActivitySchedule,
-    EmissionFactor,
-    GridIntensity,
-    Profile,
-    RegionCode,
-)
+from .schema import Activity, ActivitySchedule, EmissionFactor, GridIntensity, Profile, RegionCode
 
 
 def get_grid_intensity(
@@ -80,32 +77,129 @@ def _weekly_quantity(sched: ActivitySchedule, profile: Profile) -> Optional[floa
     return weekly
 
 
+@dataclass(frozen=True)
+class EmissionDetails:
+    mean: Optional[float]
+    low: Optional[float]
+    high: Optional[float]
+
+    def as_dict(self) -> dict:
+        payload = {"mean": self.mean}
+        if self.low is not None:
+            payload["low"] = self.low
+        if self.high is not None:
+            payload["high"] = self.high
+        return payload
+
+
 def compute_emission(
     sched: ActivitySchedule,
     profile: Profile,
     ef: EmissionFactor,
     grid_lookup: Mapping[str | RegionCode, Optional[float]],
 ) -> Optional[float]:
+    details = compute_emission_details(sched, profile, ef, grid_lookup)
+    return details.mean
+
+
+def compute_emission_details(
+    sched: ActivitySchedule,
+    profile: Profile,
+    ef: EmissionFactor,
+    grid_lookup: Mapping[str | RegionCode, Optional[float]],
+    grid_row: GridIntensity | None = None,
+) -> EmissionDetails:
     weekly_quantity = _weekly_quantity(sched, profile)
     if weekly_quantity is None:
-        return None
+        return EmissionDetails(mean=None, low=None, high=None)
+
     quantity = weekly_quantity * 52
+
     if ef.value_g_per_unit is not None:
         factor = float(ef.value_g_per_unit)
-    elif ef.is_grid_indexed:
-        intensity = get_grid_intensity(
-            profile,
-            grid_lookup,
-            sched.region_override,
-            sched.mix_region,
-            sched.use_canada_average,
+        mean = quantity * factor
+        low = (
+            quantity * float(ef.uncert_low_g_per_unit)
+            if ef.uncert_low_g_per_unit is not None
+            else None
         )
+        high = (
+            quantity * float(ef.uncert_high_g_per_unit)
+            if ef.uncert_high_g_per_unit is not None
+            else None
+        )
+        return EmissionDetails(mean=mean, low=low, high=high)
+
+    if ef.is_grid_indexed:
+        intensity = None
+        if grid_row and grid_row.intensity_g_per_kwh is not None:
+            intensity = float(grid_row.intensity_g_per_kwh)
+        if intensity is None:
+            intensity = get_grid_intensity(
+                profile,
+                grid_lookup,
+                sched.region_override,
+                sched.mix_region,
+                sched.use_canada_average,
+            )
         if intensity is None or ef.electricity_kwh_per_unit is None:
-            return None
-        factor = float(intensity) * float(ef.electricity_kwh_per_unit)
-    else:
-        return None
-    return quantity * factor
+            return EmissionDetails(mean=None, low=None, high=None)
+
+        kwh = float(ef.electricity_kwh_per_unit)
+        mean = quantity * float(intensity) * kwh
+
+        intensity_low = (
+            float(grid_row.intensity_low_g_per_kwh)
+            if grid_row and grid_row.intensity_low_g_per_kwh is not None
+            else None
+        )
+        intensity_high = (
+            float(grid_row.intensity_high_g_per_kwh)
+            if grid_row and grid_row.intensity_high_g_per_kwh is not None
+            else None
+        )
+        kwh_low = (
+            float(ef.electricity_kwh_per_unit_low)
+            if ef.electricity_kwh_per_unit_low is not None
+            else None
+        )
+        kwh_high = (
+            float(ef.electricity_kwh_per_unit_high)
+            if ef.electricity_kwh_per_unit_high is not None
+            else None
+        )
+
+        low = None
+        high = None
+        if intensity_low is not None or kwh_low is not None:
+            low = (
+                quantity
+                * (intensity_low if intensity_low is not None else float(intensity))
+                * (kwh_low if kwh_low is not None else kwh)
+            )
+        if intensity_high is not None or kwh_high is not None:
+            high = (
+                quantity
+                * (intensity_high if intensity_high is not None else float(intensity))
+                * (kwh_high if kwh_high is not None else kwh)
+            )
+
+        return EmissionDetails(mean=mean, low=low, high=high)
+
+    return EmissionDetails(mean=None, low=None, high=None)
+
+
+def _format_references(citation_keys: List[str]) -> List[str]:
+    references = citations.references_for(citation_keys)
+    return [citations.format_ieee(ref.numbered(idx)) for idx, ref in enumerate(references, start=1)]
+
+
+def _write_reference_file(directory: Path, stem: str, references: List[str]) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    text = "\n".join(references)
+    if references:
+        text += "\n"
+    (directory / f"{stem}_refs.txt").write_text(text, encoding="utf-8")
 
 
 def _resolve_grid_row(
@@ -137,6 +231,7 @@ def _resolve_grid_row(
 
 def export_view(ds: Optional[DataStore] = None) -> pd.DataFrame:
     datastore = ds or choose_backend()
+    activities = {activity.activity_id: activity for activity in datastore.load_activities()}
     efs = {ef.activity_id: ef for ef in datastore.load_emission_factors()}
     profiles = {p.profile_id: p for p in datastore.load_profiles()}
     grid_lookup: Dict[str | RegionCode, Optional[float]] = {}
@@ -147,27 +242,73 @@ def export_view(ds: Optional[DataStore] = None) -> pd.DataFrame:
         if hasattr(gi.region, "value"):
             grid_lookup[gi.region.value] = gi.intensity_g_per_kwh
             grid_by_region[gi.region.value] = gi
+
     rows: List[dict] = []
     derived_rows: List[dict] = []
     resolved_profile_ids: set[str] = set()
-    for sched in datastore.load_activity_schedule():
+    manifest_regions: set[str] = set()
+    manifest_ef_vintages: set[int] = set()
+    manifest_grid_vintages: set[int] = set()
+
+    schedules = datastore.load_activity_schedule()
+    for sched in schedules:
         profile = profiles.get(sched.profile_id)
         ef = efs.get(sched.activity_id)
-        emission = None
+        activity = activities.get(sched.activity_id)
+
         grid_row: Optional[GridIntensity] = None
+        details = EmissionDetails(mean=None, low=None, high=None)
+        emission = None
+
         if profile and ef:
-            emission = compute_emission(sched, profile, ef, grid_lookup)
-            if emission is not None and ef.is_grid_indexed:
+            if ef.vintage_year is not None:
+                manifest_ef_vintages.add(int(ef.vintage_year))
+            if ef.is_grid_indexed:
                 grid_row = _resolve_grid_row(sched, profile, grid_by_region)
+                if grid_row is not None:
+                    region_value = (
+                        grid_row.region.value
+                        if hasattr(grid_row.region, "value")
+                        else grid_row.region
+                    )
+                    if region_value is not None:
+                        manifest_regions.add(str(region_value))
+                    if grid_row.vintage_year is not None:
+                        manifest_grid_vintages.add(int(grid_row.vintage_year))
+            details = compute_emission_details(sched, profile, ef, grid_lookup, grid_row)
+            emission = details.mean
+
         rows.append(
             {
                 "profile_id": sched.profile_id,
                 "activity_id": sched.activity_id,
+                "activity_name": activity.name if isinstance(activity, Activity) else None,
+                "activity_category": activity.category if isinstance(activity, Activity) else None,
+                "scope_boundary": ef.scope_boundary if isinstance(ef, EmissionFactor) else None,
+                "emission_factor_vintage_year": (
+                    int(ef.vintage_year)
+                    if isinstance(ef, EmissionFactor) and ef.vintage_year is not None
+                    else None
+                ),
+                "grid_region": (
+                    grid_row.region.value
+                    if grid_row and hasattr(grid_row.region, "value")
+                    else (grid_row.region if grid_row else None)
+                ),
+                "grid_vintage_year": (
+                    int(grid_row.vintage_year)
+                    if grid_row and grid_row.vintage_year is not None
+                    else None
+                ),
                 "annual_emissions_g": emission,
+                "annual_emissions_g_low": details.low,
+                "annual_emissions_g_high": details.high,
             }
         )
+
         if sched.profile_id:
             resolved_profile_ids.add(sched.profile_id)
+
         derived_rows.append(
             {
                 "profile": profile,
@@ -177,23 +318,66 @@ def export_view(ds: Optional[DataStore] = None) -> pd.DataFrame:
                 "annual_emissions_g": emission,
             }
         )
+
     df = pd.DataFrame(rows)
     out_dir = Path(__file__).parent / "outputs"
     out_dir.mkdir(exist_ok=True)
+    figure_dir = out_dir / "figures"
+    figure_dir.mkdir(exist_ok=True)
+    reference_dir = out_dir / "references"
+    reference_dir.mkdir(exist_ok=True)
+
     citation_keys = sorted(collect_activity_source_keys(derived_rows))
     resolved_profiles = sorted(resolved_profile_ids)
-    metadata = figures.build_metadata(
-        "export_view", profile_ids=resolved_profiles if resolved_profiles else None
-    )
+    profile_arg = resolved_profiles if resolved_profiles else None
+    generated_at = datetime.now(timezone.utc).isoformat()
+
+    metadata = figures.build_metadata("export_view", profile_ids=profile_arg)
+    metadata["generated_at"] = generated_at
     metadata["citation_keys"] = citation_keys
-    with (out_dir / "export_view.csv").open("w") as fh:
-        for key, value in metadata.items():
+    references = _format_references(citation_keys)
+    metadata["references"] = references
+
+    _write_reference_file(reference_dir, "export_view", references)
+
+    csv_metadata = {k: v for k, v in metadata.items() if k != "references" and k != "data"}
+    with (out_dir / "export_view.csv").open("w", encoding="utf-8") as fh:
+        for key, value in csv_metadata.items():
             fh.write(f"# {key}: {value}\n")
         df.to_csv(fh, index=False)
-    payload = {**metadata, "data": df.to_dict(orient="records")}
-    (out_dir / "export_view.json").write_text(json.dumps(payload, indent=2))
-    # example figure slice
-    figures.export_total_by_activity(df, out_dir, citation_keys)
+
+    records = df.replace({pd.NA: None}).where(pd.notnull(df), None).to_dict(orient="records")
+    payload = {**metadata, "data": records}
+    (out_dir / "export_view.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    stacked = figures.slice_stacked(df)
+    bubble_points = [asdict(point) for point in figures.slice_bubble(df)]
+    sankey = figures.slice_sankey(df)
+
+    def _write_figure(name: str, method: str, data: object) -> None:
+        meta = figures.build_metadata(method, profile_ids=profile_arg)
+        meta["generated_at"] = generated_at
+        meta["citation_keys"] = citation_keys
+        meta["references"] = references
+        meta["data"] = data
+        (figure_dir / f"{name}.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+        _write_reference_file(reference_dir, name, references)
+
+    _write_figure("stacked", "figures.stacked", stacked)
+    _write_figure("bubble", "figures.bubble", bubble_points)
+    _write_figure("sankey", "figures.sankey", sankey)
+
+    manifest = {
+        "generated_at": generated_at,
+        "regions": sorted(manifest_regions),
+        "vintages": {
+            "emission_factors": sorted(manifest_ef_vintages),
+            "grid_intensity": sorted(manifest_grid_vintages),
+        },
+        "sources": citation_keys,
+    }
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
     return df
 
 

--- a/calc/schema.py
+++ b/calc/schema.py
@@ -80,6 +80,8 @@ class EmissionFactor(BaseModel):
     value_g_per_unit: Optional[float] = None
     is_grid_indexed: Optional[bool] = None
     electricity_kwh_per_unit: Optional[float] = None
+    electricity_kwh_per_unit_low: Optional[float] = None
+    electricity_kwh_per_unit_high: Optional[float] = None
     region: Optional[RegionCode] = None
     scope_boundary: Optional[ScopeBoundary] = None
     vintage_year: Optional[int] = None
@@ -104,6 +106,22 @@ class EmissionFactor(BaseModel):
                 raise ValueError("grid indexed factors must set is_grid_indexed=True")
             if self.electricity_kwh_per_unit is None or self.electricity_kwh_per_unit <= 0:
                 raise ValueError("grid indexed factors require electricity_kwh_per_unit > 0")
+            if (
+                self.electricity_kwh_per_unit_low is not None
+                and self.electricity_kwh_per_unit_low <= 0
+            ):
+                raise ValueError("electricity_kwh_per_unit_low must be > 0 when provided")
+            if (
+                self.electricity_kwh_per_unit_high is not None
+                and self.electricity_kwh_per_unit_high <= 0
+            ):
+                raise ValueError("electricity_kwh_per_unit_high must be > 0 when provided")
+            if (
+                self.electricity_kwh_per_unit_low is not None
+                and self.electricity_kwh_per_unit_high is not None
+                and self.electricity_kwh_per_unit_low > self.electricity_kwh_per_unit_high
+            ):
+                raise ValueError("electricity_kwh_per_unit_low cannot exceed high bound")
         else:
             if self.is_grid_indexed:
                 raise ValueError("is_grid_indexed only allowed with grid indexed factors")
@@ -160,7 +178,10 @@ class ActivitySchedule(BaseModel):
 class GridIntensity(BaseModel):
     region: RegionCode = Field(alias="region_code")
     intensity_g_per_kwh: Optional[float] = Field(default=None, alias="g_per_kwh")
+    intensity_low_g_per_kwh: Optional[float] = Field(default=None, alias="g_per_kwh_low")
+    intensity_high_g_per_kwh: Optional[float] = Field(default=None, alias="g_per_kwh_high")
     source_id: Optional[str] = None
+    vintage_year: Optional[int] = None
 
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
 

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -6,10 +6,7 @@ from calc import citations
 
 def test_citation_ordering():
     refs = citations.references_for(["coffee", "streaming"])
-    formatted = [
-        citations.format_ieee(ref.numbered(idx))
-        for idx, ref in enumerate(refs, start=1)
-    ]
+    formatted = [citations.format_ieee(ref.numbered(idx)) for idx, ref in enumerate(refs, start=1)]
     assert formatted == ["[1] Coffee reference.", "[2] Streaming reference."]
 
 

--- a/tests/test_figures_dynamic_citations.py
+++ b/tests/test_figures_dynamic_citations.py
@@ -50,11 +50,15 @@ def test_figures_use_dynamic_citations(tmp_path):
     expected_keys = ["SRC.DIMPACT.2021", "SRC.IESO.2024"]
     assert export_payload["citation_keys"] == expected_keys
 
-    fig_payload = json.loads((out_dir / "figure_total_by_activity.json").read_text())
     expected_refs = [
         citations.format_ieee(ref.numbered(idx))
         for idx, ref in enumerate(citations.references_for(expected_keys), start=1)
     ]
+    assert (
+        out_dir / "references" / "stacked_refs.txt"
+    ).read_text().strip().splitlines() == expected_refs
+
+    fig_payload = json.loads((out_dir / "figures" / "stacked.json").read_text())
     assert fig_payload["references"] == expected_refs
     assert fig_payload["citation_keys"] == expected_keys
     assert all("coffee" not in ref and "stream" not in ref for ref in fig_payload["references"])

--- a/tests/test_figures_slices.py
+++ b/tests/test_figures_slices.py
@@ -1,0 +1,60 @@
+import pandas as pd
+
+from calc import figures
+
+
+def _build_df():
+    return pd.DataFrame(
+        [
+            {
+                "activity_id": "a1",
+                "activity_name": "Laptop",
+                "activity_category": "Devices",
+                "annual_emissions_g": 10.0,
+                "annual_emissions_g_low": 9.0,
+                "annual_emissions_g_high": 12.0,
+            },
+            {
+                "activity_id": "a2",
+                "activity_name": "",
+                "activity_category": "Travel",
+                "annual_emissions_g": 5.0,
+                "annual_emissions_g_low": 4.0,
+                "annual_emissions_g_high": 6.0,
+            },
+            {
+                "activity_id": "a1",
+                "activity_name": "Laptop",
+                "activity_category": "Devices",
+                "annual_emissions_g": 3.0,
+                "annual_emissions_g_low": None,
+                "annual_emissions_g_high": None,
+            },
+        ]
+    )
+
+
+def test_slice_stacked_groups_by_category():
+    df = _build_df()
+    data = figures.slice_stacked(df)
+    assert data[0]["category"] == "Devices"
+    assert data[0]["values"]["mean"] == 13.0
+    assert data[0]["values"]["low"] == 9.0
+    assert "high" in data[0]["values"]
+
+
+def test_slice_bubble_sums_by_activity():
+    df = _build_df()
+    points = figures.slice_bubble(df)
+    by_id = {point.activity_id: point for point in points}
+    assert by_id["a1"].values["mean"] == 13.0
+    assert by_id["a1"].values["low"] == 9.0
+    assert by_id["a2"].activity_name == "a2"
+
+
+def test_slice_sankey_links_include_bounds():
+    df = _build_df()
+    payload = figures.slice_sankey(df)
+    assert payload["links"][0]["values"]["mean"] == 13.0
+    assert payload["links"][0]["values"]["low"] == 9.0
+    assert payload["links"][0]["category"] == "Devices"


### PR DESCRIPTION
## Summary
- add citation utilities that deduplicate IEEE references from nested inputs
- implement stacked, bubble, and sankey figure slicers with shared metadata helpers
- extend derive export to emit figure JSON payloads, manifest metadata, and reference files while preserving bounds
- add coverage for figure slicers and updated outputs

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d718b1ccd8832c80a3e952c5dc39c3