### PR TITLE
test: add Kaleido visual smoke tests and units guardrails

### DIFF
--- a/calc/figures.py
+++ b/calc/figures.py
@@ -16,6 +16,11 @@ from .schema import LayerId
 CONFIG_PATH = Path(__file__).parent / "config.yaml"
 
 LAYER_ORDER = [layer.value for layer in LayerId]
+ANNUAL_EMISSIONS_UNITS = {
+    "quantity": "annual_emissions",
+    "unit": "g_co2e",
+    "label": "Annual emissions (g CO₂e)",
+}
 DEFAULT_GENERATED_AT = "1970-01-01T00:00:00+00:00"
 GENERATED_AT_ENV = "ACX_GENERATED_AT"
 datetime = _datetime_module.datetime
@@ -186,7 +191,12 @@ def slice_stacked(
             continue
         layer = _normalise_layer(row.get("layer_id"))
         category = row["activity_category"]
-        entry = {"layer_id": layer, "category": category, "values": values}
+        entry = {
+            "layer_id": layer,
+            "category": category,
+            "values": values,
+            "units": dict(ANNUAL_EMISSIONS_UNITS),
+        }
         if reference_map is not None:
             payload = reference_map.get((layer, category))
             if payload:
@@ -206,6 +216,7 @@ class BubblePoint:
     category: str | None
     layer_id: str | None
     values: dict
+    units: dict[str, str]
     citation_keys: list[str] | None = None
     hover_reference_indices: list[int] | None = None
 
@@ -274,6 +285,7 @@ def slice_bubble(
                 category=row["activity_category"],
                 layer_id=layer,
                 values=values,
+                units=dict(ANNUAL_EMISSIONS_UNITS),
                 citation_keys=ref_keys,
                 hover_reference_indices=ref_indices,
             )
@@ -350,6 +362,7 @@ def slice_sankey(
             "category": category_label,
             "layer_id": layer,
             "values": values,
+            "units": dict(ANNUAL_EMISSIONS_UNITS),
         }
         if reference_map is not None:
             payload = reference_map.get((layer, category_label, str(row["activity_id"])))

--- a/poetry.lock
+++ b/poetry.lock
@@ -606,6 +606,22 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "kaleido"
+version = "0.2.1"
+description = "Static image export for web-based visualization libraries with zero dependencies"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "kaleido-0.2.1-py2.py3-none-macosx_10_11_x86_64.whl", hash = "sha256:ca6f73e7ff00aaebf2843f73f1d3bacde1930ef5041093fe76b83a15785049a7"},
+    {file = "kaleido-0.2.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:bb9a5d1f710357d5d432ee240ef6658a6d124c3e610935817b4b42da9c787c05"},
+    {file = "kaleido-0.2.1-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:aa21cf1bf1c78f8fa50a9f7d45e1003c387bd3d6fe0a767cfbbf344b95bdc3a8"},
+    {file = "kaleido-0.2.1-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:845819844c8082c9469d9c17e42621fbf85c2b237ef8a86ec8a8527f98b6512a"},
+    {file = "kaleido-0.2.1-py2.py3-none-win32.whl", hash = "sha256:ecc72635860be616c6b7161807a65c0dbd9b90c6437ac96965831e2e24066552"},
+    {file = "kaleido-0.2.1-py2.py3-none-win_amd64.whl", hash = "sha256:4670985f28913c2d063c5734d125ecc28e40810141bdb0a46f15b76c1d45f23c"},
+]
+
+[[package]]
 name = "license-expression"
 version = "30.4.4"
 description = "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic."
