### PR TITLE
feat(ui): dark theme + dark Plotly template

### DIFF
--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -1,4 +1,5 @@
 :root {
+  color-scheme: light;
   --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono: "JetBrains Mono", SFMono-Regular, Menlo, monospace;
   --font-size-xs: 12px;
@@ -35,6 +36,91 @@
   --color-positive: #10b981;
   --color-warning: #fbbf24;
   --color-critical: #ef4444;
+  --color-highlight-soft: rgba(191, 219, 254, 0.45);
+  --color-highlight-strong: rgba(191, 219, 254, 0.7);
+  --color-highlight-border: rgba(37, 99, 235, 0.25);
+  --color-highlight-text: #1e3a8a;
+  --color-highlight-text-subtle: rgba(30, 64, 175, 0.75);
+  --color-skeleton-start: rgba(226, 232, 240, 0.6);
+  --color-skeleton-mid: rgba(203, 213, 225, 0.7);
+  --color-footnote-border: rgba(30, 41, 59, 0.2);
+  --color-footnote-accent-border: rgba(59, 130, 246, 0.45);
+  --color-footnote-accent-bg: rgba(191, 219, 254, 0.4);
+  --color-footnote-accent-text: #1e3a8a;
+  --color-footnote-positive-border: rgba(16, 185, 129, 0.45);
+  --color-footnote-positive-bg: #ecfdf5;
+  --color-footnote-positive-text: #0f766e;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --shadow-sm: 0 18px 48px rgba(2, 6, 23, 0.45);
+  --shadow-md: 0 24px 72px rgba(2, 6, 23, 0.65);
+  --color-background: #0b1220;
+  --color-surface: #111c2e;
+  --color-border: #1f2a3d;
+  --color-border-muted: #334155;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-accent: #60a5fa;
+  --color-accent-subtle: rgba(59, 130, 246, 0.2);
+  --color-accent-strong: #93c5fd;
+  --color-positive: #34d399;
+  --color-warning: #facc15;
+  --color-critical: #f87171;
+  --color-highlight-soft: rgba(59, 130, 246, 0.2);
+  --color-highlight-strong: rgba(59, 130, 246, 0.32);
+  --color-highlight-border: rgba(59, 130, 246, 0.38);
+  --color-highlight-text: #dbeafe;
+  --color-highlight-text-subtle: rgba(191, 219, 254, 0.8);
+  --color-skeleton-start: rgba(51, 65, 85, 0.45);
+  --color-skeleton-mid: rgba(71, 85, 105, 0.55);
+  --color-footnote-border: rgba(148, 163, 184, 0.32);
+  --color-footnote-accent-border: rgba(59, 130, 246, 0.42);
+  --color-footnote-accent-bg: rgba(59, 130, 246, 0.18);
+  --color-footnote-accent-text: #e0f2fe;
+  --color-footnote-positive-border: rgba(34, 197, 94, 0.4);
+  --color-footnote-positive-bg: rgba(34, 197, 94, 0.16);
+  --color-footnote-positive-text: #bbf7d0;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]),
+  :root[data-theme="system"] {
+    color-scheme: dark;
+    --shadow-sm: 0 18px 48px rgba(2, 6, 23, 0.45);
+    --shadow-md: 0 24px 72px rgba(2, 6, 23, 0.65);
+    --color-background: #0b1220;
+    --color-surface: #111c2e;
+    --color-border: #1f2a3d;
+    --color-border-muted: #334155;
+    --color-text: #e2e8f0;
+    --color-text-muted: #94a3b8;
+    --color-accent: #60a5fa;
+    --color-accent-subtle: rgba(59, 130, 246, 0.2);
+    --color-accent-strong: #93c5fd;
+    --color-positive: #34d399;
+    --color-warning: #facc15;
+    --color-critical: #f87171;
+    --color-highlight-soft: rgba(59, 130, 246, 0.2);
+    --color-highlight-strong: rgba(59, 130, 246, 0.32);
+    --color-highlight-border: rgba(59, 130, 246, 0.38);
+    --color-highlight-text: #dbeafe;
+    --color-highlight-text-subtle: rgba(191, 219, 254, 0.8);
+    --color-skeleton-start: rgba(51, 65, 85, 0.45);
+    --color-skeleton-mid: rgba(71, 85, 105, 0.55);
+    --color-footnote-border: rgba(148, 163, 184, 0.32);
+    --color-footnote-accent-border: rgba(59, 130, 246, 0.42);
+    --color-footnote-accent-bg: rgba(59, 130, 246, 0.18);
+    --color-footnote-accent-text: #e0f2fe;
+    --color-footnote-positive-border: rgba(34, 197, 94, 0.4);
+    --color-footnote-positive-bg: rgba(34, 197, 94, 0.16);
+    --color-footnote-positive-text: #bbf7d0;
+  }
 }
 
 *,
