### PR TITLE
feat(viz): smooth Plotly transitions + persistent uirevision

### DIFF
--- a/app/components/_plotly_settings.py
+++ b/app/components/_plotly_settings.py
@@ -1,0 +1,48 @@
+"""Shared Plotly layout defaults for Carbon ACX visualizations."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Final
+
+import plotly.graph_objects as go
+
+__all__ = [
+    "REDUCED_MOTION_ENV",
+    "apply_figure_layout_defaults",
+]
+
+REDUCED_MOTION_ENV: Final[str] = "ACX_REDUCED_MOTION"
+_UIREVISION: Final[str] = "carbon-acx"
+_TRANSITION_EASING: Final[str] = "cubic-in-out"
+_TRANSITION_DURATION_MS: Final[int] = 250
+
+
+@lru_cache(maxsize=1)
+def _is_reduced_motion_enabled() -> bool:
+    """Return ``True`` when motion should be disabled."""
+
+    value = os.environ.get(REDUCED_MOTION_ENV)
+    if value is None:
+        return False
+    text = value.strip().lower()
+    if text in {"", "0", "false", "no", "off"}:
+        return False
+    return True
+
+
+def _transition_duration() -> int:
+    if _is_reduced_motion_enabled():
+        return 0
+    return _TRANSITION_DURATION_MS
+
+
+def apply_figure_layout_defaults(figure: go.Figure) -> go.Figure:
+    """Apply shared layout defaults for Plotly figures."""
+
+    figure.update_layout(
+        transition=dict(duration=_transition_duration(), easing=_TRANSITION_EASING),
+        uirevision=_UIREVISION,
+    )
+    return figure

--- a/app/components/bubble.py
+++ b/app/components/bubble.py
@@ -9,6 +9,7 @@ from calc.ui.theme import TOKENS, get_plotly_template
 
 from . import na_notice
 from ._helpers import clamp_optional, format_reference_hint, has_na_segments
+from ._plotly_settings import apply_figure_layout_defaults
 
 
 def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
@@ -36,7 +37,7 @@ def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
 
     palette = TOKENS["palette"]
 
-    figure = go.Figure()
+    figure = apply_figure_layout_defaults(go.Figure())
     if not means:
         return figure
 

--- a/app/components/sankey.py
+++ b/app/components/sankey.py
@@ -9,6 +9,7 @@ from calc.ui.theme import TOKENS, get_plotly_template
 
 from . import na_notice
 from ._helpers import clamp_optional, format_reference_hint, has_na_segments
+from ._plotly_settings import apply_figure_layout_defaults
 
 
 def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
@@ -58,7 +59,7 @@ def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
             hover += f"<br>{reference_hint}"
         hover_labels.append(hover)
 
-    figure = go.Figure()
+    figure = apply_figure_layout_defaults(go.Figure())
     if not values:
         return figure
 

--- a/app/components/stacked.py
+++ b/app/components/stacked.py
@@ -9,6 +9,7 @@ from calc.ui.theme import TOKENS, get_plotly_template
 
 from . import na_notice
 from ._helpers import clamp_optional, format_reference_hint, has_na_segments
+from ._plotly_settings import apply_figure_layout_defaults
 
 
 def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
@@ -33,7 +34,7 @@ def _build_figure(payload: dict, reference_hint: str) -> go.Figure:
 
     palette = TOKENS["palette"]
 
-    figure = go.Figure()
+    figure = apply_figure_layout_defaults(go.Figure())
     if not means:
         return figure
 


### PR DESCRIPTION
## Summary
- add a shared Plotly helper that applies consistent transitions, uirevision, and reduced-motion support
- use the helper across bubble, sankey, and stacked chart figure factories so zoom/legend state persists

## Testing
- pytest tests/ui/test_theme_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68da1ceb0dd0832c831b937321f87741