### PR TITLE
feat(app): render dash charts from local artifacts

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,29 +1,84 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
+from typing import Dict
 
 from dash import Dash, html
 
-from calc.api import get_aggregates
-from calc.dal import choose_backend
+from calc import citations
 
 from .components import bubble, references, sankey, stacked
+from .components._helpers import extend_unique
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
-CFG_PATH = Path(__file__).resolve().parent.parent / "calc" / "config.yaml"
-DS = choose_backend()
+ARTIFACT_ENV = "ACX_ARTIFACT_DIR"
+DEFAULT_ARTIFACT_DIR = Path(__file__).resolve().parent.parent / "calc" / "outputs"
+FIGURE_NAMES = ("stacked", "bubble", "sankey")
+
+
+def _artifact_dir() -> Path:
+    env_value = os.environ.get(ARTIFACT_ENV)
+    if env_value:
+        return Path(env_value).expanduser()
+    return DEFAULT_ARTIFACT_DIR
+
+
+def _load_figure_payload(base_dir: Path, name: str) -> dict | None:
+    path = base_dir / "figures" / f"{name}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+def _reference_keys(figures: Dict[str, dict | None]) -> list[str]:
+    keys: list[str] = []
+    for payload in figures.values():
+        if not payload:
+            continue
+        extend_unique(payload.get("citation_keys", []), keys)
+    return keys
+
+
+def _reference_lookup(keys: list[str]) -> dict[str, int]:
+    return {
+        ref.key: idx
+        for idx, ref in enumerate(citations.references_for(keys), start=1)
+    }
 
 
 def create_app() -> Dash:
-    aggregates, reference_keys = get_aggregates(DATA_DIR, CFG_PATH)
+    artifact_dir = _artifact_dir()
+    figures = {name: _load_figure_payload(artifact_dir, name) for name in FIGURE_NAMES}
+    reference_keys = _reference_keys(figures)
+    reference_lookup = _reference_lookup(reference_keys)
+
     app = Dash(__name__)
     app.layout = html.Div(
-        [
-            stacked.render(aggregates),
-            bubble.render(aggregates),
-            sankey.render(aggregates),
+        className="app-container",
+        children=[
+            html.Main(
+                className="chart-column",
+                children=[
+                    html.Header(
+                        [
+                            html.H1("Carbon ACX emissions overview"),
+                            html.P(
+                                "Figures sourced from precomputed artifacts. "
+                                "Hover a chart to see supporting references."
+                            ),
+                        ]
+                    ),
+                    stacked.render(figures.get("stacked"), reference_lookup),
+                    bubble.render(figures.get("bubble"), reference_lookup),
+                    sankey.render(figures.get("sankey"), reference_lookup),
+                ],
+            ),
             references.render(reference_keys),
-        ]
+        ],
     )
     return app
 