@@ -170,6 +256,18 @@ p {
   gap: clamp(1rem, 3vw, 1.75rem);
 }
 
+.page-header__top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.page-header__top h1 {
+  margin: 0;
+}
+
 .page-header .card__content {
   display: flex;
   flex-direction: column;
@@ -225,12 +323,69 @@ p {
   letter-spacing: 0.06em;
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.theme-toggle:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.theme-toggle__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.theme-toggle__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  font-size: 0.8rem;
+}
+
+.theme-toggle__icon::before {
+  content: "\2600";
+}
+
+.theme-toggle[data-mode="dark"] .theme-toggle__icon::before {
+  content: "\1F319";
+}
+
+.theme-toggle[data-mode="system"] .theme-toggle__icon::before {
+  content: "\2699";
+}
+
+.theme-toggle__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .disclosure-block {
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(37, 99, 235, 0.25);
-  background: rgba(191, 219, 254, 0.45);
+  border: 1px solid var(--color-highlight-border);
+  background: var(--color-highlight-soft);
   padding: var(--space-lg);
-  color: #1e3a8a;
+  color: var(--color-highlight-text);
 }
 
 .disclosure-block p {
@@ -244,7 +399,7 @@ p {
   padding: 0;
   display: grid;
   gap: var(--space-xs);
-  color: #1e3a8a;
+  color: var(--color-highlight-text);
 }
 
 .layout-grid {
@@ -278,7 +433,7 @@ p {
   margin: 0;
   font-size: clamp(1.15rem, 2vw, 1.5rem);
   font-weight: 600;
-  color: #1e293b;
+  color: var(--color-text);
 }
 
 .chart-section__figure {
@@ -310,7 +465,12 @@ p {
   position: relative;
   width: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, rgba(226, 232, 240, 0.6), rgba(203, 213, 225, 0.7), rgba(226, 232, 240, 0.6));
+  background: linear-gradient(
+    90deg,
+    var(--color-skeleton-start),
+    var(--color-skeleton-mid),
+    var(--color-skeleton-start)
+  );
   background-size: 200% 100%;
   animation: skeleton-shimmer 1.4s ease-in-out infinite;
 }
@@ -335,7 +495,7 @@ p {
 .chart-footnote {
   margin-top: var(--space-lg);
   border-radius: var(--radius-lg);
-  border-left: 4px solid rgba(30, 41, 59, 0.2);
+  border-left: 4px solid var(--color-footnote-border);
   padding: var(--space-sm) var(--space-lg);
   background: var(--color-surface);
   color: var(--color-text-muted);
@@ -348,15 +508,15 @@ p {
 }
 
 .chart-footnote--na {
-  border-left-color: rgba(59, 130, 246, 0.45);
-  background: rgba(191, 219, 254, 0.4);
-  color: #1e3a8a;
+  border-left-color: var(--color-footnote-accent-border);
+  background: var(--color-footnote-accent-bg);
+  color: var(--color-footnote-accent-text);
 }
 
 .chart-footnote--comparison {
-  border-left-color: rgba(16, 185, 129, 0.45);
-  background: #ecfdf5;
-  color: #0f766e;
+  border-left-color: var(--color-footnote-positive-border);
+  background: var(--color-footnote-positive-bg);
+  color: var(--color-footnote-positive-text);
 }
 
 
@@ -388,7 +548,7 @@ p {
 
 .chart-controls__label {
   font-weight: 600;
-  color: #1e293b;
+  color: var(--color-text);
   font-size: 0.95rem;
 }
 
@@ -408,15 +568,15 @@ p {
   gap: 0.35rem;
   padding: 0.4rem 0.9rem;
   border-radius: 999px;
-  background-color: rgba(191, 219, 254, 0.45);
-  color: #1e3a8a;
+  background-color: var(--color-highlight-soft);
+  color: var(--color-highlight-text);
   cursor: pointer;
   transition: background-color 0.2s ease;
 }
 
 .chart-controls__checklist label:hover,
 .chart-controls__radios label:hover {
-  background-color: rgba(191, 219, 254, 0.7);
+  background-color: var(--color-highlight-strong);
 }
 
 .chart-controls__checklist input,
@@ -432,21 +592,21 @@ p {
 }
 
 .chart-badge {
-  background: rgba(191, 219, 254, 0.45);
+  background: var(--color-highlight-soft);
   border-radius: var(--radius-lg);
   padding: var(--space-sm) var(--space-md);
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   min-width: 0;
-  color: #1e3a8a;
+  color: var(--color-highlight-text);
 }
 
 .chart-badge__label {
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(30, 64, 175, 0.75);
+  color: var(--color-highlight-text-subtle);
 }
 
 .chart-badge__value {
@@ -472,7 +632,7 @@ p {
   gap: 0.75rem;
   padding: var(--space-sm) var(--space-lg);
   font-weight: 600;
-  color: #1e3a8a;
+  color: var(--color-highlight-text);
   cursor: pointer;
   list-style: none;
 }
@@ -538,7 +698,7 @@ p {
   margin: 0;
   font-size: clamp(1.05rem, 1.8vw, 1.3rem);
   font-weight: 600;
-  color: #1e293b;
+  color: var(--color-text);
 }
 
 .info-panel ul {
@@ -562,7 +722,7 @@ p {
   margin: 0;
   font-size: clamp(1.15rem, 2vw, 1.45rem);
   font-weight: 600;
-  color: #1e293b;
+  color: var(--color-text);
 }
 
 .references-list {
@@ -600,7 +760,7 @@ p {
   font-size: var(--font-size-sm);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background-color: #fff;
+  background-color: var(--color-background);
   color: var(--color-accent);
   font-weight: 600;
   transition: background-color 0.2s ease, border-color 0.2s ease;
@@ -626,7 +786,7 @@ p {
   margin: 0;
   font-size: clamp(1rem, 1.6vw, 1.25rem);
   font-weight: 600;
-  color: #1e293b;
+  color: var(--color-text);
 }
 
 .sidebar-section:first-of-type {
@@ -667,12 +827,12 @@ p {
 }
 
 .vintages-panel__region {
-  color: #1e293b;
+  color: var(--color-text);
   font-weight: 500;
 }
 
 .vintages-panel__year {
-  color: #1e3a8a;
+  color: var(--color-highlight-text);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -699,7 +859,7 @@ blockquote {
   margin: var(--space-xl) 0;
   padding: var(--space-xs) var(--space-lg);
   color: var(--color-text-muted);
-  background: rgba(191, 219, 254, 0.35);
+  background: var(--color-highlight-soft);
 }
 
 code,

--- a/app/assets/theme.js
+++ b/app/assets/theme.js
@@ -1,0 +1,24 @@
+(function () {
+  const root = document.documentElement;
+  const storageKey = "theme-preference";
+
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored) {
+      const payload = JSON.parse(stored);
+      if (payload && typeof payload === "object" && "data" in payload) {
+        const value = payload.data;
+        if (value === "light" || value === "dark") {
+          root.setAttribute("data-theme", value);
+          return;
+        }
+      }
+    }
+  } catch (error) {
+    /* Ignore JSON parse errors and fall back to system preference. */
+  }
+
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    root.setAttribute("data-theme", "dark");
+  }
+})();

--- a/app/components/bubble.py
+++ b/app/components/bubble.py
@@ -5,7 +5,7 @@ from typing import Mapping, Optional
 import plotly.graph_objects as go
 from dash import dcc, html
 
-from calc.ui.theme import TOKENS, get_plotly_template
+from calc.ui.theme import get_palette, get_plotly_template
 
 from . import na_notice
 from ._helpers import (
@@ -18,7 +18,9 @@ from ._helpers import (
 from ._plotly_settings import apply_figure_layout_defaults
 
 
-def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figure:
+def _build_figure(
+    payload: dict, reference_lookup: Mapping[str, int], *, dark: bool = False
+) -> go.Figure:
     data = payload.get("data", []) if payload else []
 
     categories: list[str] = []
@@ -57,7 +59,7 @@ def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figu
             }
         )
 
-    palette = TOKENS["palette"]
+    palette = get_palette(dark=dark)
 
     figure = apply_figure_layout_defaults(go.Figure())
     if not means:
@@ -97,7 +99,7 @@ def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figu
             sizeref=sizeref,
             color=palette["positive"],
             opacity=0.8,
-            line=dict(color="rgba(15, 23, 42, 0.35)", width=1),
+            line=dict(color=palette["muted_border"], width=1),
         ),
         customdata=formatted_values,
         meta=meta_entries,
@@ -110,7 +112,7 @@ def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figu
     figure.add_trace(go.Scatter(**trace_kwargs))
 
     figure.update_layout(
-        template=get_plotly_template(),
+        template=get_plotly_template(dark=dark),
         margin=dict(l=60, r=20, t=40, b=60),
         xaxis=dict(title="Activity category", type="category"),
         yaxis=dict(title="Annual emissions (g CO₂e)", rangemode="tozero"),
@@ -124,11 +126,12 @@ def render(
     reference_lookup: Mapping[str, int],
     *,
     title_suffix: str | None = None,
+    dark: bool = False,
 ) -> html.Section:
     title = "Activity bubble chart"
     if title_suffix:
         title = f"{title} — {title_suffix}"
-    figure = _build_figure(figure_payload or {}, reference_lookup)
+    figure = _build_figure(figure_payload or {}, reference_lookup, dark=dark)
 
     if not figure.data:
         message = "No activity data available."

--- a/app/components/sankey.py
+++ b/app/components/sankey.py
@@ -5,7 +5,7 @@ from typing import Mapping, Optional
 import plotly.graph_objects as go
 from dash import dcc, html
 
-from calc.ui.theme import TOKENS, get_plotly_template
+from calc.ui.theme import get_palette, get_plotly_template
 
 from . import na_notice
 from ._helpers import (
@@ -18,12 +18,14 @@ from ._helpers import (
 from ._plotly_settings import apply_figure_layout_defaults
 
 
-def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figure:
+def _build_figure(
+    payload: dict, reference_lookup: Mapping[str, int], *, dark: bool = False
+) -> go.Figure:
     data = payload.get("data", {}) if payload else {}
     nodes = data.get("nodes", [])
     links = data.get("links", [])
 
-    palette = TOKENS["palette"]
+    palette = get_palette(dark=dark)
 
     id_to_index: dict[str, int] = {}
     labels: list[str] = []
@@ -79,6 +81,8 @@ def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figu
         return figure
 
     link_color = "rgba(37, 99, 235, 0.45)"
+    if dark:
+        link_color = "rgba(96, 165, 250, 0.6)"
     figure.add_trace(
         go.Sankey(
             arrangement="snap",
@@ -103,7 +107,7 @@ def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figu
     )
 
     figure.update_layout(
-        template=get_plotly_template(),
+        template=get_plotly_template(dark=dark),
         margin=dict(l=40, r=40, t=40, b=40),
     )
     return figure
@@ -114,11 +118,12 @@ def render(
     reference_lookup: Mapping[str, int],
     *,
     title_suffix: str | None = None,
+    dark: bool = False,
 ) -> html.Section:
     title = "Activity flow"
     if title_suffix:
         title = f"{title} — {title_suffix}"
-    figure = _build_figure(figure_payload or {}, reference_lookup)
+    figure = _build_figure(figure_payload or {}, reference_lookup, dark=dark)
 
     if not figure.data:
         message = "No flow data available."

--- a/app/components/stacked.py
+++ b/app/components/stacked.py
@@ -5,7 +5,7 @@ from typing import Mapping, Optional
 import plotly.graph_objects as go
 from dash import dcc, html
 
-from calc.ui.theme import TOKENS, get_plotly_template
+from calc.ui.theme import get_palette, get_plotly_template
 
 from . import na_notice
 from ._helpers import (
@@ -18,7 +18,9 @@ from ._helpers import (
 from ._plotly_settings import apply_figure_layout_defaults
 
 
-def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figure:
+def _build_figure(
+    payload: dict, reference_lookup: Mapping[str, int], *, dark: bool = False
+) -> go.Figure:
     data = payload.get("data", []) if payload else []
     categories: list[str] = []
     means: list[float] = []
@@ -54,7 +56,7 @@ def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figu
             }
         )
 
-    palette = TOKENS["palette"]
+    palette = get_palette(dark=dark)
 
     figure = apply_figure_layout_defaults(go.Figure())
     if not means:
@@ -94,7 +96,7 @@ def _build_figure(payload: dict, reference_lookup: Mapping[str, int]) -> go.Figu
     )
 
     figure.update_layout(
-        template=get_plotly_template(),
+        template=get_plotly_template(dark=dark),
         margin=dict(l=80, r=20, t=40, b=40),
         xaxis=dict(title="Annual emissions (g CO₂e)", showgrid=True, zeroline=False),
         yaxis=dict(title="Activity category", autorange="reversed"),
@@ -108,11 +110,12 @@ def render(
     reference_lookup: Mapping[str, int],
     *,
     title_suffix: str | None = None,
+    dark: bool = False,
 ) -> html.Section:
     title = "Annual emissions by activity category"
     if title_suffix:
         title = f"{title} — {title_suffix}"
-    figure = _build_figure(figure_payload or {}, reference_lookup)
+    figure = _build_figure(figure_payload or {}, reference_lookup, dark=dark)
 
     if not figure.data:
         message = "No category data available."

--- a/calc/ui/__init__.py
+++ b/calc/ui/__init__.py
@@ -1,5 +1,5 @@
 """UI theming utilities."""
 
-__all__ = ["TOKENS", "get_plotly_template"]
+__all__ = ["TOKENS", "get_palette", "get_plotly_template"]
 
-from .theme import TOKENS, get_plotly_template  # noqa: E402
+from .theme import TOKENS, get_palette, get_plotly_template  # noqa: E402

--- a/calc/ui/theme.py
+++ b/calc/ui/theme.py
@@ -3,10 +3,46 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Any
+from typing import Any, Dict
 
 import plotly.graph_objects as go
 import plotly.io as pio
+
+
+_PALETTES: Dict[str, Dict[str, str]] = {
+    "light": {
+        "background": "#ffffff",
+        "surface": "#f8fafc",
+        "border": "#e2e8f0",
+        "muted_border": "#cbd5f5",
+        "text": "#0f172a",
+        "text_muted": "#475569",
+        "accent": "#2563eb",
+        "accent_subtle": "#bfdbfe",
+        "accent_strong": "#1d4ed8",
+        "positive": "#10b981",
+        "warning": "#fbbf24",
+        "critical": "#ef4444",
+        "gridline": "rgba(148, 163, 184, 0.45)",
+        "gridline_light": "rgba(148, 163, 184, 0.2)",
+    },
+    "dark": {
+        "background": "#0b1220",
+        "surface": "#111c2e",
+        "border": "#1f2a3d",
+        "muted_border": "#334155",
+        "text": "#e2e8f0",
+        "text_muted": "#cbd5f5",
+        "accent": "#60a5fa",
+        "accent_subtle": "rgba(59, 130, 246, 0.2)",
+        "accent_strong": "#93c5fd",
+        "positive": "#34d399",
+        "warning": "#facc15",
+        "critical": "#f87171",
+        "gridline": "rgba(148, 163, 184, 0.4)",
+        "gridline_light": "rgba(71, 85, 105, 0.5)",
+    },
+}
 
 TOKENS: dict[str, Any] = {
     "font": {
@@ -49,31 +85,23 @@ TOKENS: dict[str, Any] = {
         "sm": "0 4px 10px rgba(15, 23, 42, 0.08)",
         "md": "0 12px 40px rgba(15, 23, 42, 0.16)",
     },
-    "palette": {
-        "background": "#ffffff",
-        "surface": "#f8fafc",
-        "border": "#e2e8f0",
-        "muted_border": "#cbd5f5",
-        "text": "#0f172a",
-        "text_muted": "#475569",
-        "accent": "#2563eb",
-        "accent_subtle": "#bfdbfe",
-        "accent_strong": "#1d4ed8",
-        "positive": "#10b981",
-        "warning": "#fbbf24",
-        "critical": "#ef4444",
-        "gridline": "rgba(148, 163, 184, 0.45)",
-        "gridline_light": "rgba(148, 163, 184, 0.2)",
-    },
+    "palette": _PALETTES["light"],
+    "palettes": _PALETTES,
 }
 
 
-@lru_cache(maxsize=1)
-def get_plotly_template() -> go.layout.Template:
+def get_palette(*, dark: bool = False) -> Dict[str, str]:
+    """Return the semantic color palette for the requested theme."""
+
+    return _PALETTES["dark" if dark else "light"]
+
+
+@lru_cache(maxsize=2)
+def get_plotly_template(dark: bool = False) -> go.layout.Template:
     """Return the shared Plotly template used by Carbon ACX charts."""
 
     tokens = TOKENS
-    palette = tokens["palette"]
+    palette = get_palette(dark=dark)
     font_family = tokens["font"]["family"]["sans"]
     font_size = tokens["font"]["sizes"]["md"]
     title_size = tokens["font"]["sizes"]["xl"]
@@ -98,16 +126,33 @@ def get_plotly_template() -> go.layout.Template:
     template.layout.paper_bgcolor = palette["background"]
     template.layout.plot_bgcolor = palette["background"]
     template.layout.margin = dict(l=64, r=32, t=56, b=64)
-    template.layout.colorway = [
-        palette["accent"],
-        palette["positive"],
-        palette["accent_strong"],
-        "#0ea5e9",
-        "#7c3aed",
-        "#059669",
-        "#f97316",
-        "#6366f1",
-    ]
+
+    if dark:
+        colorway = [
+            palette["accent"],
+            palette["positive"],
+            "#f472b6",
+            "#38bdf8",
+            "#a78bfa",
+            "#facc15",
+            "#fb923c",
+            "#4ade80",
+        ]
+        legend_bg = "rgba(17, 28, 46, 0.85)"
+    else:
+        colorway = [
+            palette["accent"],
+            palette["positive"],
+            palette["accent_strong"],
+            "#0ea5e9",
+            "#7c3aed",
+            "#059669",
+            "#f97316",
+            "#6366f1",
+        ]
+        legend_bg = "rgba(255, 255, 255, 0.85)"
+
+    template.layout.colorway = colorway
     template.layout.hoverlabel = dict(
         bgcolor=palette["surface"],
         bordercolor=palette["border"],
@@ -119,10 +164,11 @@ def get_plotly_template() -> go.layout.Template:
         y=1.02,
         xanchor="right",
         x=1.0,
-        bgcolor="rgba(255, 255, 255, 0.8)",
+        bgcolor=legend_bg,
         bordercolor=palette["border"],
         borderwidth=1,
         title=dict(text=""),
+        font=dict(color=palette["text"]),
     )
     template.layout.separators = ", "
 

--- a/tests/ui/test_theme_smoke.py
+++ b/tests/ui/test_theme_smoke.py
@@ -10,18 +10,24 @@ def test_tokens_cover_core_sections() -> None:
         assert section in TOKENS
     assert "sans" in TOKENS["font"]["family"]
     assert "accent" in TOKENS["palette"]
+    assert "dark" in TOKENS["palettes"]
 
 
 def test_plotly_template_smoke() -> None:
-    template = get_plotly_template()
-    assert template.layout.font.family
-    assert template.layout.margin.l >= 0
+    light = get_plotly_template()
+    dark = get_plotly_template(dark=True)
 
-    figure = go.Figure(data=[go.Bar(y=[1, 3, 2])])
-    figure.update_layout(template=template, title="Test Chart")
+    for template in (light, dark):
+        assert template.layout.font.family
+        assert template.layout.margin.l >= 0
 
-    payload = figure.to_plotly_json()
-    layout = payload["layout"]
-    assert layout["template"]["layout"]["font"]["family"]
-    assert layout["title"]["text"] == "Test Chart"
-    assert payload["data"][0]["type"] == "bar"
+        figure = go.Figure(data=[go.Bar(y=[1, 3, 2])])
+        figure.update_layout(template=template, title="Test Chart")
+
+        payload = figure.to_plotly_json()
+        layout = payload["layout"]
+        assert layout["template"]["layout"]["font"]["family"]
+        assert layout["title"]["text"] == "Test Chart"
+        assert payload["data"][0]["type"] == "bar"
+
+    assert light.layout.paper_bgcolor != dark.layout.paper_bgcolor


### PR DESCRIPTION
## Summary
- add light/dark design tokens, data-theme CSS handling, and a header toggle with persisted preference
- sync Dash layout and clientside logic with a new theme store to update chart rendering and Plotly templates
- update Plotly palettes/templates and component renderers for dark mode, plus extend UI theme tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7c06e758832ca0b419505709b438