### PR TITLE
test(ui): add Dash and static site smoke tests

### DIFF
--- a/app/components/bubble.py
+++ b/app/components/bubble.py
@@ -123,4 +123,5 @@ def render(
     return html.Section(
         [html.H2(title), content],
         className="chart-section chart-section--bubble",
+        id="bubble",
     )

--- a/app/components/references.py
+++ b/app/components/references.py
@@ -21,4 +21,5 @@ def render(reference_keys: Sequence[str] | None) -> html.Aside:
             html.Ol([html.Li(text) for text in references]),
         ],
         className="references-panel",
+        id="references",
     )

--- a/app/components/sankey.py
+++ b/app/components/sankey.py
@@ -119,4 +119,5 @@ def render(
     return html.Section(
         [html.H2(title), content],
         className="chart-section chart-section--sankey",
+        id="sankey",
     )

--- a/app/components/stacked.py
+++ b/app/components/stacked.py
@@ -108,4 +108,5 @@ def render(
     return html.Section(
         [html.H2(title), content],
         className="chart-section chart-section--stacked",
+        id="stacked",
     )

--- a/tests/fixtures/artifacts_minimal/figures/bubble.json
+++ b/tests/fixtures/artifacts_minimal/figures/bubble.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "category": "Cooling",
+      "activity_name": "Chiller",
+      "layer_id": "professional",
+      "values": {
+        "mean": 500,
+        "low": 400,
+        "high": 600
+      }
+    }
+  ],
+  "citation_keys": ["SRC.DEMO"]
+}

--- a/tests/fixtures/artifacts_minimal/figures/sankey.json
+++ b/tests/fixtures/artifacts_minimal/figures/sankey.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "nodes": [
+      {"id": "cooling", "label": "Cooling", "type": "category"},
+      {"id": "chiller", "label": "Chiller"}
+    ],
+    "links": [
+      {
+        "source": "cooling",
+        "target": "chiller",
+        "category": "Cooling",
+        "layer_id": "professional",
+        "values": {"mean": 500}
+      }
+    ]
+  },
+  "citation_keys": ["SRC.DEMO"]
+}

--- a/tests/fixtures/artifacts_minimal/figures/stacked.json
+++ b/tests/fixtures/artifacts_minimal/figures/stacked.json
@@ -1,0 +1,14 @@
+{
+  "data": [
+    {
+      "category": "Cooling",
+      "layer_id": "professional",
+      "values": {
+        "mean": 1200,
+        "low": 1000,
+        "high": 1400
+      }
+    }
+  ],
+  "citation_keys": ["SRC.DEMO"]
+}

--- a/tests/fixtures/artifacts_minimal/manifest.json
+++ b/tests/fixtures/artifacts_minimal/manifest.json
@@ -1,0 +1,9 @@
+{
+  "generated_at": "2024-01-01T00:00:00Z",
+  "regions": ["Demo Region"],
+  "vintages": {
+    "emission_factors": [2024],
+    "grid_intensity": [2024]
+  },
+  "sources": ["SRC.DEMO"]
+}

--- a/tests/test_app_layout.py
+++ b/tests/test_app_layout.py
@@ -36,11 +36,12 @@ def test_layout_contains_expected_sections(monkeypatch) -> None:
     layout_ids = _collect_ids(dash_app.layout.to_plotly_json())
 
     figures_store = {
-        name: app_module._load_figure_payload(fixture_dir, name)
-        for name in app_module.FIGURE_NAMES
+        name: app_module._load_figure_payload(fixture_dir, name) for name in app_module.FIGURE_NAMES
     }
     available_layers = app_module._collect_layers(figures_store)
-    selected_layers = available_layers[:1] if available_layers else [app_module.LayerId.PROFESSIONAL.value]
+    selected_layers = (
+        available_layers[:1] if available_layers else [app_module.LayerId.PROFESSIONAL.value]
+    )
 
     callback = next(iter(dash_app.callback_map.values()))["callback"].__wrapped__
     panels_children, _ = callback(selected_layers, "single", figures_store)

--- a/tests/test_app_layout.py
+++ b/tests/test_app_layout.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from app import app as app_module
+
+
+def _collect_ids(node: Any) -> set[str]:
+    ids: set[str] = set()
+    if hasattr(node, "to_plotly_json"):
+        return _collect_ids(node.to_plotly_json())
+    if isinstance(node, dict):
+        props = node.get("props")
+        if isinstance(props, dict) and "id" in props:
+            value = props["id"]
+            if isinstance(value, str):
+                ids.add(value)
+        for value in node.values():
+            ids.update(_collect_ids(value))
+    elif isinstance(node, Iterable) and not isinstance(node, (str, bytes)):
+        for item in node:
+            ids.update(_collect_ids(item))
+    return ids
+
+
+def test_layout_contains_expected_sections(monkeypatch) -> None:
+    fixture_dir = Path(__file__).parent / "fixtures" / "artifacts_minimal"
+    monkeypatch.setenv(app_module.ARTIFACT_ENV, str(fixture_dir))
+
+    dash_app = app_module.create_app()
+    client = dash_app.server.test_client()
+    response = client.get("/")
+    assert response.status_code == 200
+
+    layout_ids = _collect_ids(dash_app.layout.to_plotly_json())
+
+    figures_store = {
+        name: app_module._load_figure_payload(fixture_dir, name)
+        for name in app_module.FIGURE_NAMES
+    }
+    available_layers = app_module._collect_layers(figures_store)
+    selected_layers = available_layers[:1] if available_layers else [app_module.LayerId.PROFESSIONAL.value]
+
+    callback = next(iter(dash_app.callback_map.values()))["callback"].__wrapped__
+    panels_children, _ = callback(selected_layers, "single", figures_store)
+
+    panel_ids: set[str] = set()
+    for child in panels_children:
+        panel_ids.update(_collect_ids(child.to_plotly_json()))
+
+    component_ids = layout_ids | panel_ids
+
+    expected_ids = {"stacked", "bubble", "sankey", "references"}
+    assert expected_ids.issubset(component_ids)

--- a/tests/test_static_site_build.py
+++ b/tests/test_static_site_build.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.build_site import build_site
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "artifacts_minimal"
+
+
+def test_static_site_builds_index(tmp_path) -> None:
+    output_dir = tmp_path / "site"
+
+    index_path = build_site(FIXTURE_DIR, output_dir)
+
+    assert index_path.exists()
+    assert index_path.parent == output_dir
+
+    html = index_path.read_text(encoding="utf-8")
+
+    assert "Carbon ACX emissions overview" in html
+    assert "Annual emissions by activity category" in html
+    assert "Activity bubble chart" in html
+    assert "Activity flow" in html
+    assert '<aside class="references-panel">' in html
+
+    styles_path = output_dir / "styles.css"
+    assert styles_path.exists(), "Expected styles.css to be copied alongside the build output"


### PR DESCRIPTION
## Summary
- add stable IDs to the stacked, bubble, sankey, and references components
- add a minimal artifact fixture with Dash layout and static site smoke tests
- verify the static site builder renders expected content and copies assets

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d77a57892c832c9b52623511d9a9e8