### PR TITLE
feat(cf): add Pages Function for /carbon-acx* + static fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,13 @@ quality expectations, and data ingestion guidance.
 ## License
 
 Licensed under the terms of the [MIT License](LICENSE).
+
+## Cloudflare Pages route for /carbon-acx
+This repo ships a Pages Function at `functions/carbon-acx/[[path]].ts`:
+
+- If `CARBON_ACX_ORIGIN` is set (e.g., `https://carbon-acx.pages.dev`), requests to `/carbon-acx*` are proxied there (path + query preserved).
+- If not set, Pages serves static fallback from `site/carbon-acx/`.
+
+Configure in Cloudflare Pages:
+1. Build output directory: `site`
+2. Environment variable: `CARBON_ACX_ORIGIN` (optional). Leave unset to show the placeholder.

--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -1,92 +1,28 @@
-type Env = {
-  CARBON_ACX_PAGES_HOST: string;
-};
-
-const HASHED_ASSET_PATTERN = /\.[a-f0-9]{8,}\.(js|css|json|csv|png|jpg|svg|woff2?)$/i;
-const DATA_EXTENSION_PATTERN = /\.(json|csv)$/i;
-const CACHE_TTL_BY_STATUS: Record<string, number> = {
-  "200-299": 86400,
-  "404": 60,
-  "500-599": 0,
-};
-
-const ensureVaryIncludes = (headers: Headers, value: string) => {
-  const existing = headers.get("Vary");
-  if (!existing) {
-    headers.set("Vary", value);
-    return;
-  }
-  const parts = existing
-    .split(",")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  if (!parts.some((part) => part.toLowerCase() === value.toLowerCase())) {
-    parts.push(value);
-    headers.set("Vary", parts.join(", "));
-  }
-};
-
-export const onRequest: PagesFunction<Env> = async (ctx) => {
-  const { request, env } = ctx;
-  const upstream = env.CARBON_ACX_PAGES_HOST; // e.g., https://carbon-acx-pages.pages.dev
-  if (!upstream) {
-    return new Response("Missing CARBON_ACX_PAGES_HOST", { status: 500 });
-  }
-
-  const method = request.method.toUpperCase();
-  if (method !== "GET" && method !== "HEAD") {
-    return new Response("Method Not Allowed", {
-      status: 405,
-      headers: { Allow: "GET, HEAD" },
-    });
-  }
-
+export const onRequest: PagesFunction<{
+  CARBON_ACX_ORIGIN: string | undefined;
+}> = async (ctx) => {
+  const { request, env, next } = ctx;
   const reqUrl = new URL(request.url);
-  const subpath = reqUrl.pathname.replace(/^\/carbon-acx/, "") || "/";
-  const target = new URL(subpath + reqUrl.search, upstream);
 
-  const forwardedHeaders = new Headers(request.headers);
-  forwardedHeaders.delete("host");
-  if (!forwardedHeaders.has("accept")) {
-    forwardedHeaders.set("accept", "*/*");
-  }
-  forwardedHeaders.set("x-forwarded-host", reqUrl.host);
-  forwardedHeaders.set("x-forwarded-proto", reqUrl.protocol.replace(/:$/, ""));
-  const connectingIp = request.headers.get("cf-connecting-ip");
-  if (connectingIp) {
-    forwardedHeaders.set("x-forwarded-for", connectingIp);
-  }
+  const suffix = reqUrl.pathname.replace(/^\/carbon-acx/, "") + (reqUrl.search || "");
 
-  const upstreamRequest = new Request(target.toString(), {
-    method,
-    headers: forwardedHeaders,
-  });
+  const origin = (env.CARBON_ACX_ORIGIN || "").replace(/\/$/, "");
 
-  const res = await fetch(upstreamRequest, {
-    cf: {
-      cacheEverything: false,
-      cacheTtlByStatus: CACHE_TTL_BY_STATUS,
-    },
-  });
-
-  const path = target.pathname || "";
-  const isHashed = HASHED_ASSET_PATTERN.test(path);
-
-  const headers = new Headers(res.headers);
-  headers.set("X-Carbon-ACX-Proxy", "pages-function");
-  if (isHashed) {
-    headers.set("Cache-Control", "public, max-age=31536000, immutable");
-  } else {
-    headers.set("Cache-Control", "public, max-age=86400");
-  }
-  if (DATA_EXTENSION_PATTERN.test(path)) {
-    headers.set("Access-Control-Allow-Origin", "https://boot.industries");
-    ensureVaryIncludes(headers, "Origin");
+  if (origin) {
+    const target = origin + (suffix || "/");
+    const init: RequestInit = {
+      method: request.method,
+      headers: request.headers,
+      body: request.body,
+    };
+    const resp = await fetch(new Request(target, init));
+    const out = new Response(resp.body, resp);
+    out.headers.set(
+      "Cache-Control",
+      out.headers.get("Cache-Control") || "public, max-age=86400, s-maxage=86400",
+    );
+    return out;
   }
 
-  return new Response(res.body, {
-    status: res.status,
-    statusText: res.statusText,
-    headers,
-  });
+  return next();
 };

--- a/site/carbon-acx/index.html
+++ b/site/carbon-acx/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Carbon ACX</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 2rem; }
+    .wrap { max-width: 720px; margin: 0 auto; }
+    code { background: #f4f4f5; padding: 0.2rem 0.4rem; border-radius: 4px; }
+  </style>
+  <body>
+    <div class="wrap">
+      <h1>Carbon ACX</h1>
+      <p>Route <code>/carbon-acx</code> is configured.</p>
+      <p>If you expected the live app, set <code>CARBON_ACX_ORIGIN</code> in Cloudflare Pages to the upstream host.<br/>
+      Path and query are proxied transparently.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- simplify the `/carbon-acx` Pages Function to proxy to an optional `CARBON_ACX_ORIGIN`
- add a static placeholder page served when no upstream origin is configured
- document the Cloudflare Pages configuration for the new route

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac51f8af4832cb0c78722a25ca41f