### PR TITLE
docs: expand README and add contributor maintenance guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,9 @@
 **Sources & References:**
 - <!-- Required: cite datasets, reports, or tickets that informed the change -->
 
+**Source IDs:**
+- <!-- Required: list every `source_id` added or consumed in this PR -->
+
 **Scope Notes:**
 - <!-- Required: clarify anything intentionally out-of-scope or deferred -->
 
@@ -17,6 +20,7 @@
 - <!-- Required: list relevant data vintages, refresh cadence, or sunset expectations -->
 
 **ACX015 Seeding Checklist:**
+- [ ] Source IDs above follow the sources-first / null-first protocol
 - [ ] Inputs conform to seeding rules (no hidden migrations or drift)
 - [ ] QA artifacts updated or attached
 - [ ] Branch ready for CODEOWNERS review gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Check README make targets
+        run: python tools/check_readme_make_targets.py
+
       - name: Install Poetry
         run: pip install poetry==1.7.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing
+
+Thanks for investing time in carbon-acx! This guide explains how to prepare a
+change, what quality bars we expect, and how to keep the seeding protocol
+predictable across pull requests.
+
+## Getting started
+
+1. Install toolchain prerequisites listed in the [README](README.md#local-development).
+2. Create a new branch from `main`.
+3. Run the local quality targets at least once before opening your pull request:
+
+   ```bash
+   make lint
+   make test
+   make build site package
+   ```
+
+## Pull request checklist
+
+Include the following confirmations in every pull request description:
+
+- [ ] **Schema rules** — emission factor rows use XOR activity or profile keys,
+      unit symbols match `data/units.csv`, and each record carries an explicit
+      `vintage`.
+- [ ] **Sources-first / null-first** — every new measurement references a
+      `source_id` from `data/sources.csv`, and missing or unverifiable values are
+      left `null` rather than guessed.
+- [ ] **Tests** — `make lint`, `make test`, and `make build site package` were
+      run locally and relevant fixture updates are included.
+- [ ] **Activities & emission factors** — additions or edits in
+      `data/activities.csv` and `data/emission_factors.csv` include matching
+      schedule/profile entries when required.
+- [ ] **Grid intensity** — updates in `data/grid_intensity.csv` note their
+      temporal coverage and region identifiers.
+- [ ] **Profiles** — new rows in `data/profiles.csv` describe the profile type,
+      unit, and default interpretation in the accompanying source reference.
+- [ ] **References** — any new `source_id` has a complete citation in
+      `data/sources.csv` and supporting material is attached to the pull request.
+- [ ] **Parity** — backend parity tests pass locally (`pytest
+      tests/test_backend_parity.py`).
+
+## Working with data inputs
+
+### Adding activities
+
+- Append new activities to `data/activities.csv` with globally unique IDs.
+- Document the purpose and system boundary in the `description` column.
+- If the activity should appear on schedules, update `data/activity_schedule.csv`
+  with the appropriate cadence and reference IDs.
+
+### Emission factors (EFs)
+
+- Ensure each EF row references exactly one of `activity_id` or `profile_id`.
+- Provide the measurement `unit` and `vintage` year aligned to the source.
+- Link to the provenance using an existing or new `source_id`.
+
+### Grid intensity
+
+- Capture regional identifiers (ISO country or balancing authority).
+- Record the averaging window (hourly, daily, annual) in the metadata columns.
+- Note refresh expectations in the pull request under **Vintage Notes**.
+
+### Profiles and schedules
+
+- Keep profile IDs consistent across `profiles.csv`, `activity_schedule.csv`,
+  and any derived artifacts.
+- When a profile replaces an existing series, deprecate the prior row by
+  updating its `sunset_vintage`.
+
+## Updating references
+
+- Amend `data/sources.csv` with complete bibliographic details for every new
+  source: title, publisher, publication year, URL, and access timestamp.
+- Store supporting PDFs or spreadsheets in external storage and link them in
+  the pull request description when licenses permit.
+
+## Acceptance expectations
+
+Pull requests should leave the repository in a releasable state:
+
+- All quality gates succeed locally and in CI.
+- The README instructions continue to match the codebase — update them when
+  behaviours or targets change.
+- New data preserves backward compatibility for downstream consumers unless the
+  change is explicitly flagged in **Scope Notes**.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,128 @@
 # carbon-acx
 
-Minimal scaffold for carbon accounting demo.
+A lightweight reference stack for experimenting with carbon accounting data. The
+project demonstrates how raw emissions activity data can be normalised into
+shared models, derived into analytical artifacts, and rendered into a static
+site or interactive app.
 
-## Commands
+## Overview
+
+The repository is organised to keep source data, derivation logic, and delivery
+artifacts clearly separated:
+
+- **`data/`** holds source CSVs and external references.
+- **`calc/`** provides the domain models and the `calc.derive` entry point that
+  transforms the raw inputs.
+- **`app/`** contains a small FastAPI application for interactive exploration.
+- **`docs/`** aggregates reference material for maintainers and contributors.
+
+Related guides:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) documents how to propose data or model
+  changes.
+- [docs/MAINTENANCE_CALENDAR.md](docs/MAINTENANCE_CALENDAR.md) outlines the
+  operational cadence for refreshing inputs and dependencies.
+
+## Data flow
+
+1. **Sources** — tabular inputs begin in `data/csv` and may be supplemented with
+   upstream extracts listed in the references directory.
+2. **Models** — the `calc` package defines Pydantic models that enforce schema
+   expectations and unit conventions as inputs are loaded.
+3. **Derive** — `python -m calc.derive` consolidates the normalised data into a
+   reproducible output tree under `build/<backend>/calc/outputs`.
+4. **Artifacts** — packaging scripts copy curated tables, figures, and
+   manifest metadata into `dist/artifacts` for distribution.
+5. **UI** — the static site renderer and `app/` service consume the packaged
+   artifacts to power user-facing experiences.
+
+## Local development
+
+### Requirements
+
+- Python 3.11
+- [Poetry](https://python-poetry.org/) (automatically installed in CI)
+- `make`
+
+### Install dependencies
 
 ```bash
 make install
-make validate
-make build
-make app
 ```
 
-## Build & Artifacts
+### Quality gates
 
-No generated data is tracked in git. To produce fresh artifacts locally, run:
+```bash
+make lint
+make test
+make validate  # runs lint + test together for quick verification
+```
+
+### Build and package artifacts
+
+Each stage can be executed independently or as a chain:
+
+```bash
+make build     # derive data products into build/<backend>
+make site      # render the static site using the derived outputs
+make package   # assemble dist/artifacts and dist/site bundles
+```
+
+The convenience target below mirrors the CI pipeline and is safe to run locally
+before submitting a pull request:
 
 ```bash
 make build site package
 ```
 
-This sequence derives emissions data into `build/<backend>/calc/outputs`, assembles
-static assets under `build/site`, and copies distributable bundles into `dist/`.
+Build outputs are always written to the `build/` and `dist/` directories so the
+source tree remains clean.
 
-Environment variables can be used to customise the build:
+## Backends
 
-- `ACX_DATA_BACKEND` selects the datastore backend (defaults to `csv`).
-- `OUTPUT_DIR` overrides the root directory used for intermediate outputs.
+The derivation pipeline supports interchangeable storage backends to validate
+parity across implementations:
 
-CI runs the same steps and publishes two downloadable artifacts: `dist-artifacts`
-with the packaged datasets and `dist-site` with the static site bundle.
+- `ACX_DATA_BACKEND=csv` (default) reads from the repository CSV inputs.
+- `ACX_DATA_BACKEND=duckdb` exercises the DuckDB-backed loader; it requires the
+  optional `duckdb` dependency (`poetry install --extras db`).
+
+Use the `build-backend` helper to generate artifacts for a specific backend:
+
+```bash
+make build-backend B=duckdb
+```
+
+## Artifact policy
+
+Generated datasets, manifests, SBOMs, and site bundles **must not** be committed
+to the repository. Always use the `build`, `site`, and `package` targets to
+recreate them locally.
+
+Continuous integration executes the same steps and publishes downloadable
+artifacts:
+
+- `dist-artifacts` — curated tables, manifests, and references.
+- `dist-site` — the compiled static site bundle ready for deployment.
+
+## Running the app and static site
+
+Start the interactive FastAPI app after building artifacts:
+
+```bash
+make build
+make app
+```
+
+The app expects the derived outputs to exist and will serve them on
+`http://localhost:8000`.
+
+To inspect the static site locally, build it and serve the output directory with
+any static file server. For example:
+
+```bash
+make site
+python -m http.server --directory build/site 8001
+```
+
+Navigate to `http://localhost:8001` to verify the rendered pages.

--- a/docs/MAINTENANCE_CALENDAR.md
+++ b/docs/MAINTENANCE_CALENDAR.md
@@ -1,26 +1,21 @@
-# Maintenance Calendar
+# Maintenance calendar
 
-This calendar documents the regular cadences used to keep carbon-acx artifacts compliant with ACX015.
-All dates are expressed in UTC.
+Keeping the carbon-acx data pipeline trustworthy requires planned refreshes and
+dependency reviews. Use this calendar to schedule the most common maintenance
+tasks.
 
-## Quarterly Sweeps (January, April, July, October)
+## Quarterly
 
-| Window | Focus | Owners |
-| --- | --- | --- |
-| Week 1 | Review upstream grid intensity updates and refresh data feeds. | Data & Schema |
-| Week 2 | Validate app experience, update UI copy, and smoke test major user flows. | App |
-| Week 3 | Refresh documentation, regenerate diagrams, and verify onboarding instructions. | Docs |
-| Week 4 | Run CI hardening checks, audit pipelines, and rotate keys/secrets as needed. | CI |
+- **Dependency review** — audit Poetry dependencies (`poetry show --outdated`),
+  upgrade minor versions where possible, and regenerate the SBOM via `make sbom`.
+- **Grid intensity refresh** — re-fetch balancing authority and grid intensity
+  datasets, update `data/grid_intensity.csv`, and rerun backend parity tests.
 
-## Annual Sweeps
+## Annual
 
-| Month | Focus | Owners |
-| --- | --- | --- |
-| January | Publish annual roadmap, confirm governance alignment, and reset CODEOWNERS as required. | PM & Governance |
-| April | Conduct full data lineage audit and archive deprecated vintages. | Data |
-| July | Perform performance benchmarking and capacity planning. | App & Infrastructure |
-| October | Review compliance posture, update privacy impact assessments, and document exceptions. | Governance |
-
-## Ad-hoc Tasks
-
-Outside the recurring sweeps, any urgent updates should be logged as maintenance tickets and routed to the appropriate domain owners for triage within two business days.
+- **Profile refresh** — confirm long-lived profiles and schedules still reflect
+  current operating assumptions; update `data/profiles.csv` and
+  `data/activity_schedule.csv` as needed.
+- **Sources audit** — review `data/sources.csv` for broken links, outdated
+  citations, or retired publications. Replace stale references and record access
+  timestamps.

--- a/tools/check_readme_make_targets.py
+++ b/tools/check_readme_make_targets.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Verify README make targets are still defined in the Makefile."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+MAKEFILE = ROOT / "Makefile"
+
+TARGET_PATTERN = re.compile(r"^([A-Za-z0-9_.-]+)\s*:(?!=)")
+
+
+def load_make_targets() -> set[str]:
+    if not MAKEFILE.exists():
+        raise SystemExit("Makefile not found")
+
+    targets: set[str] = set()
+    for line in MAKEFILE.read_text().splitlines():
+        if line.startswith("\t") or not line.strip():
+            continue
+        match = TARGET_PATTERN.match(line)
+        if not match:
+            continue
+        target = match.group(1)
+        if target == ".PHONY":
+            continue
+        targets.add(target)
+    return targets
+
+
+def extract_targets_from_readme() -> set[str]:
+    if not README.exists():
+        raise SystemExit("README.md not found")
+
+    content = README.read_text()
+    targets: set[str] = set()
+
+    # Inline code snippets like `make build`
+    for snippet in re.findall(r"`make ([^`]+)`", content):
+        command = snippet.split("#", 1)[0].strip()
+        for token in command.split():
+            token = token.strip(".,")
+            if not token or token.startswith("-") or "=" in token:
+                continue
+            targets.add(token)
+
+    # Code blocks or standalone lines starting with make commands
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("$ make "):
+            command = stripped[2:]
+        elif stripped.startswith("make "):
+            command = stripped
+        else:
+            continue
+        command = command.split("#", 1)[0].strip()
+        parts = command.split()[1:]
+        for token in parts:
+            token = token.strip(".,")
+            if not token or token.startswith("-") or "=" in token:
+                continue
+            targets.add(token)
+
+    return targets
+
+
+def main() -> int:
+    declared_targets = load_make_targets()
+    referenced_targets = extract_targets_from_readme()
+
+    missing = sorted(target for target in referenced_targets if target not in declared_targets)
+    if missing:
+        sys.stderr.write(
+            "README.md references undefined make targets: " + ", ".join(missing) + "\n"
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- expand the README with architecture, build, and runtime guidance for contributors
- add CONTRIBUTING and maintenance calendar docs to codify seeding and refresh expectations
- enforce README accuracy in CI with a make-target checker and update the PR template to list source IDs

## Testing
- python tools/check_readme_make_targets.py

------
https://chatgpt.com/codex/tasks/task_e_68d775ec2964832cabe50a26606d2ae7