### PR TITLE
Improve Carbon ACX proxy forwarding

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -1,0 +1,28 @@
+# Route integrations
+
+## `/carbon-acx/*`
+
+Requests under `/carbon-acx` are proxied to the Carbon ACX Cloudflare Pages deployment.
+The function rewrites the subpath while preserving any query parameters and forwards the
+incoming GET/HEAD request (including headers needed for conditional requests) to the
+upstream specified by the `CARBON_ACX_PAGES_HOST` environment variable.
+
+### Caching
+
+* Fingerprinted assets (e.g. `main.abcdef12.js`) are served with `Cache-Control: public, max-age=31536000, immutable`.
+* Other responses, including HTML shell documents, use `Cache-Control: public, max-age=86400`.
+* The upstream fetch uses Cloudflare cache settings with a one-day TTL for successful responses,
+  a one-minute TTL for 404s, and no caching for 5xx.
+
+### Deep linking and SPA behaviour
+
+Deep links such as `/carbon-acx/demo` and `/carbon-acx/view?id=abc` are forwarded without
+modification. The Carbon ACX static project serves its SPA fallback (200.html) directly,
+so pages are resolved by the upstream application without additional routing logic in this
+project.
+
+### Data fetches
+
+Requests for JSON or CSV assets include `Access-Control-Allow-Origin: https://boot.industries`
+and ensure any existing `Vary` header also covers `Origin`, allowing Carbon ACX pages to make
+same-origin XHR/fetch requests when served under `/carbon-acx` on boot.industries.

--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -1,0 +1,92 @@
+type Env = {
+  CARBON_ACX_PAGES_HOST: string;
+};
+
+const HASHED_ASSET_PATTERN = /\.[a-f0-9]{8,}\.(js|css|json|csv|png|jpg|svg|woff2?)$/i;
+const DATA_EXTENSION_PATTERN = /\.(json|csv)$/i;
+const CACHE_TTL_BY_STATUS: Record<string, number> = {
+  "200-299": 86400,
+  "404": 60,
+  "500-599": 0,
+};
+
+const ensureVaryIncludes = (headers: Headers, value: string) => {
+  const existing = headers.get("Vary");
+  if (!existing) {
+    headers.set("Vary", value);
+    return;
+  }
+  const parts = existing
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (!parts.some((part) => part.toLowerCase() === value.toLowerCase())) {
+    parts.push(value);
+    headers.set("Vary", parts.join(", "));
+  }
+};
+
+export const onRequest: PagesFunction<Env> = async (ctx) => {
+  const { request, env } = ctx;
+  const upstream = env.CARBON_ACX_PAGES_HOST; // e.g., https://carbon-acx-pages.pages.dev
+  if (!upstream) {
+    return new Response("Missing CARBON_ACX_PAGES_HOST", { status: 500 });
+  }
+
+  const method = request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD" },
+    });
+  }
+
+  const reqUrl = new URL(request.url);
+  const subpath = reqUrl.pathname.replace(/^\/carbon-acx/, "") || "/";
+  const target = new URL(subpath + reqUrl.search, upstream);
+
+  const forwardedHeaders = new Headers(request.headers);
+  forwardedHeaders.delete("host");
+  if (!forwardedHeaders.has("accept")) {
+    forwardedHeaders.set("accept", "*/*");
+  }
+  forwardedHeaders.set("x-forwarded-host", reqUrl.host);
+  forwardedHeaders.set("x-forwarded-proto", reqUrl.protocol.replace(/:$/, ""));
+  const connectingIp = request.headers.get("cf-connecting-ip");
+  if (connectingIp) {
+    forwardedHeaders.set("x-forwarded-for", connectingIp);
+  }
+
+  const upstreamRequest = new Request(target.toString(), {
+    method,
+    headers: forwardedHeaders,
+  });
+
+  const res = await fetch(upstreamRequest, {
+    cf: {
+      cacheEverything: false,
+      cacheTtlByStatus: CACHE_TTL_BY_STATUS,
+    },
+  });
+
+  const path = target.pathname || "";
+  const isHashed = HASHED_ASSET_PATTERN.test(path);
+
+  const headers = new Headers(res.headers);
+  headers.set("X-Carbon-ACX-Proxy", "pages-function");
+  if (isHashed) {
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+  } else {
+    headers.set("Cache-Control", "public, max-age=86400");
+  }
+  if (DATA_EXTENSION_PATTERN.test(path)) {
+    headers.set("Access-Control-Allow-Origin", "https://boot.industries");
+    ensureVaryIncludes(headers, "Origin");
+  }
+
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = ""
 readme = "README.md"
 authors = ["Boot Industries <info@boot.industries>"]
+packages = [
+  { include = "calc" }
+]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<4"


### PR DESCRIPTION
## Summary
- forward GET/HEAD requests to the upstream Carbon ACX deployment while cloning request headers for conditional fetches
- add proxy context headers and ensure response metadata (status text, vary) is preserved alongside cache policy overrides
- update routing docs to reflect the header forwarding behaviour and Origin vary handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dabe21761c832ca9842c91eb153de5