### PR TITLE
test: add export golden and figure consistency checks

### DIFF
--- a/tests/fixtures/export_view.golden.json
+++ b/tests/fixtures/export_view.golden.json
@@ -1,0 +1,49 @@
+{
+  "generated_at": "2024-01-02T03:04:05+00:00",
+  "profile": "p1",
+  "method": "export_view",
+  "profile_resolution": {
+    "requested": "PRO.TO.24_39.HYBRID.2025",
+    "used": [
+      "p1"
+    ]
+  },
+  "citation_keys": [
+    "SRC.IESO.2024",
+    "coffee",
+    "streaming"
+  ],
+  "references": [
+    "[1] Independent Electricity System Operator (IESO), \u201cEmissions and Grid Intensity (Ontario)\u2014Data and Reports,\u201d 2024. Available: https://www.ieso.ca/en/Power-Data/Data-Directory.",
+    "[2] Coffee reference.",
+    "[3] Streaming reference."
+  ],
+  "data": [
+    {
+      "profile_id": "p1",
+      "activity_id": "coffee",
+      "activity_name": "Coffee",
+      "activity_category": "Food",
+      "scope_boundary": null,
+      "emission_factor_vintage_year": 2022,
+      "grid_region": null,
+      "grid_vintage_year": null,
+      "annual_emissions_g": 520.0,
+      "annual_emissions_g_low": null,
+      "annual_emissions_g_high": null
+    },
+    {
+      "profile_id": "p1",
+      "activity_id": "stream",
+      "activity_name": "Streaming",
+      "activity_category": "Digital",
+      "scope_boundary": null,
+      "emission_factor_vintage_year": 2023,
+      "grid_region": "CA-ON",
+      "grid_vintage_year": 2024.0,
+      "annual_emissions_g": 18200.0,
+      "annual_emissions_g_low": 16380.0,
+      "annual_emissions_g_high": 20020.0
+    }
+  ]
+}

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -1,0 +1,64 @@
+import pandas as pd
+import pytest
+
+from calc import figures
+
+
+@pytest.fixture
+def emissions_df():
+    return pd.DataFrame(
+        [
+            {
+                "activity_id": "coffee",
+                "activity_name": "Coffee",
+                "activity_category": "Food",
+                "annual_emissions_g": 120.0,
+                "annual_emissions_g_low": 100.0,
+                "annual_emissions_g_high": 150.0,
+            },
+            {
+                "activity_id": "stream",
+                "activity_name": "Streaming",
+                "activity_category": None,
+                "annual_emissions_g": 80.0,
+                "annual_emissions_g_low": 70.0,
+                "annual_emissions_g_high": 90.0,
+            },
+            {
+                "activity_id": "coffee",
+                "activity_name": "Coffee",
+                "activity_category": "Food",
+                "annual_emissions_g": 30.0,
+                "annual_emissions_g_low": None,
+                "annual_emissions_g_high": None,
+            },
+        ]
+    )
+
+
+def test_slice_totals_match_source(emissions_df):
+    total = emissions_df["annual_emissions_g"].sum()
+
+    stacked = figures.slice_stacked(emissions_df)
+    bubble = figures.slice_bubble(emissions_df)
+    sankey = figures.slice_sankey(emissions_df)
+
+    stacked_total = sum(item["values"]["mean"] for item in stacked)
+    bubble_total = sum(point.values["mean"] for point in bubble)
+    sankey_total = sum(link["values"]["mean"] for link in sankey["links"])
+
+    assert stacked_total == pytest.approx(total)
+    assert bubble_total == pytest.approx(total)
+    assert sankey_total == pytest.approx(total)
+
+
+def test_slice_outputs_include_uncategorized(emissions_df):
+    data = figures.slice_stacked(emissions_df)
+    categories = {row["category"] for row in data}
+    assert "uncategorized" in categories
+
+    points = figures.slice_bubble(emissions_df)
+    assert any(point.category == "uncategorized" for point in points)
+
+    sankey = figures.slice_sankey(emissions_df)
+    assert any(link["category"] == "uncategorized" for link in sankey["links"])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,121 @@
+import json
+import math
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import calc.derive as derive_mod
+import calc.figures as figures
+from calc.schema import (
+    Activity,
+    ActivitySchedule,
+    EmissionFactor,
+    GridIntensity,
+    Profile,
+    RegionCode,
+)
+
+
+class FrozenDateTime:
+    _fixed = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return cls._fixed
+        return cls._fixed.astimezone(tz)
+
+
+def _patch_time(monkeypatch):
+    monkeypatch.setattr(derive_mod, "datetime", FrozenDateTime)
+    monkeypatch.setattr(derive_mod.figures, "datetime", FrozenDateTime)
+    monkeypatch.setattr(figures, "datetime", FrozenDateTime)
+
+
+class GoldenStore:
+    def load_emission_factors(self):
+        return [
+            EmissionFactor(
+                activity_id="coffee",
+                value_g_per_unit=2.0,
+                source_id="coffee",
+                vintage_year=2022,
+            ),
+            EmissionFactor(
+                activity_id="stream",
+                is_grid_indexed=True,
+                electricity_kwh_per_unit=0.25,
+                source_id="streaming",
+                vintage_year=2023,
+            ),
+        ]
+
+    def load_profiles(self):
+        return [
+            Profile(
+                profile_id="p1",
+                office_days_per_week=5,
+                default_grid_region=RegionCode.CA_ON,
+            )
+        ]
+
+    def load_activity_schedule(self):
+        return [
+            ActivitySchedule(profile_id="p1", activity_id="coffee", freq_per_week=5),
+            ActivitySchedule(
+                profile_id="p1",
+                activity_id="stream",
+                freq_per_day=2,
+                region_override=RegionCode.CA_ON,
+            ),
+        ]
+
+    def load_grid_intensity(self):
+        return [
+            GridIntensity(
+                region=RegionCode.CA_ON,
+                intensity_g_per_kwh=100,
+                intensity_low_g_per_kwh=90,
+                intensity_high_g_per_kwh=110,
+                source_id="SRC.IESO.2024",
+                vintage_year=2024,
+            )
+        ]
+
+    def load_activities(self):
+        return [
+            Activity(activity_id="coffee", name="Coffee", category="Food"),
+            Activity(activity_id="stream", name="Streaming", category="Digital"),
+        ]
+
+
+def _normalise(value):
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if isinstance(value, list):
+        return [_normalise(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _normalise(val) for key, val in value.items()}
+    return value
+
+
+def test_export_view_matches_golden(monkeypatch):
+    figures.invalidate_cache()
+    _patch_time(monkeypatch)
+
+    out_dir = Path("calc/outputs")
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+
+    try:
+        derive_mod.export_view(GoldenStore())
+        payload = json.loads((out_dir / "export_view.json").read_text())
+    finally:
+        if out_dir.exists():
+            shutil.rmtree(out_dir)
+        figures.invalidate_cache()
+
+    golden_path = Path("tests/fixtures/export_view.golden.json")
+    golden_payload = json.loads(golden_path.read_text())
+
+    assert _normalise(payload) == golden_payload


### PR DESCRIPTION
## Summary
- add regression coverage for figure slices to ensure totals stay in sync across chart types
- exercise export_view end-to-end with a frozen clock and compare against a deterministic golden payload
- store the stable export_view golden artifact alongside the tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7290c9db8832c895e8b71bdaee9bf