### PR TITLE
feat: expose grid vintage matrix in UI and manifest

### DIFF
--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -40,6 +40,16 @@ body {
   line-height: 1.5;
 }
 
+.sidebar-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sidebar-panels > * {
+  width: 100%;
+}
+
 .chart-section {
   background: #ffffff;
   border-radius: 16px;
@@ -183,4 +193,77 @@ body {
     position: static;
     max-height: none;
   }
+
+  .sidebar-panels {
+    position: static;
+  }
+}
+
+.info-panel {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem 1.75rem;
+  box-shadow: 0 18px 30px -28px rgba(15, 23, 42, 0.5);
+}
+
+.info-panel h2,
+.info-panel h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.info-panel ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #475569;
+  line-height: 1.5;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.info-panel li {
+  list-style: disc;
+}
+
+.vintages-panel h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.vintages-panel p {
+  margin: 0 0 1rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.vintages-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.vintages-list li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+  list-style: none;
+}
+
+.vintages-panel__region {
+  color: #1e293b;
+  font-weight: 500;
+}
+
+.vintages-panel__year {
+  color: #1e3a8a;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }

--- a/app/components/vintages.py
+++ b/app/components/vintages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from operator import itemgetter
 from typing import Mapping
 
 from dash import html
@@ -34,7 +35,7 @@ def _coerce_matrix(manifest: Mapping | None) -> list[tuple[str, int]]:
             continue
         entries.append((region, year))
 
-    entries.sort(key=lambda item: item[0])
+    entries.sort(key=itemgetter(0))
     return entries
 
 

--- a/app/components/vintages.py
+++ b/app/components/vintages.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+from dash import html
+
+from calc.schema import RegionCode
+
+
+def _region_label(code: str) -> str:
+    try:
+        region = RegionCode(code)
+    except ValueError:
+        return code
+    return region.value
+
+
+def _coerce_matrix(manifest: Mapping | None) -> list[tuple[str, int]]:
+    if not manifest:
+        return []
+
+    matrix = manifest.get("vintage_matrix") if isinstance(manifest, Mapping) else None
+    if not isinstance(matrix, Mapping):
+        return []
+
+    entries: list[tuple[str, int]] = []
+    for raw_region, raw_year in matrix.items():
+        if raw_region is None or raw_year is None:
+            continue
+        region = str(raw_region)
+        try:
+            year = int(raw_year)
+        except (TypeError, ValueError):
+            continue
+        entries.append((region, year))
+
+    entries.sort(key=lambda item: item[0])
+    return entries
+
+
+def render(manifest: Mapping | None) -> html.Section:
+    entries = _coerce_matrix(manifest)
+
+    if entries:
+        content = html.Ul(
+            [
+                html.Li(
+                    [
+                        html.Span(_region_label(region), className="vintages-panel__region"),
+                        html.Span(str(year), className="vintages-panel__year"),
+                    ]
+                )
+                for region, year in entries
+            ],
+            className="vintages-list",
+        )
+        description = html.P("Latest grid intensity vintage year per region.")
+    else:
+        content = html.P("No grid vintages available.")
+        description = None
+
+    children = [html.H2("Vintages")]
+    if description is not None:
+        children.append(description)
+    children.append(content)
+
+    return html.Section(children, className="info-panel vintages-panel", id="vintages")

--- a/calc/derive.py
+++ b/calc/derive.py
@@ -594,8 +594,7 @@ def export_view(
             "grid_intensity": sorted(manifest_grid_vintages),
         },
         "vintage_matrix": {
-            key: manifest_vintage_matrix[key]
-            for key in sorted(manifest_vintage_matrix)
+            key: manifest_vintage_matrix[key] for key in sorted(manifest_vintage_matrix)
         },
         "sources": citation_keys,
         "layers": sorted_layers,

--- a/calc/derive.py
+++ b/calc/derive.py
@@ -471,6 +471,7 @@ def export_view(
     manifest_layers: set[str] = set()
     manifest_ef_vintages: set[int] = set()
     manifest_grid_vintages: set[int] = set()
+    manifest_vintage_matrix: dict[str, int] = {}
 
     schedules = datastore.load_activity_schedule()
     for sched in schedules:
@@ -497,8 +498,15 @@ def export_view(
                         else grid_row.region
                     )
                     if region_value is not None:
-                        manifest_regions.add(str(region_value))
-                    if grid_row.vintage_year is not None:
+                        region_key = str(region_value)
+                        manifest_regions.add(region_key)
+                        if grid_row.vintage_year is not None:
+                            year = int(grid_row.vintage_year)
+                            manifest_grid_vintages.add(year)
+                            existing_year = manifest_vintage_matrix.get(region_key)
+                            if existing_year is None or year > existing_year:
+                                manifest_vintage_matrix[region_key] = year
+                    elif grid_row.vintage_year is not None:
                         manifest_grid_vintages.add(int(grid_row.vintage_year))
             details = compute_emission_details(sched, profile, ef, grid_lookup, grid_row)
             emission = details.mean
@@ -584,6 +592,10 @@ def export_view(
         "vintages": {
             "emission_factors": sorted(manifest_ef_vintages),
             "grid_intensity": sorted(manifest_grid_vintages),
+        },
+        "vintage_matrix": {
+            key: manifest_vintage_matrix[key]
+            for key in sorted(manifest_vintage_matrix)
         },
         "sources": citation_keys,
         "layers": sorted_layers,

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -87,14 +87,10 @@ def _format_manifest_summary(manifest: Mapping | None) -> str:
 
     summary_items: list[str] = []
     if generated_at:
-        summary_items.append(
-            f"<li><strong>Generated at:</strong> {escape(str(generated_at))}</li>"
-        )
+        summary_items.append(f"<li><strong>Generated at:</strong> {escape(str(generated_at))}</li>")
     if regions:
         joined_regions = ", ".join(str(region) for region in regions)
-        summary_items.append(
-            f"<li><strong>Regions:</strong> {escape(joined_regions)}</li>"
-        )
+        summary_items.append(f"<li><strong>Regions:</strong> {escape(joined_regions)}</li>")
     if vintages:
         ef = vintages.get("emission_factors") or []
         grid = vintages.get("grid_intensity") or []
@@ -127,9 +123,9 @@ def _format_manifest_summary(manifest: Mapping | None) -> str:
     matrix_html = ""
     if matrix_entries:
         rows = "".join(
-            "<li><span class=\"vintages-panel__region\">"
+            '<li><span class="vintages-panel__region">'
             + escape(region)
-            + "</span><span class=\"vintages-panel__year\">"
+            + '</span><span class="vintages-panel__year">'
             + escape(str(year))
             + "</span></li>"
             for region, year in matrix_entries
@@ -138,9 +134,7 @@ def _format_manifest_summary(manifest: Mapping | None) -> str:
             '<div class="info-panel vintages-panel">'
             "<h3>Grid vintages</h3>"
             "<p>Latest grid intensity vintage year per region.</p>"
-            '<ul class="vintages-list">'
-            + rows
-            + "</ul>"
+            '<ul class="vintages-list">' + rows + "</ul>"
             "</div>"
         )
 

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -83,36 +83,75 @@ def _format_manifest_summary(manifest: Mapping | None) -> str:
     regions = manifest.get("regions") or []
     vintages = manifest.get("vintages") or {}
     sources = manifest.get("sources") or []
+    matrix_raw = manifest.get("vintage_matrix") or {}
 
-    items: list[str] = []
+    summary_items: list[str] = []
     if generated_at:
-        items.append(f"<li><strong>Generated at:</strong> {escape(str(generated_at))}</li>")
+        summary_items.append(
+            f"<li><strong>Generated at:</strong> {escape(str(generated_at))}</li>"
+        )
     if regions:
         joined_regions = ", ".join(str(region) for region in regions)
-        items.append(f"<li><strong>Regions:</strong> {escape(joined_regions)}</li>")
+        summary_items.append(
+            f"<li><strong>Regions:</strong> {escape(joined_regions)}</li>"
+        )
     if vintages:
         ef = vintages.get("emission_factors") or []
         grid = vintages.get("grid_intensity") or []
         if ef:
-            items.append(
+            summary_items.append(
                 f"<li><strong>Emission factor vintages:</strong> {escape(', '.join(map(str, ef)))}</li>"
             )
         if grid:
-            items.append(
+            summary_items.append(
                 f"<li><strong>Grid intensity vintages:</strong> {escape(', '.join(map(str, grid)))}</li>"
             )
     if sources:
-        items.append(f"<li><strong>Total sources:</strong> {len(sources)}</li>")
+        summary_items.append(f"<li><strong>Total sources:</strong> {len(sources)}</li>")
 
-    if not items:
-        items.append("<li>No manifest metadata available.</li>")
+    if not summary_items:
+        summary_items.append("<li>No manifest metadata available.</li>")
 
-    return (
-        '<section class="manifest-section">'
+    matrix_entries: list[tuple[str, int]] = []
+    if isinstance(matrix_raw, Mapping):
+        for region, year in matrix_raw.items():
+            if region is None or year is None:
+                continue
+            try:
+                matrix_entries.append((str(region), int(year)))
+            except (TypeError, ValueError):
+                continue
+
+    matrix_entries.sort(key=lambda item: item[0])
+
+    matrix_html = ""
+    if matrix_entries:
+        rows = "".join(
+            "<li><span class=\"vintages-panel__region\">"
+            + escape(region)
+            + "</span><span class=\"vintages-panel__year\">"
+            + escape(str(year))
+            + "</span></li>"
+            for region, year in matrix_entries
+        )
+        matrix_html = (
+            '<div class="info-panel vintages-panel">'
+            "<h3>Grid vintages</h3>"
+            "<p>Latest grid intensity vintage year per region.</p>"
+            '<ul class="vintages-list">'
+            + rows
+            + "</ul>"
+            "</div>"
+        )
+
+    summary_html = (
+        '<div class="info-panel manifest-panel">'
         "<h3>Dataset manifest</h3>"
-        "<ul>" + "".join(items) + "</ul>"
-        "</section>"
+        "<ul>" + "".join(summary_items) + "</ul>"
+        "</div>"
     )
+
+    return summary_html + matrix_html
 
 
 def build_site(artifact_dir: Path, output_dir: Path) -> Path:

--- a/tests/fixtures/artifacts_minimal/manifest.json
+++ b/tests/fixtures/artifacts_minimal/manifest.json
@@ -5,5 +5,8 @@
     "emission_factors": [2024],
     "grid_intensity": [2024]
   },
+  "vintage_matrix": {
+    "Demo Region": 2024
+  },
   "sources": ["SRC.DEMO"]
 }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,26 @@
+import json
+
+import calc.derive as derive_mod
+from calc import schema
+
+
+def test_manifest_includes_regions_and_vintage_matrix(derived_output_root):
+    derive_mod.export_view(output_root=derived_output_root)
+
+    manifest_path = derived_output_root / "calc" / "outputs" / "manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    regions = payload.get("regions")
+    assert isinstance(regions, list) and regions, "expected regions in manifest"
+
+    matrix = payload.get("vintage_matrix")
+    assert isinstance(matrix, dict) and matrix, "expected vintage_matrix entries"
+
+    reference_year = max(row.vintage_year or 0 for row in schema.load_grid_intensity())
+    assert reference_year > 0
+
+    for region, year in matrix.items():
+        assert isinstance(region, str) and region
+        assert isinstance(year, int)
+        assert year <= reference_year
+        assert region in regions


### PR DESCRIPTION
## Summary
- add a grid vintage matrix to the calc manifest payload and static site summary
- show the new vintage details in the Dash app sidebar with dedicated styling
- cover the manifest contract with a focused regression test and fixture update

## Testing
- pytest tests/test_manifest.py

------
https://chatgpt.com/codex/tasks/task_e_68d8b81e2e8c832c84a8379324e0e929