### PR TITLE
feat(ui): interactive profile builder controls → live recompute

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -3,53 +3,56 @@ import { useState } from 'react';
 import { ProfileControls } from './components/ProfileControls';
 import { ReferencesDrawer } from './components/ReferencesDrawer';
 import { VizCanvas } from './components/VizCanvas';
+import { ProfileProvider } from './state/profile';
 
 export default function App(): JSX.Element {
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <a
-        href="#main"
-        className="absolute left-4 top-4 z-50 -translate-y-20 rounded-lg bg-sky-500 px-3 py-2 font-semibold text-slate-900 transition focus:translate-y-0 focus:outline-none"
-      >
-        Skip to main content
-      </a>
-      <header className="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
-          <div>
-            <p className="text-xs uppercase tracking-[0.3em] text-sky-400">Carbon</p>
-            <h1 className="text-xl font-semibold">Analysis Console</h1>
+    <ProfileProvider>
+      <div className="min-h-screen bg-slate-950 text-slate-100">
+        <a
+          href="#main"
+          className="absolute left-4 top-4 z-50 -translate-y-20 rounded-lg bg-sky-500 px-3 py-2 font-semibold text-slate-900 transition focus:translate-y-0 focus:outline-none"
+        >
+          Skip to main content
+        </a>
+        <header className="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+          <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-sky-400">Carbon</p>
+              <h1 className="text-xl font-semibold">Analysis Console</h1>
+            </div>
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-sm font-medium text-slate-100 shadow-sm transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:hidden"
+              aria-expanded={isDrawerOpen}
+              aria-controls="references-panel"
+              onClick={() => setIsDrawerOpen((open) => !open)}
+              onKeyDown={(event) => {
+                if (event.key.toLowerCase() === 'r') {
+                  event.preventDefault();
+                  setIsDrawerOpen((open) => !open);
+                }
+              }}
+            >
+              <span className="h-2 w-2 rounded-full bg-sky-400" aria-hidden="true" />
+              References
+            </button>
           </div>
-          <button
-            type="button"
-            className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-sm font-medium text-slate-100 shadow-sm transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:hidden"
-            aria-expanded={isDrawerOpen}
-            aria-controls="references-panel"
-            onClick={() => setIsDrawerOpen((open) => !open)}
-            onKeyDown={(event) => {
-              if (event.key.toLowerCase() === 'r') {
-                event.preventDefault();
-                setIsDrawerOpen((open) => !open);
-              }
-            }}
-          >
-            <span className="h-2 w-2 rounded-full bg-sky-400" aria-hidden="true" />
-            References
-          </button>
-        </div>
-      </header>
-      <main id="main" className="mx-auto flex max-w-7xl flex-1 flex-col gap-6 px-4 py-6 lg:py-10">
-        <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(260px,0.85fr)_minmax(0,2.2fr)_minmax(260px,1fr)]">
-          <ProfileControls />
-          <VizCanvas />
-          <ReferencesDrawer
-            id="references-panel"
-            open={isDrawerOpen}
-            onToggle={() => setIsDrawerOpen((open) => !open)}
-          />
-        </div>
-      </main>
-    </div>
+        </header>
+        <main id="main" className="mx-auto flex max-w-7xl flex-1 flex-col gap-6 px-4 py-6 lg:py-10">
+          <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(260px,0.85fr)_minmax(0,2.2fr)_minmax(260px,1fr)]">
+            <ProfileControls />
+            <VizCanvas />
+            <ReferencesDrawer
+              id="references-panel"
+              open={isDrawerOpen}
+              onToggle={() => setIsDrawerOpen((open) => !open)}
+            />
+          </div>
+        </main>
+      </div>
+    </ProfileProvider>
   );
 }

