### PR TITLE
ci: enforce backend export parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        backend: [csv, duckdb]
+    env:
+      ACX_DATA_BACKEND: ${{ matrix.backend }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,6 +46,13 @@ jobs:
       - name: Build packages
         run: make build site package
 
+      - name: Upload export_view.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: export-view-${{ matrix.backend }}
+          path: dist/artifacts/**/${{ matrix.backend }}/calc/outputs/export_view.json
+          if-no-files-found: error
+
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
@@ -65,8 +77,35 @@ jobs:
           path: dist/site
           if-no-files-found: error
 
-  deploy-pages:
+  backend-parity:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download CSV export
+        uses: actions/download-artifact@v4
+        with:
+          name: export-view-csv
+          path: parity/csv
+
+      - name: Download DuckDB export
+        uses: actions/download-artifact@v4
+        with:
+          name: export-view-duckdb
+          path: parity/duckdb
+
+      - name: Diff backend exports
+        run: python tools/diff_exports.py parity/csv/export_view.json parity/duckdb/export_view.json
+
+  deploy-pages:
+    needs: [build, backend-parity]
     if: github.ref == 'refs/heads/main'
     permissions:
       pages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,31 @@ jobs:
           name: export-view-csv-${{ github.run_id }}
           path: parity/csv
 
+      - name: Normalize CSV export path
+        run: |
+          set -euo pipefail
+          csv_file="$(find parity/csv -name export_view.json -print -quit)"
+          if [ -z "${csv_file}" ]; then
+            echo "export_view.json from CSV backend artifact not found" >&2
+            exit 1
+          fi
+          mv "${csv_file}" parity/csv/export_view.json
+
       - name: Download DuckDB export
         uses: actions/download-artifact@v4
         with:
           name: export-view-duckdb-${{ github.run_id }}
           path: parity/duckdb
+
+      - name: Normalize DuckDB export path
+        run: |
+          set -euo pipefail
+          duckdb_file="$(find parity/duckdb -name export_view.json -print -quit)"
+          if [ -z "${duckdb_file}" ]; then
+            echo "export_view.json from DuckDB backend artifact not found" >&2
+            exit 1
+          fi
+          mv "${duckdb_file}" parity/duckdb/export_view.json
 
       - name: Diff backend exports
         run: python tools/diff_exports.py parity/csv/export_view.json parity/duckdb/export_view.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,14 @@ jobs:
       - name: Upload export_view.json
         uses: actions/upload-artifact@v4
         with:
-          name: export-view-${{ matrix.backend }}
+          name: export-view-${{ matrix.backend }}-${{ github.run_id }}
           path: dist/artifacts/**/${{ matrix.backend }}/calc/outputs/export_view.json
           if-no-files-found: error
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
-          name: sbom
+          name: sbom-${{ matrix.backend }}-${{ github.run_id }}
           path: dist/sbom.cdx.json
           if-no-files-found: error
 
@@ -66,14 +66,14 @@ jobs:
       - name: Upload dist artifacts bundle
         uses: actions/upload-artifact@v4
         with:
-          name: dist-artifacts
+          name: dist-artifacts-${{ matrix.backend }}-${{ github.run_id }}
           path: dist/artifacts
           if-no-files-found: error
 
       - name: Upload static site bundle
         uses: actions/upload-artifact@v4
         with:
-          name: dist-site
+          name: dist-site-${{ matrix.backend }}-${{ github.run_id }}
           path: dist/site
           if-no-files-found: error
 
@@ -92,13 +92,13 @@ jobs:
       - name: Download CSV export
         uses: actions/download-artifact@v4
         with:
-          name: export-view-csv
+          name: export-view-csv-${{ github.run_id }}
           path: parity/csv
 
       - name: Download DuckDB export
         uses: actions/download-artifact@v4
         with:
-          name: export-view-duckdb
+          name: export-view-duckdb-${{ github.run_id }}
           path: parity/duckdb
 
       - name: Diff backend exports
@@ -118,7 +118,7 @@ jobs:
       - name: Download static site
         uses: actions/download-artifact@v4
         with:
-          name: dist-site
+          name: dist-site-csv-${{ github.run_id }}
           path: dist-site
 
       - name: Upload Pages artifact

--- a/tools/diff_exports.py
+++ b/tools/diff_exports.py
@@ -1,0 +1,77 @@
+"""Diff export_view payloads produced by different data backends."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _normalize(value: Any) -> Any:
+    """Return a canonical, order-insensitive representation of ``value``."""
+
+    if isinstance(value, dict):
+        return {key: _normalize(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return sorted((_normalize(item) for item in value), key=_sort_key)
+    return value
+
+
+def _sort_key(value: Any) -> str:
+    """Stable sort key for normalized data structures."""
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(f"Failed to parse JSON from {path}: {exc}") from exc
+
+
+def diff_exports(csv_path: Path, duckdb_path: Path) -> int:
+    csv_payload = _normalize(_load_json(csv_path))
+    duckdb_payload = _normalize(_load_json(duckdb_path))
+
+    if csv_payload == duckdb_payload:
+        return 0
+
+    csv_dump = json.dumps(csv_payload, indent=2, sort_keys=True, ensure_ascii=False)
+    duckdb_dump = json.dumps(duckdb_payload, indent=2, sort_keys=True, ensure_ascii=False)
+
+    diff = "\n".join(
+        difflib.unified_diff(
+            csv_dump.splitlines(),
+            duckdb_dump.splitlines(),
+            fromfile=str(csv_path),
+            tofile=str(duckdb_path),
+            lineterm="",
+        )
+    )
+
+    message = [
+        "Detected differences between export_view.json outputs.",
+        "CSV backend is authoritative. Please investigate the DuckDB output.",
+    ]
+    if diff:
+        message.append(diff)
+
+    print("\n".join(message))
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv_export", type=Path, help="Path to CSV backend export_view.json")
+    parser.add_argument("duckdb_export", type=Path, help="Path to DuckDB backend export_view.json")
+    args = parser.parse_args(argv)
+
+    return diff_exports(args.csv_export, args.duckdb_export)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- run the CI pipeline for both csv and duckdb backends and publish their export outputs
- add a backend parity job that diffs export_view.json with a new helper script

## Testing
- python -m compileall tools/diff_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68d8b4071b5c832cb878a0cc22a9bab2