--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -1,1 +1,105 @@
-body { font-family: sans-serif; }
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+.app-container {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(280px, 1fr);
+  gap: 2rem;
+  padding: 2rem clamp(1.5rem, 4vw, 4rem);
+  box-sizing: border-box;
+  align-items: start;
+}
+
+.chart-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chart-column header {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem 1.75rem;
+  box-shadow: 0 12px 24px -20px rgba(15, 23, 42, 0.45);
+}
+
+.chart-column header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  font-weight: 700;
+}
+
+.chart-column header p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.chart-section {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.25rem 1.75rem 1.5rem;
+  box-shadow: 0 20px 35px -28px rgba(15, 23, 42, 0.5);
+}
+
+.chart-section h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.chart-section p {
+  margin: 0;
+  color: #64748b;
+}
+
+.chart-figure {
+  width: 100%;
+}
+
+.references-panel {
+  position: sticky;
+  top: 2rem;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: 0 18px 30px -28px rgba(30, 64, 175, 0.55);
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+}
+
+.references-panel h2 {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.references-panel ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.9rem;
+  color: #475569;
+}
+
+.references-panel li {
+  line-height: 1.4;
+}
+
+@media (max-width: 1100px) {
+  .app-container {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .references-panel {
+    position: static;
+    max-height: none;
+  }
+}

--- a/app/components/_helpers.py
+++ b/app/components/_helpers.py
@@ -1,0 +1,75 @@
+"""Utility helpers shared across Dash components."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Sequence
+
+
+def reference_numbers(
+    citation_keys: Sequence[str] | None, reference_lookup: Mapping[str, int]
+) -> list[int]:
+    """Return ordered reference numbers for the given citation keys."""
+
+    if not citation_keys:
+        return []
+
+    numbers: list[int] = []
+    seen: set[int] = set()
+    for key in citation_keys:
+        index = reference_lookup.get(key)
+        if index is None or index in seen:
+            continue
+        seen.add(index)
+        numbers.append(index)
+    return numbers
+
+
+def format_reference_hint(
+    citation_keys: Sequence[str] | None, reference_lookup: Mapping[str, int]
+) -> str:
+    """Return a space-delimited reference hint such as "[n]"."""
+
+    numbers = reference_numbers(citation_keys, reference_lookup)
+    if not numbers:
+        return "No references"
+    return " ".join(f"[{number}]" for number in numbers)
+
+
+def format_emissions(value: float) -> str:
+    """Format emission values with adaptive units for readability."""
+
+    abs_value = abs(value)
+    if abs_value >= 1_000_000:
+        return f"{value / 1_000_000:.2f} t CO₂e"
+    if abs_value >= 1_000:
+        return f"{value / 1_000:.2f} kg CO₂e"
+    return f"{value:,.0f} g CO₂e"
+
+
+def clamp_optional(value: float | int | None) -> float | None:
+    """Return a float for numeric inputs, or ``None`` when missing."""
+
+    if value is None:
+        return None
+    return float(value)
+
+
+def extend_unique(values: Iterable[str], existing: list[str]) -> list[str]:
+    """Extend ``existing`` with new values preserving the original order."""
+
+    seen = set(existing)
+    for item in values:
+        if item not in seen:
+            seen.add(item)
+            existing.append(item)
+    return existing
+
+
+__all__ = [
+    "clamp_optional",
+    "extend_unique",
+    "format_emissions",
+    "format_reference_hint",
+    "reference_numbers",
+]

--- a/app/components/bubble.py
+++ b/app/components/bubble.py
@@ -1,11 +1,118 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Mapping, Optional
 
-from dash import html
+import plotly.graph_objects as go
+from dash import dcc, html
 
-from calc.api import Aggregates
+from ._helpers import clamp_optional, format_reference_hint
 
 
-def render(aggregates: Optional[Aggregates] = None) -> html.Div:
-    return html.Div("bubble placeholder")
+def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
+    data = payload.get("data", []) if payload else []
+
+    categories: list[str] = []
+    activities: list[str] = []
+    means: list[float] = []
+    errors_high: list[float] = []
+    errors_low: list[float] = []
+
+    for row in data:
+        values = row.get("values", {})
+        mean = clamp_optional(values.get("mean"))
+        if mean is None or mean <= 0:
+            continue
+        high = clamp_optional(values.get("high"))
+        low = clamp_optional(values.get("low"))
+
+        categories.append(str(row.get("category", "uncategorized")))
+        activities.append(str(row.get("activity_name") or row.get("activity_id")))
+        means.append(mean)
+        errors_high.append(max((high or mean) - mean, 0.0))
+        errors_low.append(max(mean - (low or mean), 0.0))
+
+    figure = go.Figure()
+    if not means:
+        return figure
+
+    max_mean = max(means)
+    desired_max_size = 50
+    sizeref = 2.0
+    if max_mean > 0:
+        sizeref = (2.0 * max_mean) / (desired_max_size**2)
+
+    has_error = any(err > 0 for err in errors_high) or any(err > 0 for err in errors_low)
+    error_kwargs = (
+        {
+            "type": "data",
+            "array": errors_high,
+            "arrayminus": errors_low,
+            "symmetric": False,
+        }
+        if has_error
+        else None
+    )
+
+    hover_template = (
+        "<b>%{text}</b><br>Category: %{x}<br>Annual emissions: %{y:,.0f} g CO₂e"
+        + ("<br>%{customdata}" if reference_hint != "No references" else "")
+        + "<extra></extra>"
+    )
+
+    trace_kwargs = dict(
+        x=categories,
+        y=means,
+        mode="markers",
+        text=activities,
+        marker=dict(
+            size=means,
+            sizemode="area",
+            sizeref=sizeref,
+            color="#10b981",
+            opacity=0.8,
+            line=dict(color="rgba(15, 23, 42, 0.4)", width=1),
+        ),
+        customdata=[reference_hint] * len(means),
+        hovertemplate=hover_template,
+    )
+    if error_kwargs:
+        trace_kwargs["error_y"] = error_kwargs
+
+    figure.add_trace(go.Scatter(**trace_kwargs))
+
+    figure.update_layout(
+        margin=dict(l=60, r=20, t=40, b=60),
+        xaxis=dict(title="Activity category", type="category"),
+        yaxis=dict(title="Annual emissions (g CO₂e)", rangemode="tozero"),
+        plot_bgcolor="#ffffff",
+        paper_bgcolor="rgba(0,0,0,0)",
+        showlegend=False,
+    )
+    return figure
+
+
+def render(
+    figure_payload: Optional[dict], reference_lookup: Mapping[str, int]
+) -> html.Section:
+    reference_hint = format_reference_hint(
+        figure_payload.get("citation_keys") if figure_payload else None,
+        reference_lookup,
+    )
+
+    title = "Activity bubble chart"
+    figure = _build_figure(figure_payload or {}, reference_hint)
+
+    if not figure.data:
+        content = html.P("No activity data available.")
+    else:
+        content = dcc.Graph(
+            figure=figure,
+            config={"displayModeBar": False, "responsive": True},
+            style={"height": "360px"},
+            className="chart-figure",
+        )
+
+    return html.Section(
+        [html.H2(title), content],
+        className="chart-section chart-section--bubble",
+    )

--- a/app/components/references.py
+++ b/app/components/references.py
@@ -7,12 +7,18 @@ from dash import html
 from calc import citations
 
 
-def render(reference_keys: Sequence[str]) -> html.Section:
-    refs = citations.references_for(reference_keys)
-    items = [
-        html.Li(citations.format_ieee(ref.numbered(idx)))
-        for idx, ref in enumerate(refs, start=1)
+def render(reference_keys: Sequence[str] | None) -> html.Aside:
+    references = [
+        citations.format_ieee(ref.numbered(idx))
+        for idx, ref in enumerate(citations.references_for(reference_keys or []), start=1)
     ]
-    if not items:
-        items = [html.Li("No references available.")]
-    return html.Section([html.H2("References"), html.Ul(items)])
+    if not references:
+        references = ["No references available."]
+
+    return html.Aside(
+        [
+            html.H2("References"),
+            html.Ol([html.Li(text) for text in references]),
+        ],
+        className="references-panel",
+    )

--- a/app/components/sankey.py
+++ b/app/components/sankey.py
@@ -1,11 +1,114 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Mapping, Optional
 
-from dash import html
+import plotly.graph_objects as go
+from dash import dcc, html
 
-from calc.api import Aggregates
+from ._helpers import clamp_optional, format_reference_hint
 
 
-def render(aggregates: Optional[Aggregates] = None) -> html.Div:
-    return html.Div("sankey placeholder")
+def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
+    data = payload.get("data", {}) if payload else {}
+    nodes = data.get("nodes", [])
+    links = data.get("links", [])
+
+    id_to_index: dict[str, int] = {}
+    labels: list[str] = []
+    colors: list[str] = []
+
+    for node in nodes:
+        node_id = str(node.get("id"))
+        if node_id in id_to_index:
+            continue
+        idx = len(id_to_index)
+        id_to_index[node_id] = idx
+        labels.append(str(node.get("label") or node_id))
+        node_type = str(node.get("type") or "node")
+        if node_type == "category":
+            colors.append("#0ea5e9")
+        else:
+            colors.append("#6366f1")
+
+    sources: list[int] = []
+    targets: list[int] = []
+    values: list[float] = []
+    hover_labels: list[str] = []
+
+    for link in links:
+        mean = clamp_optional(link.get("values", {}).get("mean"))
+        if mean is None or mean <= 0:
+            continue
+        source_id = id_to_index.get(str(link.get("source")))
+        target_id = id_to_index.get(str(link.get("target")))
+        if source_id is None or target_id is None:
+            continue
+        sources.append(source_id)
+        targets.append(target_id)
+        values.append(mean)
+        category_label = str(link.get("category", ""))
+        activity_label = labels[target_id]
+        hover = f"{category_label} → {activity_label}<br>Annual emissions: {mean:,.0f} g CO₂e"
+        if reference_hint != "No references":
+            hover += f"<br>{reference_hint}"
+        hover_labels.append(hover)
+
+    figure = go.Figure()
+    if not values:
+        return figure
+
+    link_color = "rgba(79, 70, 229, 0.45)"
+    figure.add_trace(
+        go.Sankey(
+            arrangement="snap",
+            node=dict(
+                label=labels,
+                color=colors,
+                pad=18,
+                thickness=20,
+            ),
+            link=dict(
+                source=sources,
+                target=targets,
+                value=values,
+                color=[link_color] * len(values),
+                hovertemplate=[f"{label}<extra></extra>" for label in hover_labels],
+            ),
+            valueformat=",.0f",
+            valuesuffix=" g CO₂e",
+        )
+    )
+
+    figure.update_layout(
+        margin=dict(l=40, r=40, t=40, b=40),
+        plot_bgcolor="#ffffff",
+        paper_bgcolor="rgba(0,0,0,0)",
+    )
+    return figure
+
+
+def render(
+    figure_payload: Optional[dict], reference_lookup: Mapping[str, int]
+) -> html.Section:
+    reference_hint = format_reference_hint(
+        figure_payload.get("citation_keys") if figure_payload else None,
+        reference_lookup,
+    )
+
+    title = "Activity flow"
+    figure = _build_figure(figure_payload or {}, reference_hint)
+
+    if not figure.data:
+        content = html.P("No flow data available.")
+    else:
+        content = dcc.Graph(
+            figure=figure,
+            config={"displayModeBar": False, "responsive": True},
+            style={"height": "420px"},
+            className="chart-figure",
+        )
+
+    return html.Section(
+        [html.H2(title), content],
+        className="chart-section chart-section--sankey",
+    )

--- a/app/components/stacked.py
+++ b/app/components/stacked.py
@@ -1,11 +1,103 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Mapping, Optional
 
-from dash import html
+import plotly.graph_objects as go
+from dash import dcc, html
 
-from calc.api import Aggregates
+from ._helpers import clamp_optional, format_reference_hint
 
 
-def render(aggregates: Optional[Aggregates] = None) -> html.Div:
-    return html.Div("stacked placeholder")
+def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
+    data = payload.get("data", []) if payload else []
+    categories: list[str] = []
+    means: list[float] = []
+    err_plus: list[float] = []
+    err_minus: list[float] = []
+
+    for row in data:
+        values = row.get("values", {})
+        mean = clamp_optional(values.get("mean"))
+        if mean is None:
+            continue
+        high = clamp_optional(values.get("high"))
+        low = clamp_optional(values.get("low"))
+
+        categories.append(str(row.get("category", "uncategorized")))
+        means.append(mean)
+        err_plus.append(max((high or mean) - mean, 0.0))
+        err_minus.append(max(mean - (low or mean), 0.0))
+
+    figure = go.Figure()
+    if not means:
+        return figure
+
+    has_error = any(value > 0 for value in err_plus) or any(value > 0 for value in err_minus)
+    error_kwargs = (
+        {
+            "type": "data",
+            "array": err_plus,
+            "arrayminus": err_minus,
+            "symmetric": False,
+            "color": "rgba(30, 64, 175, 0.6)",
+        }
+        if has_error
+        else None
+    )
+
+    hover_template = (
+        "<b>%{y}</b><br>Annual emissions: %{x:,.0f} g CO₂e"
+        + ("<br>%{customdata}" if reference_hint != "No references" else "")
+        + "<extra></extra>"
+    )
+
+    figure.add_trace(
+        go.Bar(
+            name="Annual emissions",
+            x=means,
+            y=categories,
+            orientation="h",
+            marker=dict(color="#1d4ed8"),
+            opacity=0.85,
+            customdata=[reference_hint] * len(means),
+            hovertemplate=hover_template,
+            error_x=error_kwargs,
+        )
+    )
+
+    figure.update_layout(
+        margin=dict(l=80, r=20, t=40, b=40),
+        xaxis=dict(title="Annual emissions (g CO₂e)", showgrid=True, zeroline=False),
+        yaxis=dict(title="Activity category", autorange="reversed"),
+        plot_bgcolor="#ffffff",
+        paper_bgcolor="rgba(0,0,0,0)",
+        showlegend=False,
+    )
+    return figure
+
+
+def render(
+    figure_payload: Optional[dict], reference_lookup: Mapping[str, int]
+) -> html.Section:
+    reference_hint = format_reference_hint(
+        figure_payload.get("citation_keys") if figure_payload else None,
+        reference_lookup,
+    )
+
+    title = "Annual emissions by activity category"
+    figure = _build_figure(figure_payload or {}, reference_hint)
+
+    if not figure.data:
+        content = html.P("No category data available.")
+    else:
+        content = dcc.Graph(
+            figure=figure,
+            config={"displayModeBar": False, "responsive": True},
+            style={"height": "360px"},
+            className="chart-figure",
+        )
+
+    return html.Section(
+        [html.H2(title), content],
+        className="chart-section chart-section--stacked",
+    )

--- a/calc/outputs/figures/bubble.json
+++ b/calc/outputs/figures/bubble.json
@@ -1,0 +1,27 @@
+{
+  "generated_at": "2025-09-26T23:53:06.402994+00:00",
+  "profile": "PRO.TO.24_39.HYBRID.2025",
+  "method": "figures.bubble",
+  "profile_resolution": {
+    "requested": "PRO.TO.24_39.HYBRID.2025",
+    "used": [
+      "PRO.TO.24_39.HYBRID.2025"
+    ]
+  },
+  "citation_keys": [
+    "SRC.DEMO"
+  ],
+  "references": [
+    "[1] Demo, \u201cDemonstration placeholder reference,\u201d 2025. Available: https://example.org/demo."
+  ],
+  "data": [
+    {
+      "activity_id": "FOOD.COFFEE.CUP.HOT",
+      "activity_name": "Coffee\u201412 oz hot",
+      "category": "food",
+      "values": {
+        "mean": 156.0
+      }
+    }
+  ]
+}

--- a/calc/outputs/figures/sankey.json
+++ b/calc/outputs/figures/sankey.json
@@ -1,0 +1,42 @@
+{
+  "generated_at": "2025-09-26T23:53:06.402994+00:00",
+  "profile": "PRO.TO.24_39.HYBRID.2025",
+  "method": "figures.sankey",
+  "profile_resolution": {
+    "requested": "PRO.TO.24_39.HYBRID.2025",
+    "used": [
+      "PRO.TO.24_39.HYBRID.2025"
+    ]
+  },
+  "citation_keys": [
+    "SRC.DEMO"
+  ],
+  "references": [
+    "[1] Demo, \u201cDemonstration placeholder reference,\u201d 2025. Available: https://example.org/demo."
+  ],
+  "data": {
+    "nodes": [
+      {
+        "id": "activity:Coffee\u201412 oz hot",
+        "type": "activity",
+        "label": "Coffee\u201412 oz hot"
+      },
+      {
+        "id": "category:food",
+        "type": "category",
+        "label": "food"
+      }
+    ],
+    "links": [
+      {
+        "source": "category:food",
+        "target": "activity:Coffee\u201412 oz hot",
+        "activity_id": "FOOD.COFFEE.CUP.HOT",
+        "category": "food",
+        "values": {
+          "mean": 156.0
+        }
+      }
+    ]
+  }
+}

--- a/calc/outputs/figures/stacked.json
+++ b/calc/outputs/figures/stacked.json
@@ -1,0 +1,25 @@
+{
+  "generated_at": "2025-09-26T23:53:06.402994+00:00",
+  "profile": "PRO.TO.24_39.HYBRID.2025",
+  "method": "figures.stacked",
+  "profile_resolution": {
+    "requested": "PRO.TO.24_39.HYBRID.2025",
+    "used": [
+      "PRO.TO.24_39.HYBRID.2025"
+    ]
+  },
+  "citation_keys": [
+    "SRC.DEMO"
+  ],
+  "references": [
+    "[1] Demo, \u201cDemonstration placeholder reference,\u201d 2025. Available: https://example.org/demo."
+  ],
+  "data": [
+    {
+      "category": "food",
+      "values": {
+        "mean": 156.0
+      }
+    }
+  ]
+}

--- a/calc/outputs/references/bubble_refs.txt
+++ b/calc/outputs/references/bubble_refs.txt
@@ -1,0 +1,1 @@
+[1] Demo, “Demonstration placeholder reference,” 2025. Available: https://example.org/demo.

--- a/calc/outputs/references/export_view_refs.txt
+++ b/calc/outputs/references/export_view_refs.txt
@@ -1,0 +1,1 @@
+[1] Demo, “Demonstration placeholder reference,” 2025. Available: https://example.org/demo.

--- a/calc/outputs/references/sankey_refs.txt
+++ b/calc/outputs/references/sankey_refs.txt
@@ -1,0 +1,1 @@
+[1] Demo, “Demonstration placeholder reference,” 2025. Available: https://example.org/demo.

--- a/calc/outputs/references/stacked_refs.txt
+++ b/calc/outputs/references/stacked_refs.txt
@@ -1,0 +1,1 @@
+[1] Demo, “Demonstration placeholder reference,” 2025. Available: https://example.org/demo.


### PR DESCRIPTION
## Summary
- load Dash with figures from a configurable artifact directory and collect shared reference numbering
- replace the stacked, bubble, and sankey placeholders with Plotly graphs that surface reference hints
- refresh styling and add precomputed figure/reference artifacts for local development

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d725324080832c8e69f638062f7f38