### PR TITLE
feat(ui): add preset profiles gallery

### DIFF
--- a/site/src/components/PresetGallery.tsx
+++ b/site/src/components/PresetGallery.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import presetsData from '../data/presets.json';
+import { ProfileControlsState, useProfile } from '../state/profile';
+
+interface PresetDefinition {
+  id: string;
+  title: string;
+  summary: string;
+  controls: ProfileControlsState;
+  overrides: Record<string, number>;
+}
+
+const PRESETS: PresetDefinition[] = presetsData as PresetDefinition[];
+const EPSILON = 0.001;
+
+function areOverridesEqual(
+  candidate: Record<string, number>,
+  reference: Record<string, number>
+): boolean {
+  const candidateKeys = Object.keys(candidate);
+  const referenceKeys = Object.keys(reference);
+
+  if (candidateKeys.length !== referenceKeys.length) {
+    return false;
+  }
+
+  for (const key of candidateKeys) {
+    if (!Object.prototype.hasOwnProperty.call(reference, key)) {
+      return false;
+    }
+    const candidateValue = candidate[key];
+    const referenceValue = reference[key];
+    if (Math.abs(candidateValue - referenceValue) > EPSILON) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function PresetGallery(): JSX.Element {
+  const { overrides, setControlsState } = useProfile();
+  const [hasInitialised, setHasInitialised] = useState(false);
+
+  const activePresetId = useMemo(() => {
+    for (const preset of PRESETS) {
+      if (areOverridesEqual(preset.overrides, overrides)) {
+        return preset.id;
+      }
+    }
+    return null;
+  }, [overrides]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || hasInitialised) {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const presetId = params.get('preset');
+    if (presetId) {
+      const match = PRESETS.find((preset) => preset.id === presetId);
+      if (match) {
+        setControlsState(match.controls);
+      }
+    }
+    setHasInitialised(true);
+  }, [hasInitialised, setControlsState]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !hasInitialised) {
+      return;
+    }
+    const url = new URL(window.location.href);
+    if (activePresetId) {
+      url.searchParams.set('preset', activePresetId);
+    } else {
+      url.searchParams.delete('preset');
+    }
+    window.history.replaceState(null, '', url);
+  }, [activePresetId, hasInitialised]);
+
+  const handleApply = (preset: PresetDefinition) => {
+    setControlsState(preset.controls);
+  };
+
+  return (
+    <section aria-labelledby="preset-gallery-heading" className="mt-6 space-y-4">
+      <div>
+        <p
+          id="preset-gallery-heading"
+          className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400"
+        >
+          Preset gallery
+        </p>
+        <p className="mt-1 text-sm text-slate-400">
+          Load a ready-made lifestyle profile. Re-selecting a preset restores its saved state.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {PRESETS.map((preset) => {
+          const isActive = preset.id === activePresetId;
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => handleApply(preset)}
+              className={`group flex h-full flex-col justify-between rounded-lg border p-4 text-left transition focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
+                isActive
+                  ? 'border-sky-500 bg-sky-500/10 text-slate-100 shadow-sm shadow-sky-900/40'
+                  : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
+              }`}
+              aria-pressed={isActive}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-semibold text-slate-100">{preset.title}</span>
+                {isActive && (
+                  <span className="inline-flex items-center rounded-full bg-sky-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-sky-300">
+                    Active
+                  </span>
+                )}
+              </div>
+              <p className="mt-3 text-xs text-slate-400">{preset.summary}</p>
+              <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                <span className="h-1.5 w-1.5 rounded-full bg-slate-500 transition group-hover:bg-sky-400" aria-hidden="true" />
+                Apply preset
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/site/src/components/ProfileControls.tsx
+++ b/site/src/components/ProfileControls.tsx
@@ -2,6 +2,8 @@ import { Fragment, useMemo } from 'react';
 
 import { DietOption, ModeSplit, useProfile } from '../state/profile';
 
+import { PresetGallery } from './PresetGallery';
+
 const MODE_METADATA: Record<keyof ModeSplit, { label: string; description: string; color: string }> = {
   car: {
     label: 'Car',
@@ -79,6 +81,7 @@ export function ProfileControls(): JSX.Element {
           </p>
         </div>
       </div>
+      <PresetGallery />
       <form className="mt-6 space-y-7" aria-describedby="profile-controls-heading">
         <fieldset className="space-y-4">
           <legend className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Commute cadence</legend>

--- a/site/src/data/presets.json
+++ b/site/src/data/presets.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "remote",
+    "title": "Remote knowledge worker",
+    "summary": "WFH default with vegetarian meals and a little extra streaming.",
+    "controls": {
+      "commuteDaysPerWeek": 0,
+      "modeSplit": {
+        "car": 60,
+        "transit": 30,
+        "bike": 10
+      },
+      "diet": "vegetarian",
+      "streamingHoursPerDay": 2
+    },
+    "overrides": {
+      "TRAVEL.COMMUTE.CAR.WORKDAY": 0,
+      "TRAVEL.COMMUTE.TRANSIT.WORKDAY": 0,
+      "TRAVEL.COMMUTE.BIKE.WORKDAY": 0,
+      "FOOD.DIET.OMNIVORE.WEEK": 0,
+      "FOOD.DIET.VEGETARIAN.WEEK": 7,
+      "FOOD.DIET.VEGAN.WEEK": 0,
+      "MEDIA.STREAM.HD.HOUR.TV": 14
+    }
+  },
+  {
+    "id": "suburban",
+    "title": "Suburban commuter",
+    "summary": "Five office days, car-heavy trips, and a standard omnivore diet.",
+    "controls": {
+      "commuteDaysPerWeek": 5,
+      "modeSplit": {
+        "car": 85,
+        "transit": 10,
+        "bike": 5
+      },
+      "diet": "omnivore",
+      "streamingHoursPerDay": 1
+    },
+    "overrides": {
+      "TRAVEL.COMMUTE.CAR.WORKDAY": 4.25,
+      "TRAVEL.COMMUTE.TRANSIT.WORKDAY": 0.5,
+      "TRAVEL.COMMUTE.BIKE.WORKDAY": 0.25,
+      "FOOD.DIET.OMNIVORE.WEEK": 7,
+      "FOOD.DIET.VEGETARIAN.WEEK": 0,
+      "FOOD.DIET.VEGAN.WEEK": 0,
+      "MEDIA.STREAM.HD.HOUR.TV": 7
+    }
+  },
+  {
+    "id": "gamer",
+    "title": "Gamer / streamer",
+    "summary": "Minimal commuting, omnivore meals, and heavy daily streaming.",
+    "controls": {
+      "commuteDaysPerWeek": 1,
+      "modeSplit": {
+        "car": 40,
+        "transit": 40,
+        "bike": 20
+      },
+      "diet": "omnivore",
+      "streamingHoursPerDay": 5
+    },
+    "overrides": {
+      "TRAVEL.COMMUTE.CAR.WORKDAY": 0.4,
+      "TRAVEL.COMMUTE.TRANSIT.WORKDAY": 0.4,
+      "TRAVEL.COMMUTE.BIKE.WORKDAY": 0.2,
+      "FOOD.DIET.OMNIVORE.WEEK": 7,
+      "FOOD.DIET.VEGETARIAN.WEEK": 0,
+      "FOOD.DIET.VEGAN.WEEK": 0,
+      "MEDIA.STREAM.HD.HOUR.TV": 35
+    }
+  },
+  {
+    "id": "minimalist",
+    "title": "Minimalist urbanite",
+    "summary": "Transit-forward lifestyle, vegan diet, and limited screen time.",
+    "controls": {
+      "commuteDaysPerWeek": 2,
+      "modeSplit": {
+        "car": 15,
+        "transit": 25,
+        "bike": 60
+      },
+      "diet": "vegan",
+      "streamingHoursPerDay": 0.5
+    },
+    "overrides": {
+      "TRAVEL.COMMUTE.CAR.WORKDAY": 0.3,
+      "TRAVEL.COMMUTE.TRANSIT.WORKDAY": 0.5,
+      "TRAVEL.COMMUTE.BIKE.WORKDAY": 1.2,
+      "FOOD.DIET.OMNIVORE.WEEK": 0,
+      "FOOD.DIET.VEGETARIAN.WEEK": 0,
+      "FOOD.DIET.VEGAN.WEEK": 7,
+      "MEDIA.STREAM.HD.HOUR.TV": 3.5
+    }
+  }
+]

--- a/site/src/state/profile.tsx
+++ b/site/src/state/profile.tsx
@@ -68,6 +68,7 @@ interface ProfileContextValue {
   setModeSplit: (mode: keyof ModeSplit, value: number) => void;
   setDiet: (diet: DietOption) => void;
   setStreamingHours: (value: number) => void;
+  setControlsState: (next: ProfileControlsState) => void;
 }
 
 const STORAGE_KEY = 'acx:profile-controls';
@@ -125,6 +126,26 @@ function normaliseSplit(split: ModeSplit): ModeSplit {
 
   const distributed = distributeIntegerTotal(100, weights);
   return { car: distributed[0], transit: distributed[1], bike: distributed[2] };
+}
+
+function controlsAreEqual(a: ProfileControlsState, b: ProfileControlsState): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (
+    a.commuteDaysPerWeek !== b.commuteDaysPerWeek ||
+    a.streamingHoursPerDay !== b.streamingHoursPerDay ||
+    a.diet !== b.diet
+  ) {
+    return false;
+  }
+
+  return (
+    a.modeSplit.car === b.modeSplit.car &&
+    a.modeSplit.transit === b.modeSplit.transit &&
+    a.modeSplit.bike === b.modeSplit.bike
+  );
 }
 
 function roundTo(value: number, precision: number): number {
@@ -373,6 +394,16 @@ export function ProfileProvider({ children }: { children: React.ReactNode }): JS
     });
   }, []);
 
+  const setControlsState = useCallback((next: ProfileControlsState) => {
+    setControls((previous) => {
+      const normalised = normaliseControls(next);
+      if (controlsAreEqual(previous, normalised)) {
+        return previous;
+      }
+      return normalised;
+    });
+  }, []);
+
   const contextValue = useMemo<ProfileContextValue>(
     () => ({
       profileId,
@@ -384,7 +415,8 @@ export function ProfileProvider({ children }: { children: React.ReactNode }): JS
       setCommuteDays,
       setModeSplit,
       setDiet,
-      setStreamingHours
+      setStreamingHours,
+      setControlsState
     }),
     [
       profileId,
@@ -396,7 +428,8 @@ export function ProfileProvider({ children }: { children: React.ReactNode }): JS
       setCommuteDays,
       setModeSplit,
       setDiet,
-      setStreamingHours
+      setStreamingHours,
+      setControlsState
     ]
   );
 

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- add a preset gallery component with four curated lifestyle bundles and override payloads
- expose a full-state setter in the profile store so presets can restore controls and sync the preset query string
- switch vite config to vitest defineConfig so the suite builds with the new test metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db2db8ae84832c9f1f8638b52a329a