### PR TITLE
perf(viz): shrink figure JSON and set Cache-Control

### DIFF
--- a/calc/derive.py
+++ b/calc/derive.py
@@ -790,7 +790,8 @@ def export_view(
             meta["layer_references"] = layer_references
         meta["references"] = references
         meta["data"] = data
-        _write_json(figure_dir / f"{name}.json", meta)
+        trimmed_meta = figures.trim_figure_payload(meta)
+        _write_json(figure_dir / f"{name}.json", trimmed_meta)
         _write_reference_file(reference_dir, name, references)
 
     _write_figure("stacked", "figures.stacked", stacked)

--- a/site/_headers
+++ b/site/_headers
@@ -1,0 +1,4 @@
+/figures/*
+  Cache-Control: public, max-age=3600, s-maxage=86400
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -91,7 +91,7 @@ def test_export_metadata_and_references(derived_output_dir, derived_output_root)
     assert export_refs == expected_refs
 
     stacked_payload = json.loads((out_dir / "figures" / "stacked.json").read_text())
-    assert stacked_payload["references"] == expected_refs
+    assert "references" not in stacked_payload
     assert stacked_payload["citation_keys"] == ["coffee", "streaming"]
     assert stacked_payload["profile"] == "p1"
     assert stacked_payload["profile_resolution"] == {
@@ -102,23 +102,23 @@ def test_export_metadata_and_references(derived_output_dir, derived_output_root)
     assert stacked_payload["data"]
     assert all("layer_id" in row for row in stacked_payload["data"])
     assert stacked_payload.get("layer_citation_keys") == {"professional": ["coffee", "streaming"]}
-    assert stacked_payload.get("layer_references") == {"professional": expected_refs}
+    assert "layer_references" not in stacked_payload
 
     bubble_payload = json.loads((out_dir / "figures" / "bubble.json").read_text())
-    assert bubble_payload["references"] == expected_refs
+    assert "references" not in bubble_payload
     assert all("mean" in point["values"] for point in bubble_payload["data"])
     assert all(point.get("layer_id") for point in bubble_payload["data"])
     assert bubble_payload.get("layer_citation_keys") == {"professional": ["coffee", "streaming"]}
-    assert bubble_payload.get("layer_references") == {"professional": expected_refs}
+    assert "layer_references" not in bubble_payload
 
     sankey_payload = json.loads((out_dir / "figures" / "sankey.json").read_text())
-    assert sankey_payload["references"] == expected_refs
+    assert "references" not in sankey_payload
     assert isinstance(sankey_payload["data"], dict)
     assert "nodes" in sankey_payload["data"]
     assert "links" in sankey_payload["data"]
     assert all("layer_id" in link for link in sankey_payload["data"]["links"])
     assert sankey_payload.get("layer_citation_keys") == {"professional": ["coffee", "streaming"]}
-    assert sankey_payload.get("layer_references") == {"professional": expected_refs}
+    assert "layer_references" not in sankey_payload
 
     for name in ("stacked", "bubble", "sankey"):
         txt = (out_dir / "references" / f"{name}_refs.txt").read_text().strip().splitlines()

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -167,7 +167,7 @@ def test_exported_figures_have_consistent_references(derived_artifacts):
             if line.strip()
         ]
 
-        assert payload.get("references") == reference_lines
+        assert "references" not in payload
         for idx, line in enumerate(reference_lines, start=1):
             assert line.startswith(f"[{idx}]")
 

--- a/tests/test_figures_dynamic_citations.py
+++ b/tests/test_figures_dynamic_citations.py
@@ -71,9 +71,8 @@ def test_figures_use_dynamic_citations(derived_output_dir, derived_output_root):
     ).read_text().strip().splitlines() == expected_refs
 
     fig_payload = json.loads((out_dir / "figures" / "stacked.json").read_text())
-    assert fig_payload["references"] == expected_refs
     assert fig_payload["citation_keys"] == expected_keys
     assert fig_payload.get("layer_citation_keys") == {"professional": expected_keys}
-    assert fig_payload.get("layer_references") == {"professional": expected_refs}
-    assert all("coffee" not in ref and "stream" not in ref for ref in fig_payload["references"])
+    assert "references" not in fig_payload
+    assert "layer_references" not in fig_payload
     assert all(row.get("layer_id") == "professional" for row in fig_payload["data"])


### PR DESCRIPTION
## Summary
- add a calc.figures helper to trim redundant metadata before persisting figure JSON and call it from the export pipeline
- refresh figure-related tests to expect leaner payloads while still validating reference exports
- publish Cloudflare Pages cache headers for figure JSON and static assets

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68da8a8a7e38832cbac96d0abd550ada