--- a/site/src/components/ProfileControls.tsx
+++ b/site/src/components/ProfileControls.tsx
@@ -1,4 +1,68 @@
+import { Fragment, useMemo } from 'react';
+
+import { DietOption, ModeSplit, useProfile } from '../state/profile';
+
+const MODE_METADATA: Record<keyof ModeSplit, { label: string; description: string; color: string }> = {
+  car: {
+    label: 'Car',
+    description: 'Single-occupancy or carpool commute days',
+    color: 'bg-sky-500'
+  },
+  transit: {
+    label: 'Transit',
+    description: 'Bus, rail, or micro-transit commute days',
+    color: 'bg-emerald-400'
+  },
+  bike: {
+    label: 'Active',
+    description: 'Bike and other active commute days',
+    color: 'bg-amber-400'
+  }
+};
+
+const DIET_COPY: Record<DietOption, { label: string; helper: string }> = {
+  omnivore: {
+    label: 'Omnivore',
+    helper: 'Mixed animal and plant-based diet'
+  },
+  vegetarian: {
+    label: 'Vegetarian',
+    helper: 'No meat; includes eggs and dairy'
+  },
+  vegan: {
+    label: 'Vegan',
+    helper: 'Fully plant-based meals'
+  }
+};
+
+function pluraliseDays(value: number): string {
+  const rounded = Math.round(value);
+  return `${rounded} day${rounded === 1 ? '' : 's'}`;
+}
+
+function formatHoursPerDay(value: number): string {
+  return `${value.toFixed(1)} h/day`;
+}
+
 export function ProfileControls(): JSX.Element {
+  const {
+    profileId,
+    controls,
+    setCommuteDays,
+    setModeSplit,
+    setDiet,
+    setStreamingHours
+  } = useProfile();
+
+  const modeSegments = useMemo(() => {
+    const entries = Object.entries(controls.modeSplit) as [keyof ModeSplit, number][];
+    return entries.map(([key, value]) => ({
+      key,
+      value,
+      metadata: MODE_METADATA[key]
+    }));
+  }, [controls.modeSplit]);
+
   return (
     <section
       aria-labelledby="profile-controls-heading"
@@ -10,77 +74,157 @@ export function ProfileControls(): JSX.Element {
             Profile Controls
           </h2>
           <p className="mt-1 text-sm text-slate-400">
-            Configure the parameters that drive the model outputs. These controls will expand as the
-            analysis surface matures.
+            Tune lifestyle assumptions for <span className="font-semibold text-slate-200">{profileId}</span>. Updates
+            propagate to the compute API automatically.
           </p>
         </div>
       </div>
-      <form className="mt-6 space-y-5" aria-describedby="profile-controls-heading">
-        <div className="space-y-2">
-          <label htmlFor="scenario" className="text-sm font-medium text-slate-200">
-            Scenario
+      <form className="mt-6 space-y-7" aria-describedby="profile-controls-heading">
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Commute cadence</legend>
+          <label className="block space-y-2">
+            <span className="flex items-center justify-between text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
+              <span>Days in office</span>
+              <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] font-semibold text-slate-200">
+                {pluraliseDays(controls.commuteDaysPerWeek)}
+              </span>
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={7}
+              step={1}
+              value={controls.commuteDaysPerWeek}
+              onChange={(event) => setCommuteDays(Number(event.target.value))}
+              className="w-full accent-sky-500"
+              aria-valuetext={`${controls.commuteDaysPerWeek} commute days per week`}
+            />
           </label>
-          <select
-            id="scenario"
-            name="scenario"
-            className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-            defaultValue="baseline"
-          >
-            <option value="baseline">Baseline</option>
-            <option value="accelerated">Accelerated</option>
-            <option value="stress-test">Stress Test</option>
-          </select>
-        </div>
-        <div className="space-y-2">
-          <label htmlFor="region" className="text-sm font-medium text-slate-200">
-            Region
-          </label>
-          <div className="grid grid-cols-2 gap-3">
-            <button
-              type="button"
-              className="rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2 text-left text-sm font-medium text-slate-200 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-            >
-              North America
-            </button>
-            <button
-              type="button"
-              className="rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2 text-left text-sm font-medium text-slate-200 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-            >
-              Europe
-            </button>
-            <button
-              type="button"
-              className="rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2 text-left text-sm font-medium text-slate-200 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-            >
-              Asia-Pacific
-            </button>
-            <button
-              type="button"
-              className="rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2 text-left text-sm font-medium text-slate-200 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-            >
-              Latin America
-            </button>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
+              <span>Mode split</span>
+              <span>{controls.modeSplit.car + controls.modeSplit.transit + controls.modeSplit.bike}%</span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
+              {modeSegments.map(({ key, value, metadata }) => (
+                <div
+                  key={key}
+                  className={`${metadata.color} h-full`}
+                  style={{ width: `${value}%` }}
+                  aria-hidden="true"
+                />
+              ))}
+            </div>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              {modeSegments.map(({ key, value, metadata }) => (
+                <div key={key} className="space-y-2 rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-100">{metadata.label}</p>
+                      <p className="text-xs text-slate-400">{metadata.description}</p>
+                    </div>
+                    <span className="text-sm font-semibold text-slate-200">{value}%</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={value}
+                    onChange={(event) => setModeSplit(key, Number(event.target.value))}
+                    className="w-full accent-slate-200"
+                    aria-valuetext={`${metadata.label} ${value}% share`}
+                  />
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-        <div className="space-y-2">
-          <label htmlFor="notes" className="text-sm font-medium text-slate-200">
-            Notes
+        </fieldset>
+
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Dietary baseline</legend>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {(Object.entries(DIET_COPY) as [DietOption, { label: string; helper: string }][]).map(
+              ([key, copy]) => {
+                const isActive = controls.diet === key;
+                return (
+                  <label
+                    key={key}
+                    className={`relative flex cursor-pointer flex-col gap-2 rounded-lg border px-3 py-3 text-left shadow-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 ${
+                      isActive
+                        ? 'border-sky-500 bg-sky-500/10 text-slate-100'
+                        : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
+                    }`}
+                  >
+                    <span className="text-sm font-semibold">{copy.label}</span>
+                    <span className="text-xs text-slate-400">{copy.helper}</span>
+                    <input
+                      type="radio"
+                      name="diet"
+                      value={key}
+                      checked={isActive}
+                      onChange={() => setDiet(key)}
+                      className="sr-only"
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={`pointer-events-none absolute right-3 top-3 inline-flex h-2.5 w-2.5 rounded-full ${
+                        isActive ? 'bg-sky-400' : 'bg-slate-700'
+                      }`}
+                    />
+                  </label>
+                );
+              }
+            )}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-4">
+          <legend className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Streaming intensity
+          </legend>
+          <label className="block space-y-2">
+            <span className="flex items-center justify-between text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
+              <span>HD streaming</span>
+              <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] font-semibold text-slate-200">
+                {formatHoursPerDay(controls.streamingHoursPerDay)}
+              </span>
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={6}
+              step={0.1}
+              value={controls.streamingHoursPerDay}
+              onChange={(event) => setStreamingHours(Number(event.target.value))}
+              className="w-full accent-pink-400"
+              aria-valuetext={`${controls.streamingHoursPerDay.toFixed(1)} hours per day of streaming`}
+            />
           </label>
-          <textarea
-            id="notes"
-            name="notes"
-            rows={4}
-            className="w-full resize-none rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 shadow-inner focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-            placeholder="Document assumptions, caveats, or pending data requests."
-          />
-        </div>
-        <div className="flex justify-end">
-          <button
-            type="button"
-            className="inline-flex items-center gap-2 rounded-lg bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-          >
-            Queue computation
-          </button>
+        </fieldset>
+
+        <div className="space-y-3 rounded-xl border border-slate-800 bg-slate-900/40 p-4 text-sm text-slate-400">
+          <p className="font-semibold text-slate-200">Live overrides</p>
+          <dl className="grid gap-2 text-xs md:grid-cols-2">
+            {modeSegments.map(({ key, value, metadata }) => (
+              <Fragment key={`override-${key}`}>
+                <dt className="uppercase tracking-[0.2em] text-slate-500">{metadata.label} days/wk</dt>
+                <dd className="font-semibold text-slate-200">
+                  {((controls.commuteDaysPerWeek * value) / 100).toFixed(2)}
+                </dd>
+              </Fragment>
+            ))}
+            <Fragment key="override-diet">
+              <dt className="uppercase tracking-[0.2em] text-slate-500">Diet selection</dt>
+              <dd className="font-semibold text-slate-200">{DIET_COPY[controls.diet].label}</dd>
+            </Fragment>
+            <Fragment key="override-stream">
+              <dt className="uppercase tracking-[0.2em] text-slate-500">Streaming hours/week</dt>
+              <dd className="font-semibold text-slate-200">
+                {(controls.streamingHoursPerDay * 7).toFixed(1)}
+              </dd>
+            </Fragment>
+          </dl>
         </div>
       </form>
     </section>

--- a/site/src/components/VizCanvas.tsx
+++ b/site/src/components/VizCanvas.tsx
@@ -1,4 +1,90 @@
+import { useMemo } from 'react';
+
+import { ComputeResult, useProfile } from '../state/profile';
+
+interface ActivityRow {
+  id: string;
+  label: string;
+  emissions: number;
+}
+
+function formatEmission(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return '—';
+  }
+  const tonnes = value / 1_000_000;
+  if (Math.abs(tonnes) >= 1) {
+    return `${tonnes.toFixed(2)} t CO₂e`;
+  }
+  const kilograms = value / 1_000;
+  if (Math.abs(kilograms) >= 1) {
+    return `${kilograms.toFixed(1)} kg CO₂e`;
+  }
+  return `${value.toFixed(0)} g CO₂e`;
+}
+
+function resolveActivities(result: ComputeResult | null): {
+  topActivities: ActivityRow[];
+  total: number | null;
+  count: number;
+} {
+  const bubble = result?.figures?.bubble;
+  const rows = Array.isArray(bubble?.data) ? bubble?.data : [];
+  const aggregated = rows
+    .map((row) => {
+      const id = row.activity_id ?? 'unknown-activity';
+      const name = row.activity_name || row.activity_id || 'Activity';
+      const emissions = typeof row.annual_emissions_g === 'number' ? row.annual_emissions_g : 0;
+      return {
+        id,
+        label: name,
+        emissions
+      } satisfies ActivityRow;
+    })
+    .filter((row) => row.emissions > 0)
+    .sort((a, b) => b.emissions - a.emissions);
+
+  const topActivities = aggregated.slice(0, 5);
+  const total = aggregated.reduce((sum, row) => sum + row.emissions, 0);
+  return { topActivities, total: aggregated.length > 0 ? total : null, count: aggregated.length };
+}
+
+function resolveStatusTone(status: string): string {
+  switch (status) {
+    case 'loading':
+      return 'text-amber-300';
+    case 'success':
+      return 'text-emerald-300';
+    case 'error':
+      return 'text-rose-300';
+    default:
+      return 'text-slate-300';
+  }
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  idle: 'Idle',
+  loading: 'Recomputing…',
+  success: 'Up to date',
+  error: 'Error'
+};
+
 export function VizCanvas(): JSX.Element {
+  const { status, result, error } = useProfile();
+
+  const { topActivities, total, count } = useMemo(() => resolveActivities(result), [result]);
+
+  const datasetVersion =
+    typeof result?.manifest?.dataset_version === 'string'
+      ? result?.manifest?.dataset_version
+      : 'unknown';
+  const generatedAt =
+    typeof result?.manifest?.generated_at === 'string' ? result?.manifest?.generated_at : null;
+  const referenceCount = Array.isArray(result?.references) ? result?.references.length : null;
+
+  const statusTone = resolveStatusTone(status);
+  const statusLabel = STATUS_LABEL[status] ?? status;
+
   return (
     <section
       aria-labelledby="viz-canvas-heading"
@@ -10,27 +96,89 @@ export function VizCanvas(): JSX.Element {
             Visualization Canvas
           </h2>
           <p className="mt-1 text-sm text-slate-400">
-            A responsive surface to host charts, timelines, and other analytical storytelling assets.
+            Connected to the live compute API. Figures refresh automatically when controls change.
           </p>
         </div>
         <div className="hidden sm:flex sm:flex-col sm:items-end sm:text-xs sm:text-slate-500">
           <span>Status</span>
-          <span className="font-semibold text-sky-300">Idle</span>
+          <span className={`font-semibold ${statusTone}`} aria-live="polite">
+            {statusLabel}
+          </span>
+          <span className="mt-1 text-[11px] uppercase tracking-[0.3em] text-slate-600">
+            dataset {datasetVersion}
+          </span>
         </div>
       </div>
-      <div className="mt-6 grid min-h-[320px] place-items-center rounded-xl border border-dashed border-slate-700 bg-slate-950/40 px-6 py-12 text-center text-sm text-slate-500">
-        <div className="space-y-3">
-          <p className="text-base font-medium text-slate-300">Ready for renderings</p>
-          <p className="max-w-sm text-sm text-slate-400">
-            Drop in future visual components or connect the compute API to stream results into this
-            canvas.
-          </p>
-          <div className="flex items-center justify-center gap-3 text-xs uppercase tracking-[0.3em] text-slate-600">
-            <span className="h-2 w-2 rounded-full bg-slate-700" aria-hidden="true" />
-            <span>Awaiting data</span>
-            <span className="h-2 w-2 rounded-full bg-slate-700" aria-hidden="true" />
+      <div className="mt-6 rounded-xl border border-slate-800/80 bg-slate-950/60 p-5">
+        {status === 'error' ? (
+          <div className="space-y-3 text-sm text-rose-200">
+            <p className="font-semibold">Unable to refresh results</p>
+            <p>{error ?? 'An unexpected error occurred while requesting /api/compute.'}</p>
           </div>
-        </div>
+        ) : null}
+        {status !== 'error' && result === null ? (
+          <div className="grid min-h-[260px] place-items-center text-center text-sm text-slate-400">
+            <div className="space-y-2">
+              <p className="text-base font-medium text-slate-200">Ready for the first compute run</p>
+              <p>Adjust the profile controls to trigger a request.</p>
+            </div>
+          </div>
+        ) : null}
+        {status !== 'error' && result !== null ? (
+          <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Total emissions</p>
+                <p className="mt-2 text-2xl font-semibold text-slate-50">{formatEmission(total)}</p>
+                <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">
+                  {generatedAt ? `run ${new Date(generatedAt).toLocaleString()}` : 'timestamp pending'}
+                </p>
+              </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Activities tracked</p>
+                <p className="mt-2 text-2xl font-semibold text-slate-50">{count}</p>
+                <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">
+                  showing top contributors
+                </p>
+              </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">References</p>
+                <p className="mt-2 text-2xl font-semibold text-slate-50">
+                  {referenceCount ?? '—'}
+                </p>
+                <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">source citations</p>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+                  Top emitting activities
+                </h3>
+                {status === 'loading' ? (
+                  <span className="text-xs font-medium text-amber-300">Recomputing…</span>
+                ) : null}
+              </div>
+              {topActivities.length === 0 ? (
+                <p className="text-sm text-slate-500">No emitting activities returned for this profile yet.</p>
+              ) : (
+                <ul className="space-y-3">
+                  {topActivities.map((row) => (
+                    <li
+                      key={row.id}
+                      className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-3"
+                    >
+                      <div>
+                        <p className="text-sm font-semibold text-slate-100">{row.label}</p>
+                        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">{row.id}</p>
+                      </div>
+                      <span className="text-sm font-semibold text-slate-100">{formatEmission(row.emissions)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -1,12 +1,20 @@
 export type ComputeRequest = Record<string, unknown>;
 
-export async function compute<TResponse = unknown>(payload: ComputeRequest): Promise<TResponse> {
+export type ComputeOptions = Omit<RequestInit, 'method' | 'body'>;
+
+export async function compute<TResponse = unknown>(
+  payload: ComputeRequest,
+  options: ComputeOptions = {}
+): Promise<TResponse> {
+  const { headers, ...fetchOptions } = options;
   const response = await fetch('/api/compute', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...(headers ?? {})
     },
-    body: JSON.stringify(payload)
+    body: JSON.stringify(payload),
+    ...fetchOptions
   });
 
   if (!response.ok) {

--- a/site/src/state/profile.tsx
+++ b/site/src/state/profile.tsx
@@ -1,0 +1,406 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+
+import { compute } from '../lib/api';
+
+export type DietOption = 'omnivore' | 'vegetarian' | 'vegan';
+
+export interface ModeSplit {
+  car: number;
+  transit: number;
+  bike: number;
+}
+
+export interface ProfileControlsState {
+  commuteDaysPerWeek: number;
+  modeSplit: ModeSplit;
+  diet: DietOption;
+  streamingHoursPerDay: number;
+}
+
+export type ProfileStatus = 'idle' | 'loading' | 'success' | 'error';
+
+interface BubbleDatum {
+  activity_id?: string;
+  activity_name?: string | null;
+  annual_emissions_g?: number | null;
+}
+
+export interface ComputeResult {
+  manifest?: {
+    profile_id?: string;
+    dataset_version?: string;
+    overrides?: Record<string, number>;
+    [key: string]: unknown;
+  };
+  figures?: {
+    bubble?: {
+      data?: BubbleDatum[];
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  references?: unknown;
+  [key: string]: unknown;
+}
+
+interface ProfileContextValue {
+  profileId: string;
+  controls: ProfileControlsState;
+  overrides: Record<string, number>;
+  status: ProfileStatus;
+  result: ComputeResult | null;
+  error: string | null;
+  setCommuteDays: (value: number) => void;
+  setModeSplit: (mode: keyof ModeSplit, value: number) => void;
+  setDiet: (diet: DietOption) => void;
+  setStreamingHours: (value: number) => void;
+}
+
+const STORAGE_KEY = 'acx:profile-controls';
+const DEFAULT_PROFILE_ID = 'PRO.TO.24_39.HYBRID.2025';
+const DEBOUNCE_MS = 250;
+const DAYS_PER_WEEK = 7;
+
+const COMMUTE_ACTIVITY_IDS: Record<keyof ModeSplit, string> = {
+  car: 'TRAVEL.COMMUTE.CAR.WORKDAY',
+  transit: 'TRAVEL.COMMUTE.TRANSIT.WORKDAY',
+  bike: 'TRAVEL.COMMUTE.BIKE.WORKDAY'
+};
+
+const DIET_ACTIVITY_IDS: Record<DietOption, string> = {
+  omnivore: 'FOOD.DIET.OMNIVORE.WEEK',
+  vegetarian: 'FOOD.DIET.VEGETARIAN.WEEK',
+  vegan: 'FOOD.DIET.VEGAN.WEEK'
+};
+
+const STREAMING_ACTIVITY_ID = 'MEDIA.STREAM.HD.HOUR.TV';
+
+const DEFAULT_CONTROLS: ProfileControlsState = {
+  commuteDaysPerWeek: 3,
+  modeSplit: {
+    car: 60,
+    transit: 30,
+    bike: 10
+  },
+  diet: 'omnivore',
+  streamingHoursPerDay: 1.5
+};
+
+const ProfileContext = createContext<ProfileContextValue | undefined>(undefined);
+
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+function clampPercentage(value: number): number {
+  return Math.round(clamp(value, 0, 100));
+}
+
+function normaliseSplit(split: ModeSplit): ModeSplit {
+  const weights = [split.car, split.transit, split.bike].map((value) =>
+    clamp(Math.round(value), 0, 100)
+  );
+  const total = weights.reduce((sum, value) => sum + value, 0);
+
+  if (total === 100) {
+    return { car: weights[0], transit: weights[1], bike: weights[2] };
+  }
+
+  const distributed = distributeIntegerTotal(100, weights);
+  return { car: distributed[0], transit: distributed[1], bike: distributed[2] };
+}
+
+function roundTo(value: number, precision: number): number {
+  const multiplier = 10 ** precision;
+  return Math.round(value * multiplier) / multiplier;
+}
+
+function distributeIntegerTotal(total: number, weights: number[]): number[] {
+  if (weights.length === 0) {
+    return [];
+  }
+  const normalisedWeights = weights.map((value) => Math.max(0, value));
+  const weightSum = normalisedWeights.reduce((sum, value) => sum + value, 0);
+
+  if (total <= 0) {
+    return new Array(weights.length).fill(0);
+  }
+
+  if (weightSum === 0) {
+    const base = Math.floor(total / weights.length);
+    const remainder = total - base * weights.length;
+    return normalisedWeights.map((_, index) => (index < remainder ? base + 1 : base));
+  }
+
+  const raw = normalisedWeights.map((value) => (value / weightSum) * total);
+  const floored = raw.map((value) => Math.floor(value));
+  let remainder = total - floored.reduce((sum, value) => sum + value, 0);
+
+  const fractional = raw
+    .map((value, index) => ({ index, fraction: value - floored[index] }))
+    .sort((a, b) => b.fraction - a.fraction);
+
+  const distributed = [...floored];
+  for (let i = 0; i < remainder; i += 1) {
+    distributed[fractional[i % fractional.length].index] += 1;
+  }
+
+  return distributed;
+}
+
+function rebalanceSplit(current: ModeSplit, mode: keyof ModeSplit, value: number): ModeSplit {
+  const target = clampPercentage(value);
+  const otherKeys = (Object.keys(current) as (keyof ModeSplit)[]).filter((key) => key !== mode);
+  const otherWeights = otherKeys.map((key) => current[key]);
+  const distribution = distributeIntegerTotal(100 - target, otherWeights);
+  const next: ModeSplit = { ...current };
+  next[mode] = target;
+  otherKeys.forEach((key, index) => {
+    next[key] = distribution[index];
+  });
+  return next;
+}
+
+function normaliseControls(partial: Partial<ProfileControlsState>): ProfileControlsState {
+  const next: ProfileControlsState = {
+    commuteDaysPerWeek: clamp(partial.commuteDaysPerWeek ?? DEFAULT_CONTROLS.commuteDaysPerWeek, 0, 7),
+    streamingHoursPerDay: clamp(partial.streamingHoursPerDay ?? DEFAULT_CONTROLS.streamingHoursPerDay, 0, 6),
+    diet: (partial.diet ?? DEFAULT_CONTROLS.diet) as DietOption,
+    modeSplit: normaliseSplit(partial.modeSplit ?? DEFAULT_CONTROLS.modeSplit)
+  };
+
+  if (!Object.prototype.hasOwnProperty.call(DIET_ACTIVITY_IDS, next.diet)) {
+    next.diet = DEFAULT_CONTROLS.diet;
+  }
+
+  return next;
+}
+
+function loadStoredControls(): ProfileControlsState | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+    const parsed = JSON.parse(stored) as Partial<ProfileControlsState> | null;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    return normaliseControls(parsed);
+  } catch (error) {
+    console.warn('Failed to read persisted profile controls', error);
+    return null;
+  }
+}
+
+function persistControls(state: ProfileControlsState): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('Failed to persist profile controls', error);
+  }
+}
+
+function buildOverrides(controls: ProfileControlsState): Record<string, number> {
+  const overrides: Record<string, number> = {};
+
+  const commuteDays = clamp(controls.commuteDaysPerWeek, 0, 7);
+  const split = normaliseSplit(controls.modeSplit);
+  const carDays = roundTo((split.car / 100) * commuteDays, 3);
+  const transitDays = roundTo((split.transit / 100) * commuteDays, 3);
+  let bikeDays = roundTo((split.bike / 100) * commuteDays, 3);
+  const commuteDiff = roundTo(commuteDays - (carDays + transitDays + bikeDays), 3);
+  if (commuteDiff !== 0) {
+    bikeDays = roundTo(Math.max(0, bikeDays + commuteDiff), 3);
+  }
+
+  overrides[COMMUTE_ACTIVITY_IDS.car] = carDays;
+  overrides[COMMUTE_ACTIVITY_IDS.transit] = transitDays;
+  overrides[COMMUTE_ACTIVITY_IDS.bike] = bikeDays;
+
+  const dietEntries = Object.entries(DIET_ACTIVITY_IDS) as [DietOption, string][];
+  dietEntries.forEach(([diet, activityId]) => {
+    overrides[activityId] = diet === controls.diet ? DAYS_PER_WEEK : 0;
+  });
+
+  overrides[STREAMING_ACTIVITY_ID] = roundTo(controls.streamingHoursPerDay * DAYS_PER_WEEK, 3);
+
+  return overrides;
+}
+
+export function ProfileProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  const [controls, setControls] = useState<ProfileControlsState>(() => {
+    const stored = loadStoredControls();
+    return stored ?? DEFAULT_CONTROLS;
+  });
+  const [status, setStatus] = useState<ProfileStatus>('idle');
+  const [result, setResult] = useState<ComputeResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [profileId] = useState<string>(DEFAULT_PROFILE_ID);
+
+  const overrides = useMemo(() => buildOverrides(controls), [controls]);
+  const overridesKey = useMemo(() => JSON.stringify(overrides), [overrides]);
+
+  const hasHydrated = useRef(false);
+  useEffect(() => {
+    hasHydrated.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!hasHydrated.current) {
+      return;
+    }
+    persistControls(controls);
+  }, [controls]);
+
+  const debounceRef = useRef<number | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+    }
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+
+    setStatus((previous) => (previous === 'loading' ? previous : 'loading'));
+    setError(null);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const timeoutId = window.setTimeout(async () => {
+      try {
+        const payload = { profile_id: profileId, overrides };
+        const response = await compute<ComputeResult>(payload, {
+          signal: controller.signal
+        });
+        if (controller.signal.aborted) {
+          return;
+        }
+        setResult(response);
+        setStatus('success');
+        setError(null);
+      } catch (requestError) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        const message =
+          requestError instanceof Error ? requestError.message : 'Request failed';
+        setError(message);
+        setStatus('error');
+      }
+    }, DEBOUNCE_MS);
+
+    debounceRef.current = timeoutId;
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      controller.abort();
+    };
+  }, [profileId, overrides, overridesKey]);
+
+  const setCommuteDays = useCallback((value: number) => {
+    setControls((previous) => {
+      const nextValue = clamp(value, 0, 7);
+      if (previous.commuteDaysPerWeek === nextValue) {
+        return previous;
+      }
+      return { ...previous, commuteDaysPerWeek: nextValue };
+    });
+  }, []);
+
+  const setModeSplit = useCallback((mode: keyof ModeSplit, value: number) => {
+    setControls((previous) => {
+      const rebalanced = rebalanceSplit(previous.modeSplit, mode, value);
+      if (
+        previous.modeSplit.car === rebalanced.car &&
+        previous.modeSplit.transit === rebalanced.transit &&
+        previous.modeSplit.bike === rebalanced.bike
+      ) {
+        return previous;
+      }
+      return { ...previous, modeSplit: rebalanced };
+    });
+  }, []);
+
+  const setDiet = useCallback((diet: DietOption) => {
+    setControls((previous) => {
+      if (previous.diet === diet) {
+        return previous;
+      }
+      const nextDiet: DietOption = Object.prototype.hasOwnProperty.call(
+        DIET_ACTIVITY_IDS,
+        diet
+      )
+        ? diet
+        : previous.diet;
+      return { ...previous, diet: nextDiet };
+    });
+  }, []);
+
+  const setStreamingHours = useCallback((value: number) => {
+    setControls((previous) => {
+      const nextValue = clamp(value, 0, 6);
+      if (previous.streamingHoursPerDay === nextValue) {
+        return previous;
+      }
+      return { ...previous, streamingHoursPerDay: nextValue };
+    });
+  }, []);
+
+  const contextValue = useMemo<ProfileContextValue>(
+    () => ({
+      profileId,
+      controls,
+      overrides,
+      status,
+      result,
+      error,
+      setCommuteDays,
+      setModeSplit,
+      setDiet,
+      setStreamingHours
+    }),
+    [
+      profileId,
+      controls,
+      overrides,
+      status,
+      result,
+      error,
+      setCommuteDays,
+      setModeSplit,
+      setDiet,
+      setStreamingHours
+    ]
+  );
+
+  return <ProfileContext.Provider value={contextValue}>{children}</ProfileContext.Provider>;
+}
+
+export function useProfile(): ProfileContextValue {
+  const context = useContext(ProfileContext);
+  if (!context) {
+    throw new Error('useProfile must be used within a ProfileProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a profile state provider that persists control selections, debounces compute requests, and maps overrides to activity IDs
- replace the profile controls card with interactive commute, mode split, diet, and streaming inputs backed by the new state store
- refresh the visualization canvas to show live compute status, totals, and top-emitting activities from the API response

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db221ac618832cba87e5f3d969da99