### PR TITLE
deploy(build): emit static site bundle for Pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PACKAGED_ARTIFACTS_DIR := $(DIST_DIR)/packaged-artifacts
 PACKAGED_MANIFEST := $(PACKAGED_ARTIFACTS_DIR)/manifest.json
 DEFAULT_GENERATED_AT ?= 1970-01-01T00:00:00+00:00
 
-.PHONY: install lint test ci_build_pages app format validate release build-backend build site package sbom
+.PHONY: install lint test ci_build_pages app format validate release build-backend build site package sbom build-static
 
 install:
 	poetry install --with dev --no-root
@@ -43,7 +43,10 @@ $(DIST_SITE_DIR)/index.html: $(LATEST_BUILD)
 
 package: $(PACKAGED_MANIFEST) $(DIST_SITE_DIR)/index.html sbom
 
-ci_build_pages: install lint test package
+ci_build_pages: install lint test build-static
+
+build-static: $(DIST_SITE_DIR)/index.html
+	@echo "Static site available at $(DIST_SITE_DIR)"
 
 app:
 	ACX_DATA_BACKEND=$(ACX_DATA_BACKEND) PYTHONPATH=. poetry run python -m app.app

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,35 @@
+# Deploying to Cloudflare Pages
+
+The Carbon ACX static client is designed to run on Cloudflare Pages and to be
+served from the `/carbon-acx` path by the main Carbonplan site.
+
+## Build the static site
+
+1. Install dependencies if you have not already done so:
+   ```bash
+   make install
+   ```
+2. Produce fresh derived data artifacts and the static site bundle:
+   ```bash
+   make build-static
+   ```
+
+This command runs the standard data build and emits the static site to
+`dist/site/`. The directory contains:
+
+- `index.html` – the single-page application shell.
+- `200.html` – a copy of `index.html` used by Cloudflare Pages for SPA
+  fallback routing.
+- asset files (CSS, fonts, JavaScript) required by the client.
+- a `data/` folder that mirrors the contents of `dist/artifacts/`, allowing the
+  client to serve JSON/CSV artifacts relative to the deployed path.
+
+All asset links are written as relative paths, so the bundle can be mounted at
+`/carbon-acx` without additional rewrites.
+
+## Deploy
+
+Upload the contents of `dist/site/` to a Cloudflare Pages project. The main
+Carbonplan site proxies requests under `/carbon-acx/*` to this bundle, so the
+relative asset paths must remain intact. If you add new artifact files to the
+build, confirm that they appear under `dist/site/data/` before deploying.

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -88,6 +88,14 @@ def _copy_assets(destination: Path) -> None:
                 shutil.copy2(asset, js_target / asset.name)
 
 
+def _copy_data_artifacts(artifact_dir: Path, destination: Path) -> None:
+    if not artifact_dir.exists():
+        return
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(artifact_dir, destination)
+
+
 def _format_manifest_summary(manifest: Mapping | None) -> str:
     if not manifest:
         return ""
@@ -171,6 +179,7 @@ def build_site(artifact_dir: Path, output_dir: Path) -> Path:
 
     output_dir.mkdir(parents=True, exist_ok=True)
     _copy_assets(output_dir)
+    _copy_data_artifacts(artifact_dir, output_dir / "data")
 
     figures: dict[str, Mapping | None] = {}
     for name in FIGURE_BUILDERS:
@@ -277,6 +286,7 @@ def build_site(artifact_dir: Path, output_dir: Path) -> Path:
         "<head>"
         '<meta charset="utf-8" />'
         '<meta name="viewport" content="width=device-width, initial-scale=1" />'
+        '<base href="./" />'
         "<title>Carbon ACX emissions overview</title>"
         '<link rel="stylesheet" href="fonts.css" />'
         '<link rel="stylesheet" href="styles.css" />'
@@ -301,6 +311,9 @@ def build_site(artifact_dir: Path, output_dir: Path) -> Path:
 
     index_path = output_dir / "index.html"
     index_path.write_text(html, encoding="utf-8")
+
+    fallback_path = output_dir / "200.html"
+    fallback_path.write_text(html, encoding="utf-8")
 
     return index_path
 


### PR DESCRIPTION
## Summary
- add a dedicated `make build-static` target for producing the Cloudflare Pages bundle
- update the site builder to copy data artifacts, emit a SPA fallback, and use relative asset paths
- document the Pages deployment process and artifact layout

## Testing
- make build-static

------
https://chatgpt.com/codex/tasks/task_e_68dabbc8c768832ca2bac356e344d0aa