### PR TITLE
chore(calc): clarify output guard override hint

### DIFF
--- a/calc/derive.py
+++ b/calc/derive.py
@@ -124,7 +124,8 @@ def is_safe_output_dir(path: Path, repo_root: Path) -> bool:
 def _prepare_output_dir(path: Path) -> None:
     if not is_safe_output_dir(path, REPO_ROOT):
         raise ValueError(
-            "Refusing to clear output directory outside dist/artifacts build guardrails:" f" {path}"
+            "Refusing to clear output directory outside dist/artifacts build guardrails: "
+            f"{path}. Set ACX_ALLOW_OUTPUT_RM=1 to override."
         )
 
     if path.exists():


### PR DESCRIPTION
## Summary
- clarify the guardrail failure error message to explain how to override deletion protections

## Testing
- poetry run pytest tests/test_outputs.py

------
https://chatgpt.com/codex/tasks/task_e_68d88bc6daa8832cbae91d3f0266dfe3