### PR TITLE
feat: add layer-aware references and toggles

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -155,9 +155,7 @@ def _reference_rank(key: str, reference_lookup: Mapping[str, int]) -> tuple[int,
     return (index, key)
 
 
-def _order_reference_keys(
-    keys: Iterable[str], reference_lookup: Mapping[str, int]
-) -> list[str]:
+def _order_reference_keys(keys: Iterable[str], reference_lookup: Mapping[str, int]) -> list[str]:
     seen: set[str] = set()
     unique: list[str] = []
     for key in keys:

--- a/app/app.py
+++ b/app/app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Iterable, Mapping
 
 import copy
 from dash import Dash, Input, Output, State, dcc, html
@@ -119,6 +119,22 @@ def _filter_payload(payload: dict | None, layer_id: str | None) -> dict | None:
         node_ids = {link.get("source") for link in links} | {link.get("target") for link in links}
         nodes = [node for node in data.get("nodes", []) if node.get("id") in node_ids]
         filtered["data"] = {"nodes": nodes, "links": links}
+    filtered["layers"] = [layer_id]
+
+    layer_key_map = filtered.get("layer_citation_keys")
+    if isinstance(layer_key_map, dict):
+        keys = layer_key_map.get(layer_id, [])
+        filtered["layer_citation_keys"] = {layer_id: keys}
+        filtered["citation_keys"] = keys
+    else:
+        keys = None
+
+    layer_ref_map = filtered.get("layer_references")
+    if isinstance(layer_ref_map, dict):
+        filtered["layer_references"] = {layer_id: layer_ref_map.get(layer_id, [])}
+        if keys is not None:
+            filtered["references"] = layer_ref_map.get(layer_id, filtered.get("references"))
+
     return filtered
 
 
@@ -132,6 +148,26 @@ def _order_layers(layers: list[str]) -> list[str]:
     return sorted(unique, key=_layer_order_index)
 
 
+def _reference_rank(key: str, reference_lookup: Mapping[str, int]) -> tuple[int, str]:
+    index = reference_lookup.get(key)
+    if index is None:
+        return (len(reference_lookup), key)
+    return (index, key)
+
+
+def _order_reference_keys(
+    keys: Iterable[str], reference_lookup: Mapping[str, int]
+) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for key in keys:
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(key)
+    return sorted(unique, key=lambda item: _reference_rank(item, reference_lookup))
+
+
 def create_app() -> Dash:
     artifact_dir = _artifact_dir()
     figures = {name: _load_figure_payload(artifact_dir, name) for name in FIGURE_NAMES}
@@ -139,8 +175,32 @@ def create_app() -> Dash:
     reference_lookup = _reference_lookup(reference_keys)
     manifest_payload = _load_manifest_payload(artifact_dir)
 
+    layer_citation_keys: dict[str, list[str]] = {}
+    if isinstance(manifest_payload, dict):
+        manifest_layers = manifest_payload.get("layer_citation_keys")
+        if isinstance(manifest_layers, dict):
+            layer_citation_keys = {
+                str(layer): list(keys)
+                for layer, keys in manifest_layers.items()
+                if isinstance(keys, list)
+            }
+
     available_layers = _collect_layers(figures)
     default_layers = [available_layers[0]] if available_layers else [LayerId.PROFESSIONAL.value]
+
+    def _resolve_reference_keys(
+        layers: Iterable[str], mapping: Mapping[str, list[str]] | None = None
+    ) -> list[str]:
+        active_map: Mapping[str, list[str]] = mapping or layer_citation_keys
+        aggregated: list[str] = []
+        has_mapping = bool(active_map)
+        for layer in layers:
+            extend_unique(active_map.get(layer, []), aggregated)
+        if not aggregated and not has_mapping:
+            aggregated = list(reference_keys)
+        return _order_reference_keys(aggregated, reference_lookup)
+
+    initial_reference_keys = _resolve_reference_keys(default_layers)
     layer_options: list[dict] = []
     for layer in LayerId:
         option = {"label": layer.label, "value": layer.value}
@@ -154,6 +214,7 @@ def create_app() -> Dash:
         children=[
             dcc.Store(id="figures-store", data=figures),
             dcc.Store(id="available-layers", data=available_layers),
+            dcc.Store(id="layer-citation-keys", data=layer_citation_keys),
             html.Main(
                 className="chart-column",
                 children=[
@@ -214,7 +275,7 @@ def create_app() -> Dash:
             html.Div(
                 [
                     vintages.render(manifest_payload),
-                    references.render(reference_keys),
+                    references.render(initial_reference_keys),
                 ],
                 className="sidebar-panels",
             ),
@@ -277,6 +338,29 @@ def create_app() -> Dash:
             )
 
         return children, panels_class
+
+    @app.callback(
+        Output("references", "children"),
+        Input("layer-selector", "value"),
+        State("layer-citation-keys", "data"),
+    )
+    def _update_references(selected_layers, layer_map):
+        layers = selected_layers or []
+        if isinstance(layers, str):
+            layers = [layers]
+        layers = [layer for layer in layers if isinstance(layer, str)]
+        ordered_layers = _order_layers(layers)
+
+        mapping = layer_citation_keys
+        if isinstance(layer_map, dict):
+            mapping = {
+                str(layer): list(keys)
+                for layer, keys in layer_map.items()
+                if isinstance(keys, list)
+            }
+
+        reference_keys_for_layers = _resolve_reference_keys(ordered_layers, mapping)
+        return references.render_children(reference_keys_for_layers)
 
     return app
 

--- a/app/components/references.py
+++ b/app/components/references.py
@@ -7,19 +7,27 @@ from dash import html
 from calc import citations
 
 
-def render(reference_keys: Sequence[str] | None) -> html.Aside:
+def _reference_texts(reference_keys: Sequence[str] | None) -> list[str]:
     references = [
         citations.format_ieee(ref.numbered(idx))
         for idx, ref in enumerate(citations.references_for(reference_keys or []), start=1)
     ]
     if not references:
         references = ["No references available."]
+    return references
 
+
+def render_children(reference_keys: Sequence[str] | None) -> list[html.Component]:
+    references = _reference_texts(reference_keys)
+    return [html.H2("References"), html.Ol([html.Li(text) for text in references])]
+
+
+def render(reference_keys: Sequence[str] | None) -> html.Aside:
     return html.Aside(
-        [
-            html.H2("References"),
-            html.Ol([html.Li(text) for text in references]),
-        ],
+        render_children(reference_keys),
         className="references-panel",
         id="references",
     )
+
+
+__all__ = ["render", "render_children"]

--- a/calc/derive.py
+++ b/calc/derive.py
@@ -771,4 +771,3 @@ _LAYER_NAME_HINTS: dict[str, LayerId] = {
     "industrial_heavy": LayerId.INDUSTRIAL_HEAVY,
     "heavy_industrial": LayerId.INDUSTRIAL_HEAVY,
 }
-

--- a/calc/derive.py
+++ b/calc/derive.py
@@ -242,6 +242,33 @@ def _layer_value(value: LayerId | str | None) -> str | None:
     return str(value)
 
 
+def _normalise_layer_hint(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+
+
+def _resolve_layer_hint(value: object | None) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, LayerId):
+        return value.value
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    upper = text.upper()
+    for prefix, layer in _LAYER_PREFIXES:
+        if upper.startswith(prefix):
+            return layer.value
+
+    normalised = _normalise_layer_hint(text)
+    hinted = _LAYER_NAME_HINTS.get(normalised)
+    if hinted is not None:
+        return hinted.value
+
+    return None
+
+
 def _resolve_layer_id(
     sched: ActivitySchedule | None,
     profile: Profile | None,
@@ -254,7 +281,20 @@ def _resolve_layer_id(
         resolved = _layer_value(layer)
         if resolved:
             return resolved
-    return None
+
+    hint_sources = (
+        getattr(sched, "profile_id", None),
+        getattr(profile, "profile_id", None),
+        getattr(sched, "activity_id", None),
+        getattr(activity, "activity_id", None),
+        getattr(activity, "category", None),
+    )
+    for candidate in hint_sources:
+        hinted = _resolve_layer_hint(candidate)
+        if hinted:
+            return hinted
+
+    return LayerId.PROFESSIONAL.value
 
 
 def _office_ratio(profile: Profile) -> Optional[float]:
@@ -564,6 +604,27 @@ def export_view(
     generated_at = _resolve_generated_at()
     sorted_layers = sorted(manifest_layers)
 
+    layer_key_sets: dict[str, set[str]] = {}
+    for row in derived_rows:
+        layer = row.get("layer_id") if isinstance(row, dict) else getattr(row, "layer_id", None)
+        if not layer:
+            continue
+        keys = collect_activity_source_keys([row])
+        if not keys:
+            continue
+        layer_key_sets.setdefault(str(layer), set()).update(keys)
+
+    layer_citation_keys: dict[str, List[str]] = {}
+    for layer in sorted_layers:
+        key_set = layer_key_sets.get(layer, set())
+        ordered = [key for key in citation_keys if key in key_set]
+        remaining = sorted(key_set.difference(ordered))
+        layer_citation_keys[layer] = ordered + remaining
+
+    layer_references: dict[str, List[str]] = {
+        layer: _format_references(layer_citation_keys.get(layer, [])) for layer in sorted_layers
+    }
+
     metadata = figures.build_metadata(
         "export_view",
         profile_ids=profile_arg,
@@ -571,6 +632,10 @@ def export_view(
     )
     metadata["citation_keys"] = citation_keys
     metadata["layers"] = sorted_layers
+    if layer_citation_keys:
+        metadata["layer_citation_keys"] = layer_citation_keys
+    if layer_references:
+        metadata["layer_references"] = layer_references
     references = _format_references(citation_keys)
     metadata["references"] = references
 
@@ -599,6 +664,10 @@ def export_view(
         "sources": citation_keys,
         "layers": sorted_layers,
     }
+    if layer_citation_keys:
+        manifest_payload["layer_citation_keys"] = layer_citation_keys
+    if layer_references:
+        manifest_payload["layer_references"] = layer_references
 
     build_hash = _compute_build_hash(manifest_payload, normalised_rows)
     base_output_root = _resolve_output_root(output_root, REPO_ROOT)
@@ -641,6 +710,10 @@ def export_view(
         )
         meta["citation_keys"] = citation_keys
         meta["layers"] = sorted_layers
+        if layer_citation_keys:
+            meta["layer_citation_keys"] = layer_citation_keys
+        if layer_references:
+            meta["layer_references"] = layer_references
         meta["references"] = references
         meta["data"] = data
         _write_json(figure_dir / f"{name}.json", meta)
@@ -683,3 +756,19 @@ if __name__ == "__main__":
 
     datastore = choose_backend()
     export_view(datastore, output_root=args.output_root)
+_LAYER_PREFIXES: list[tuple[str, LayerId]] = [
+    ("PRO.", LayerId.PROFESSIONAL),
+    ("ONLINE.", LayerId.ONLINE),
+    ("IND.TO.LIGHT.", LayerId.INDUSTRIAL_LIGHT),
+    ("IND.TO.HEAVY.", LayerId.INDUSTRIAL_HEAVY),
+]
+
+_LAYER_NAME_HINTS: dict[str, LayerId] = {
+    "professional": LayerId.PROFESSIONAL,
+    "online": LayerId.ONLINE,
+    "industrial_light": LayerId.INDUSTRIAL_LIGHT,
+    "light_industrial": LayerId.INDUSTRIAL_LIGHT,
+    "industrial_heavy": LayerId.INDUSTRIAL_HEAVY,
+    "heavy_industrial": LayerId.INDUSTRIAL_HEAVY,
+}
+

--- a/tests/fixtures/export_view.golden.json
+++ b/tests/fixtures/export_view.golden.json
@@ -1,54 +1,68 @@
 {
+  "citation_keys": [
+    "SRC.IESO.2024",
+    "coffee",
+    "streaming"
+  ],
+  "data": [
+    {
+      "activity_category": "Food",
+      "activity_id": "coffee",
+      "activity_name": "Coffee",
+      "annual_emissions_g": 520.0,
+      "annual_emissions_g_high": null,
+      "annual_emissions_g_low": null,
+      "emission_factor_vintage_year": 2022,
+      "grid_region": null,
+      "grid_vintage_year": null,
+      "layer_id": "professional",
+      "profile_id": "p1",
+      "scope_boundary": null
+    },
+    {
+      "activity_category": "Digital",
+      "activity_id": "stream",
+      "activity_name": "Streaming",
+      "annual_emissions_g": 18200.0,
+      "annual_emissions_g_high": 20020.0,
+      "annual_emissions_g_low": 16380.0,
+      "emission_factor_vintage_year": 2023,
+      "grid_region": "CA-ON",
+      "grid_vintage_year": 2024,
+      "layer_id": "professional",
+      "profile_id": "p1",
+      "scope_boundary": null
+    }
+  ],
   "generated_at": "2024-01-02T03:04:05+00:00",
-  "profile": "p1",
+  "layer_citation_keys": {
+    "professional": [
+      "SRC.IESO.2024",
+      "coffee",
+      "streaming"
+    ]
+  },
+  "layer_references": {
+    "professional": [
+      "[1] Independent Electricity System Operator (IESO), \u201cEmissions and Grid Intensity (Ontario)\u2014Data and Reports,\u201d 2024. Available: https://www.ieso.ca/en/Power-Data/Data-Directory.",
+      "[2] Coffee reference.",
+      "[3] Streaming reference."
+    ]
+  },
+  "layers": [
+    "professional"
+  ],
   "method": "export_view",
+  "profile": "p1",
   "profile_resolution": {
     "requested": "PRO.TO.24_39.HYBRID.2025",
     "used": [
       "p1"
     ]
   },
-  "citation_keys": [
-    "SRC.IESO.2024",
-    "coffee",
-    "streaming"
-  ],
-  "layers": [
-    "professional"
-  ],
   "references": [
     "[1] Independent Electricity System Operator (IESO), \u201cEmissions and Grid Intensity (Ontario)\u2014Data and Reports,\u201d 2024. Available: https://www.ieso.ca/en/Power-Data/Data-Directory.",
     "[2] Coffee reference.",
     "[3] Streaming reference."
-  ],
-  "data": [
-    {
-      "profile_id": "p1",
-      "activity_id": "coffee",
-      "layer_id": "professional",
-      "activity_name": "Coffee",
-      "activity_category": "Food",
-      "scope_boundary": null,
-      "emission_factor_vintage_year": 2022,
-      "grid_region": null,
-      "grid_vintage_year": null,
-      "annual_emissions_g": 520.0,
-      "annual_emissions_g_low": null,
-      "annual_emissions_g_high": null
-    },
-    {
-      "profile_id": "p1",
-      "activity_id": "stream",
-      "layer_id": "professional",
-      "activity_name": "Streaming",
-      "activity_category": "Digital",
-      "scope_boundary": null,
-      "emission_factor_vintage_year": 2023,
-      "grid_region": "CA-ON",
-      "grid_vintage_year": 2024.0,
-      "annual_emissions_g": 18200.0,
-      "annual_emissions_g_low": 16380.0,
-      "annual_emissions_g_high": 20020.0
-    }
   ]
 }

--- a/tests/test_app_layout.py
+++ b/tests/test_app_layout.py
@@ -44,9 +44,7 @@ def test_layout_contains_expected_sections(monkeypatch) -> None:
     )
 
     panel_callback_info = next(
-        info
-        for key, info in dash_app.callback_map.items()
-        if "layer-panels.children" in key
+        info for key, info in dash_app.callback_map.items() if "layer-panels.children" in key
     )
     callback = panel_callback_info["callback"].__wrapped__
     panels_children, _ = callback(selected_layers, "single", figures_store)

--- a/tests/test_app_layout.py
+++ b/tests/test_app_layout.py
@@ -43,7 +43,12 @@ def test_layout_contains_expected_sections(monkeypatch) -> None:
         available_layers[:1] if available_layers else [app_module.LayerId.PROFESSIONAL.value]
     )
 
-    callback = next(iter(dash_app.callback_map.values()))["callback"].__wrapped__
+    panel_callback_info = next(
+        info
+        for key, info in dash_app.callback_map.items()
+        if "layer-panels.children" in key
+    )
+    callback = panel_callback_info["callback"].__wrapped__
     panels_children, _ = callback(selected_layers, "single", figures_store)
 
     panel_ids: set[str] = set()

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -78,11 +78,14 @@ def test_export_metadata_and_references(derived_output_dir, derived_output_root)
     assert data["citation_keys"] == ["coffee", "streaming"]
     assert data["layers"] == ["professional"]
     assert all(row["layer_id"] == "professional" for row in data["data"])
+    assert data.get("layer_citation_keys") == {"professional": ["coffee", "streaming"]}
 
     expected_refs = [
         citations.format_ieee(ref.numbered(idx))
         for idx, ref in enumerate(citations.references_for(["coffee", "streaming"]), start=1)
     ]
+
+    assert data.get("layer_references") == {"professional": expected_refs}
 
     export_refs = (out_dir / "references" / "export_view_refs.txt").read_text().strip().splitlines()
     assert export_refs == expected_refs
@@ -98,11 +101,15 @@ def test_export_metadata_and_references(derived_output_dir, derived_output_root)
     assert stacked_payload["method"] == "figures.stacked"
     assert stacked_payload["data"]
     assert all("layer_id" in row for row in stacked_payload["data"])
+    assert stacked_payload.get("layer_citation_keys") == {"professional": ["coffee", "streaming"]}
+    assert stacked_payload.get("layer_references") == {"professional": expected_refs}
 
     bubble_payload = json.loads((out_dir / "figures" / "bubble.json").read_text())
     assert bubble_payload["references"] == expected_refs
     assert all("mean" in point["values"] for point in bubble_payload["data"])
     assert all(point.get("layer_id") for point in bubble_payload["data"])
+    assert bubble_payload.get("layer_citation_keys") == {"professional": ["coffee", "streaming"]}
+    assert bubble_payload.get("layer_references") == {"professional": expected_refs}
 
     sankey_payload = json.loads((out_dir / "figures" / "sankey.json").read_text())
     assert sankey_payload["references"] == expected_refs
@@ -110,6 +117,8 @@ def test_export_metadata_and_references(derived_output_dir, derived_output_root)
     assert "nodes" in sankey_payload["data"]
     assert "links" in sankey_payload["data"]
     assert all("layer_id" in link for link in sankey_payload["data"]["links"])
+    assert sankey_payload.get("layer_citation_keys") == {"professional": ["coffee", "streaming"]}
+    assert sankey_payload.get("layer_references") == {"professional": expected_refs}
 
     for name in ("stacked", "bubble", "sankey"):
         txt = (out_dir / "references" / f"{name}_refs.txt").read_text().strip().splitlines()
@@ -118,6 +127,8 @@ def test_export_metadata_and_references(derived_output_dir, derived_output_root)
     manifest = json.loads((out_dir / "manifest.json").read_text())
     assert manifest["sources"] == ["coffee", "streaming"]
     assert manifest["layers"] == ["professional"]
+    assert manifest.get("layer_citation_keys") == {"professional": ["coffee", "streaming"]}
+    assert manifest.get("layer_references") == {"professional": expected_refs}
 
 
 def test_emission_calculation_and_nulls():

--- a/tests/test_figures_dynamic_citations.py
+++ b/tests/test_figures_dynamic_citations.py
@@ -73,5 +73,7 @@ def test_figures_use_dynamic_citations(derived_output_dir, derived_output_root):
     fig_payload = json.loads((out_dir / "figures" / "stacked.json").read_text())
     assert fig_payload["references"] == expected_refs
     assert fig_payload["citation_keys"] == expected_keys
+    assert fig_payload.get("layer_citation_keys") == {"professional": expected_keys}
+    assert fig_payload.get("layer_references") == {"professional": expected_refs}
     assert all("coffee" not in ref and "stream" not in ref for ref in fig_payload["references"])
     assert all(row.get("layer_id") == "professional" for row in fig_payload["data"])

--- a/tests/test_layer_toggle.py
+++ b/tests/test_layer_toggle.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dash import html
+
+import calc.derive as derive_mod
+from calc import citations
+from calc.schema import ActivitySchedule, EmissionFactor, LayerId, Profile
+
+from app import app as app_module
+
+
+class LayeredStore:
+    def load_emission_factors(self):
+        return [
+            EmissionFactor(activity_id="coffee", value_g_per_unit=1, source_id="coffee"),
+            EmissionFactor(activity_id="stream", value_g_per_unit=2, source_id="streaming"),
+        ]
+
+    def load_profiles(self):
+        return [
+            Profile(profile_id="PRO.TEST", layer_id=LayerId.PROFESSIONAL, office_days_per_week=5),
+            Profile(profile_id="ONLINE.TEST", layer_id=LayerId.ONLINE, office_days_per_week=0),
+        ]
+
+    def load_activity_schedule(self):
+        return [
+            ActivitySchedule(
+                profile_id="PRO.TEST",
+                activity_id="coffee",
+                layer_id=LayerId.PROFESSIONAL,
+                freq_per_week=5,
+            ),
+            ActivitySchedule(
+                profile_id="ONLINE.TEST",
+                activity_id="stream",
+                layer_id=LayerId.ONLINE,
+                freq_per_day=1,
+            ),
+        ]
+
+    def load_grid_intensity(self):
+        return []
+
+    def load_activities(self):
+        return []
+
+
+def _extract_reference_texts(children) -> list[str]:
+    ordered_list = next(child for child in children if isinstance(child, html.Ol))
+    return [item.children for item in ordered_list.children]
+
+
+def test_layer_filter_and_reference_union(monkeypatch, derived_output_dir, derived_output_root):
+    derive_mod.export_view(LayeredStore(), output_root=derived_output_root)
+
+    artifact_dir = derived_output_dir
+    figures_store = {
+        name: app_module._load_figure_payload(artifact_dir, name) for name in app_module.FIGURE_NAMES
+    }
+
+    professional = app_module._filter_payload(figures_store["stacked"], "professional")
+    assert professional["layers"] == ["professional"]
+    assert professional["citation_keys"] == ["coffee"]
+    assert professional.get("layer_citation_keys") == {"professional": ["coffee"]}
+    assert all(row.get("layer_id") == "professional" for row in professional.get("data", []))
+
+    online = app_module._filter_payload(figures_store["stacked"], "online")
+    assert online["layers"] == ["online"]
+    assert online["citation_keys"] == ["streaming"]
+    assert online.get("layer_citation_keys") == {"online": ["streaming"]}
+    assert all(row.get("layer_id") == "online" for row in online.get("data", []))
+
+    reference_lookup = app_module._reference_lookup(app_module._reference_keys(figures_store))
+    manifest_payload = app_module._load_manifest_payload(artifact_dir)
+    layer_map = manifest_payload["layer_citation_keys"]
+
+    union_keys = app_module._order_reference_keys(
+        layer_map["professional"] + layer_map["online"], reference_lookup
+    )
+    expected_union = [
+        citations.format_ieee(ref.numbered(idx))
+        for idx, ref in enumerate(citations.references_for(union_keys), start=1)
+    ]
+
+    monkeypatch.setenv(app_module.ARTIFACT_ENV, str(artifact_dir))
+    dash_app = app_module.create_app()
+
+    references_callback_info = next(
+        info for key, info in dash_app.callback_map.items() if key.startswith("references.children")
+    )
+    references_callback = references_callback_info["callback"].__wrapped__
+
+    professional_children = references_callback(["professional"], layer_map)
+    pro_expected = [
+        citations.format_ieee(ref.numbered(idx))
+        for idx, ref in enumerate(citations.references_for(layer_map["professional"]), start=1)
+    ]
+    assert _extract_reference_texts(professional_children) == pro_expected
+
+    combined_children = references_callback(["professional", "online"], layer_map)
+    assert _extract_reference_texts(combined_children) == expected_union
+
+    manifest_references = manifest_payload["layer_references"]
+    assert manifest_references["professional"] == pro_expected
+    assert manifest_references["online"] == [
+        citations.format_ieee(ref.numbered(idx))
+        for idx, ref in enumerate(citations.references_for(layer_map["online"]), start=1)
+    ]

--- a/tests/test_layer_toggle.py
+++ b/tests/test_layer_toggle.py
@@ -55,7 +55,8 @@ def test_layer_filter_and_reference_union(monkeypatch, derived_output_dir, deriv
 
     artifact_dir = derived_output_dir
     figures_store = {
-        name: app_module._load_figure_payload(artifact_dir, name) for name in app_module.FIGURE_NAMES
+        name: app_module._load_figure_payload(artifact_dir, name)
+        for name in app_module.FIGURE_NAMES
     }
 
     professional = app_module._filter_payload(figures_store["stacked"], "professional")


### PR DESCRIPTION
## Summary
- derive layer identifiers from profile and activity hints when missing and record per-layer citation mappings in derived artifacts
- update the Dash app to persist layer citation metadata, filter figure payloads, and drive a layer-aware references panel
- refresh fixtures and add coverage for layer toggling and reference unions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da01531678832cab78c51bd92a12d4