### PR TITLE
Proxy Carbon ACX through Pages Function

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -1,0 +1,27 @@
+# Route integrations
+
+## `/carbon-acx/*`
+
+Requests under `/carbon-acx` are proxied to the Carbon ACX Cloudflare Pages deployment.
+The function rewrites the subpath while preserving any query parameters and forwards the
+request to the upstream specified by the `CARBON_ACX_PAGES_HOST` environment variable.
+
+### Caching
+
+* Fingerprinted assets (e.g. `main.abcdef12.js`) are served with `Cache-Control: public, max-age=31536000, immutable`.
+* Other responses, including HTML shell documents, use `Cache-Control: public, max-age=86400`.
+* The upstream fetch uses Cloudflare cache settings with a one-day TTL for successful responses,
+  a one-minute TTL for 404s, and no caching for 5xx.
+
+### Deep linking and SPA behaviour
+
+Deep links such as `/carbon-acx/demo` and `/carbon-acx/view?id=abc` are forwarded without
+modification. The Carbon ACX static project serves its SPA fallback (200.html) directly,
+so pages are resolved by the upstream application without additional routing logic in this
+project.
+
+### Data fetches
+
+Requests for JSON or CSV assets include `Access-Control-Allow-Origin: https://boot.industries`
+and `Vary: Origin`, allowing Carbon ACX pages to make same-origin XHR/fetch requests when
+served under `/carbon-acx` on boot.industries.

--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -1,0 +1,37 @@
+export const onRequestGet: PagesFunction = async (ctx) => {
+  const upstream = ctx.env.CARBON_ACX_PAGES_HOST; // e.g., https://carbon-acx-pages.pages.dev
+  if (!upstream) return new Response("Missing CARBON_ACX_PAGES_HOST", { status: 500 });
+
+  const reqUrl = new URL(ctx.request.url);
+  const subpath = reqUrl.pathname.replace(/^\/carbon-acx/, "") || "/";
+  const target = new URL(subpath + reqUrl.search, upstream);
+
+  const res = await fetch(target.toString(), {
+    headers: {
+      "accept": ctx.request.headers.get("accept") || "*/*",
+      "user-agent": ctx.request.headers.get("user-agent") || "",
+      "cf-connecting-ip": ctx.request.headers.get("cf-connecting-ip") || "",
+    },
+    cf: {
+      cacheEverything: false,
+      cacheTtlByStatus: { "200-299": 86400, "404": 60, "500-599": 0 },
+    },
+  });
+
+  const path = target.pathname || "";
+  const isHashed = /\.[a-f0-9]{8,}\.(js|css|json|csv|png|jpg|svg|woff2?)$/i.test(path);
+
+  const headers = new Headers(res.headers);
+  headers.set("X-Carbon-ACX-Proxy", "pages-function");
+  if (isHashed) {
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+  } else {
+    headers.set("Cache-Control", "public, max-age=86400");
+  }
+  if (/\.(json|csv)$/i.test(path)) {
+    headers.set("Access-Control-Allow-Origin", "https://boot.industries");
+    headers.set("Vary", "Origin");
+  }
+
+  return new Response(res.body, { status: res.status, headers });
+};


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages Function that proxies /carbon-acx requests to the Carbon ACX Pages deployment with cache-aware headers and CORS for data assets
- document the new route, caching behaviour, and SPA deep-link handling in docs/routes.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dabe21761c832ca9842c91eb153de5