@@ -1034,6 +1050,104 @@ files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
+
+[[package]]
+name = "pillow"
+version = "10.4.0"
+description = "Python Imaging Library (Fork)"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pillow-10.4.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:4d9667937cfa347525b319ae34375c37b9ee6b525440f3ef48542fcf66f2731e"},
+    {file = "pillow-10.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:543f3dc61c18dafb755773efc89aae60d06b6596a63914107f75459cf984164d"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7928ecbf1ece13956b95d9cbcfc77137652b02763ba384d9ab508099a2eca856"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4d49b85c4348ea0b31ea63bc75a9f3857869174e2bf17e7aba02945cd218e6f"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6c762a5b0997f5659a5ef2266abc1d8851ad7749ad9a6a5506eb23d314e4f46b"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a985e028fc183bf12a77a8bbf36318db4238a3ded7fa9df1b9a133f1cb79f8fc"},
+    {file = "pillow-10.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:812f7342b0eee081eaec84d91423d1b4650bb9828eb53d8511bcef8ce5aecf1e"},
+    {file = "pillow-10.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ac1452d2fbe4978c2eec89fb5a23b8387aba707ac72810d9490118817d9c0b46"},
+    {file = "pillow-10.4.0-cp310-cp310-win32.whl", hash = "sha256:bcd5e41a859bf2e84fdc42f4edb7d9aba0a13d29a2abadccafad99de3feff984"},
+    {file = "pillow-10.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:ecd85a8d3e79cd7158dec1c9e5808e821feea088e2f69a974db5edf84dc53141"},
+    {file = "pillow-10.4.0-cp310-cp310-win_arm64.whl", hash = "sha256:ff337c552345e95702c5fde3158acb0625111017d0e5f24bf3acdb9cc16b90d1"},
+    {file = "pillow-10.4.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c"},
+    {file = "pillow-10.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e84b6cc6a4a3d76c153a6b19270b3526a5a8ed6b09501d3af891daa2a9de7d6"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbc527b519bd3aa9d7f429d152fea69f9ad37c95f0b02aebddff592688998abe"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319"},
+    {file = "pillow-10.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:59291fb29317122398786c2d44427bbd1a6d7ff54017075b22be9d21aa59bd8d"},
+    {file = "pillow-10.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:416d3a5d0e8cfe4f27f574362435bc9bae57f679a7158e0096ad2beb427b8696"},
+    {file = "pillow-10.4.0-cp311-cp311-win32.whl", hash = "sha256:7086cc1d5eebb91ad24ded9f58bec6c688e9f0ed7eb3dbbf1e4800280a896496"},
+    {file = "pillow-10.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cbed61494057c0f83b83eb3a310f0bf774b09513307c434d4366ed64f4128a91"},
+    {file = "pillow-10.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:f5f0c3e969c8f12dd2bb7e0b15d5c468b51e5017e01e2e867335c81903046a22"},
+    {file = "pillow-10.4.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94"},
+    {file = "pillow-10.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a"},
+    {file = "pillow-10.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:780c072c2e11c9b2c7ca37f9a2ee8ba66f44367ac3e5c7832afcfe5104fd6d1b"},
+    {file = "pillow-10.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37fb69d905be665f68f28a8bba3c6d3223c8efe1edf14cc4cfa06c241f8c81d9"},
+    {file = "pillow-10.4.0-cp312-cp312-win32.whl", hash = "sha256:7dfecdbad5c301d7b5bde160150b4db4c659cee2b69589705b6f8a0c509d9f42"},
+    {file = "pillow-10.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a"},
+    {file = "pillow-10.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:e553cad5179a66ba15bb18b353a19020e73a7921296a7979c4a2b7f6a5cd57f9"},
+    {file = "pillow-10.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8bc1a764ed8c957a2e9cacf97c8b2b053b70307cf2996aafd70e91a082e70df3"},
+    {file = "pillow-10.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6209bb41dc692ddfee4942517c19ee81b86c864b626dbfca272ec0f7cff5d9fb"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bee197b30783295d2eb680b311af15a20a8b24024a19c3a26431ff83eb8d1f70"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ef61f5dd14c300786318482456481463b9d6b91ebe5ef12f405afbba77ed0be"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:297e388da6e248c98bc4a02e018966af0c5f92dfacf5a5ca22fa01cb3179bca0"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e4db64794ccdf6cb83a59d73405f63adbe2a1887012e308828596100a0b2f6cc"},
+    {file = "pillow-10.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd2880a07482090a3bcb01f4265f1936a903d70bc740bfcb1fd4e8a2ffe5cf5a"},
+    {file = "pillow-10.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b35b21b819ac1dbd1233317adeecd63495f6babf21b7b2512d244ff6c6ce309"},
+    {file = "pillow-10.4.0-cp313-cp313-win32.whl", hash = "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060"},
+    {file = "pillow-10.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea"},
+    {file = "pillow-10.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d"},
+    {file = "pillow-10.4.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:8d4d5063501b6dd4024b8ac2f04962d661222d120381272deea52e3fc52d3736"},
+    {file = "pillow-10.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7c1ee6f42250df403c5f103cbd2768a28fe1a0ea1f0f03fe151c8741e1469c8b"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b15e02e9bb4c21e39876698abf233c8c579127986f8207200bc8a8f6bb27acf2"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a8d4bade9952ea9a77d0c3e49cbd8b2890a399422258a77f357b9cc9be8d680"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:43efea75eb06b95d1631cb784aa40156177bf9dd5b4b03ff38979e048258bc6b"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:950be4d8ba92aca4b2bb0741285a46bfae3ca699ef913ec8416c1b78eadd64cd"},
+    {file = "pillow-10.4.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d7480af14364494365e89d6fddc510a13e5a2c3584cb19ef65415ca57252fb84"},
+    {file = "pillow-10.4.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:73664fe514b34c8f02452ffb73b7a92c6774e39a647087f83d67f010eb9a0cf0"},
+    {file = "pillow-10.4.0-cp38-cp38-win32.whl", hash = "sha256:e88d5e6ad0d026fba7bdab8c3f225a69f063f116462c49892b0149e21b6c0a0e"},
+    {file = "pillow-10.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:5161eef006d335e46895297f642341111945e2c1c899eb406882a6c61a4357ab"},
+    {file = "pillow-10.4.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:0ae24a547e8b711ccaaf99c9ae3cd975470e1a30caa80a6aaee9a2f19c05701d"},
+    {file = "pillow-10.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:298478fe4f77a4408895605f3482b6cc6222c018b2ce565c2b6b9c354ac3229b"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:134ace6dc392116566980ee7436477d844520a26a4b1bd4053f6f47d096997fd"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:930044bb7679ab003b14023138b50181899da3f25de50e9dbee23b61b4de2126"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:c76e5786951e72ed3686e122d14c5d7012f16c8303a674d18cdcd6d89557fc5b"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:b2724fdb354a868ddf9a880cb84d102da914e99119211ef7ecbdc613b8c96b3c"},
+    {file = "pillow-10.4.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dbc6ae66518ab3c5847659e9988c3b60dc94ffb48ef9168656e0019a93dbf8a1"},
+    {file = "pillow-10.4.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:06b2f7898047ae93fad74467ec3d28fe84f7831370e3c258afa533f81ef7f3df"},
+    {file = "pillow-10.4.0-cp39-cp39-win32.whl", hash = "sha256:7970285ab628a3779aecc35823296a7869f889b8329c16ad5a71e4901a3dc4ef"},
+    {file = "pillow-10.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:961a7293b2457b405967af9c77dcaa43cc1a8cd50d23c532e62d48ab6cdd56f5"},
+    {file = "pillow-10.4.0-cp39-cp39-win_arm64.whl", hash = "sha256:32cda9e3d601a52baccb2856b8ea1fc213c90b340c542dcef77140dfa3278a9e"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5b4815f2e65b30f5fbae9dfffa8636d992d49705723fe86a3661806e069352d4"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:8f0aef4ef59694b12cadee839e2ba6afeab89c0f39a3adc02ed51d109117b8da"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f4727572e2918acaa9077c919cbbeb73bd2b3ebcfe033b72f858fc9fbef0026"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff25afb18123cea58a591ea0244b92eb1e61a1fd497bf6d6384f09bc3262ec3e"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dc3e2db6ba09ffd7d02ae9141cfa0ae23393ee7687248d46a7507b75d610f4f5"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:02a2be69f9c9b8c1e97cf2713e789d4e398c751ecfd9967c18d0ce304efbf885"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:0755ffd4a0c6f267cccbae2e9903d95477ca2f77c4fcf3a3a09570001856c8a5"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a02364621fe369e06200d4a16558e056fe2805d3468350df3aef21e00d26214b"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:1b5dea9831a90e9d0721ec417a80d4cbd7022093ac38a568db2dd78363b00908"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b885f89040bb8c4a1573566bbb2f44f5c505ef6e74cec7ab9068c900047f04b"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87dd88ded2e6d74d31e1e0a99a726a6765cda32d00ba72dc37f0651f306daaa8"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:2db98790afc70118bd0255c2eeb465e9767ecf1f3c25f9a1abb8ffc8cfd1fe0a"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f7baece4ce06bade126fb84b8af1c33439a76d8a6fd818970215e0560ca28c27"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cfdd747216947628af7b259d274771d84db2268ca062dd5faf373639d00113a3"},
+    {file = "pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=7.3)", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
+typing = ["typing-extensions ; python_version < \"3.10\""]
+xmp = ["defusedxml"]
 
 [[package]]
 name = "pip"
@@ -1724,4 +1838,4 @@ db = ["duckdb"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4"
-content-hash = "dafbcfe4f9009b163f0046e00efc663d3aa9775e593dccb41f63341cee914db9"
+content-hash = "a699e1f4cdcceb0d71a09dc797337f8d06a8022a2c4116604a910decb1ccc17f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ pytest-cov = ">=4.1,<5"
 ruff = ">=0.3,<0.5"
 black = ">=24.3,<25"
 pip-audit = ">=2.7,<3"
+kaleido = "0.2.1"
+Pillow = ">=10,<11"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/visual/test_visual_smoke.py
+++ b/tests/visual/test_visual_smoke.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import io
+from dataclasses import asdict
+from pathlib import Path
+
+import pandas as pd
+import plotly.io as pio
+import pytest
+from PIL import Image
+
+from app.components import bubble as bubble_component
+from app.components import sankey as sankey_component
+from app.components import stacked as stacked_component
+from calc import figures
+
+_CANONICAL_ROWS = [
+    {
+        "activity_id": "coffee_hot",
+        "activity_name": "Coffee – hot cup",
+        "activity_category": "Food",
+        "layer_id": "professional",
+        "annual_emissions_g": 1240.0,
+        "annual_emissions_g_low": 980.0,
+        "annual_emissions_g_high": 1500.0,
+    },
+    {
+        "activity_id": "commute_bus",
+        "activity_name": "Commute by bus",
+        "activity_category": "Travel",
+        "layer_id": "professional",
+        "annual_emissions_g": 860.0,
+        "annual_emissions_g_low": 740.0,
+        "annual_emissions_g_high": 980.0,
+    },
+    {
+        "activity_id": "stream_tv",
+        "activity_name": "Stream HD TV",
+        "activity_category": "Media",
+        "layer_id": "online",
+        "annual_emissions_g": 1815.0,
+        "annual_emissions_g_low": 1650.0,
+        "annual_emissions_g_high": 2050.0,
+    },
+]
+
+_CITATION_KEYS = ["SRC.COFFEE", "SRC.BUS", "SRC.STREAM"]
+_HASH_SIZE = 8
+_HASH_TOLERANCE = 6
+_EXPECTED_HASHES = {
+    "stacked": 0xFF07878F8F8101FF,
+    "bubble": 0xFFFC3E3F677FFFE6,
+    "sankey": 0xFF80BD80BD8080FF,
+}
+
+
+def _reference_lookup() -> dict[str, int]:
+    return {key: idx for idx, key in enumerate(_CITATION_KEYS, start=1)}
+
+
+def _stacked_reference_map() -> dict[tuple[str | None, str], tuple[list[str], list[int]]]:
+    return {
+        ("professional", "Food"): (["SRC.COFFEE"], [1]),
+        ("professional", "Travel"): (["SRC.BUS"], [2]),
+        ("online", "Media"): (["SRC.STREAM"], [3]),
+    }
+
+
+def _bubble_reference_map() -> dict[tuple[str | None, str], tuple[list[str], list[int]]]:
+    return {
+        ("professional", "coffee_hot"): (["SRC.COFFEE"], [1]),
+        ("professional", "commute_bus"): (["SRC.BUS"], [2]),
+        ("online", "stream_tv"): (["SRC.STREAM"], [3]),
+    }
+
+
+def _sankey_reference_map() -> dict[tuple[str | None, str, str], tuple[list[str], list[int]]]:
+    return {
+        ("professional", "Food", "coffee_hot"): (["SRC.COFFEE"], [1]),
+        ("professional", "Travel", "commute_bus"): (["SRC.BUS"], [2]),
+        ("online", "Media", "stream_tv"): (["SRC.STREAM"], [3]),
+    }
+
+
+def _perceptual_hash(image_bytes: bytes, size: int = _HASH_SIZE) -> int:
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        if hasattr(Image, "Resampling"):
+            resample = Image.Resampling.LANCZOS
+        else:  # pragma: no cover - Pillow < 9 compatibility
+            resample = Image.LANCZOS
+        resized = img.convert("L").resize((size, size), resample)
+        pixels = list(resized.getdata())
+    avg = sum(pixels) / len(pixels)
+    digest = 0
+    for value in pixels:
+        digest = (digest << 1) | int(value >= avg)
+    return digest
+
+
+def _hamming_distance(lhs: int, rhs: int) -> int:
+    return (lhs ^ rhs).bit_count()
+
+
+def _render_and_hash(name: str, figure, out_dir: Path) -> tuple[Path, int]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    image_bytes = pio.to_image(
+        figure, format="png", engine="kaleido", width=960, height=540, scale=1
+    )
+    output_path = out_dir / f"{name}.png"
+    output_path.write_bytes(image_bytes)
+    return output_path, _perceptual_hash(image_bytes)
+
+
+@pytest.mark.parametrize(
+    "name, builder",
+    [
+        ("stacked", stacked_component._build_figure),
+        ("bubble", bubble_component._build_figure),
+        ("sankey", sankey_component._build_figure),
+    ],
+)
+def test_canonical_figures_render_within_hash_bounds(name: str, builder, tmp_path: Path) -> None:
+    df = pd.DataFrame(_CANONICAL_ROWS)
+    reference_lookup = _reference_lookup()
+
+    stacked_payload = {"data": figures.slice_stacked(df, reference_map=_stacked_reference_map())}
+    bubble_payload = {
+        "data": [
+            asdict(point)
+            for point in figures.slice_bubble(df, reference_map=_bubble_reference_map())
+        ]
+    }
+    sankey_payload = {"data": figures.slice_sankey(df, reference_map=_sankey_reference_map())}
+
+    payloads = {
+        "stacked": stacked_payload,
+        "bubble": bubble_payload,
+        "sankey": sankey_payload,
+    }
+
+    figure = builder(payloads[name], reference_lookup)
+    output_dir = tmp_path / "visual"
+    path, digest = _render_and_hash(name, figure, output_dir)
+
+    assert path.exists()
+    expected = _EXPECTED_HASHES[name]
+    if expected == 0:
+        pytest.fail(
+            "Expected hash placeholder not updated. Capture the test output and set _EXPECTED_HASHES accordingly."
+        )
+    distance = _hamming_distance(digest, expected)
+    assert (
+        distance <= _HASH_TOLERANCE
+    ), f"{name} visual hash deviated by {distance} bits (tolerance {_HASH_TOLERANCE})"


### PR DESCRIPTION
## Summary
- attach annual emissions units metadata to stacked, bubble, and sankey payloads and surface it through existing slices
- extend figure integrity tests to require units metadata and verify hover reference indices against generated references
- add Kaleido-based visual smoke tests with pinned kaleido/pillow dependencies to catch visual regressions via perceptual hashes

## Testing
- pytest tests/test_figures.py -q
- pytest tests/visual/test_visual_smoke.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dab2fb79d0832c8a6644be4fef0898