### PR TITLE
ui(layout): tighten density and typography

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -2,30 +2,36 @@ import { useState } from 'react';
 
 import { ProfileControls } from './components/ProfileControls';
 import { ReferencesDrawer } from './components/ReferencesDrawer';
+import { Layout } from './components/Layout';
 import { VizCanvas } from './components/VizCanvas';
 import { ProfileProvider } from './state/profile';
 
 export default function App(): JSX.Element {
-  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return true;
+    }
+    return window.matchMedia('(min-width: 1280px)').matches;
+  });
 
   return (
     <ProfileProvider>
-      <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="flex min-h-screen w-screen flex-col bg-slate-950 text-slate-100">
         <a
           href="#main"
           className="absolute left-4 top-4 z-50 -translate-y-20 rounded-lg bg-sky-500 px-3 py-2 font-semibold text-slate-900 transition focus:translate-y-0 focus:outline-none"
         >
           Skip to main content
         </a>
-        <header className="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
-          <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
+        <header className="border-b border-slate-800/60 bg-slate-950/70 backdrop-blur">
+          <div className="flex items-center justify-between px-4 py-2.5 sm:px-5 lg:px-6">
             <div>
-              <p className="text-xs uppercase tracking-[0.3em] text-sky-400">Carbon</p>
-              <h1 className="text-xl font-semibold">Analysis Console</h1>
+              <p className="text-[10px] uppercase tracking-[0.35em] text-sky-400">Carbon</p>
+              <h1 className="text-base font-semibold">Analysis Console</h1>
             </div>
             <button
               type="button"
-              className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-sm font-medium text-slate-100 shadow-sm transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:hidden"
+              className="inline-flex items-center gap-1 rounded-lg border border-slate-700 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-slate-100 shadow-sm transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:hidden"
               aria-expanded={isDrawerOpen}
               aria-controls="references-panel"
               onClick={() => setIsDrawerOpen((open) => !open)}
@@ -41,16 +47,18 @@ export default function App(): JSX.Element {
             </button>
           </div>
         </header>
-        <main id="main" className="mx-auto flex max-w-7xl flex-1 flex-col gap-6 px-4 py-6 lg:py-10">
-          <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(260px,0.85fr)_minmax(0,2.2fr)_minmax(260px,1fr)]">
-            <ProfileControls />
-            <VizCanvas />
-            <ReferencesDrawer
-              id="references-panel"
-              open={isDrawerOpen}
-              onToggle={() => setIsDrawerOpen((open) => !open)}
-            />
-          </div>
+        <main id="main" className="flex min-h-0 flex-1 flex-col px-4 py-4 sm:px-5 lg:px-6">
+          <Layout
+            controls={<ProfileControls />}
+            canvas={<VizCanvas />}
+            references={
+              <ReferencesDrawer
+                id="references-panel"
+                open={isDrawerOpen}
+                onToggle={() => setIsDrawerOpen((open) => !open)}
+              />
+            }
+          />
         </main>
       </div>
     </ProfileProvider>

--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+interface LayoutProps {
+  controls: ReactNode;
+  canvas: ReactNode;
+  references: ReactNode;
+}
+
+export function Layout({ controls, canvas, references }: LayoutProps): JSX.Element {
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-1 gap-x-4 gap-y-3 md:grid-cols-[minmax(0,1fr)_320px] lg:grid-cols-[320px_minmax(0,1fr)_320px] lg:gap-x-5 xl:grid-cols-[360px_minmax(0,1fr)_300px] xl:gap-x-6">
+      <div className="order-2 min-h-0 md:col-span-2 md:order-3 lg:order-1 lg:col-span-1 lg:max-h-[calc(100vh-96px)] lg:overflow-auto lg:pr-1">
+        {controls}
+      </div>
+      <div className="order-1 min-h-0 lg:order-2 lg:min-h-[calc(100vh-120px)] lg:overflow-hidden">
+        {canvas}
+      </div>
+      <div className="order-3 min-h-0 md:order-2">
+        {references}
+      </div>
+    </div>
+  );
+}

--- a/site/src/components/PresetGallery.tsx
+++ b/site/src/components/PresetGallery.tsx
@@ -85,19 +85,19 @@ export function PresetGallery(): JSX.Element {
   };
 
   return (
-    <section aria-labelledby="preset-gallery-heading" className="mt-6 space-y-4">
+    <section aria-labelledby="preset-gallery-heading" className="space-y-2.5">
       <div>
         <p
           id="preset-gallery-heading"
-          className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400"
+          className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-400"
         >
           Preset gallery
         </p>
-        <p className="mt-1 text-sm text-slate-400">
+        <p className="mt-1 text-compact text-slate-400">
           Load a ready-made lifestyle profile. Re-selecting a preset restores its saved state.
         </p>
       </div>
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid gap-2.5 sm:grid-cols-2">
         {PRESETS.map((preset) => {
           const isActive = preset.id === activePresetId;
           return (
@@ -105,23 +105,23 @@ export function PresetGallery(): JSX.Element {
               key={preset.id}
               type="button"
               onClick={() => handleApply(preset)}
-              className={`group flex h-full flex-col justify-between rounded-lg border p-4 text-left transition focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
+              className={`group flex h-full flex-col justify-between rounded-lg border text-left shadow-sm transition focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 pad-compact ${
                 isActive
                   ? 'border-sky-500 bg-sky-500/10 text-slate-100 shadow-sm shadow-sky-900/40'
                   : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
               }`}
               aria-pressed={isActive}
             >
-              <div className="flex items-center justify-between gap-2">
-                <span className="text-sm font-semibold text-slate-100">{preset.title}</span>
+              <div className="flex items-center justify-between gap-1.5">
+                <span className="text-[13px] font-semibold text-slate-100">{preset.title}</span>
                 {isActive && (
-                  <span className="inline-flex items-center rounded-full bg-sky-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-sky-300">
+                  <span className="inline-flex items-center rounded-full bg-sky-500/20 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.25em] text-sky-300">
                     Active
                   </span>
                 )}
               </div>
-              <p className="mt-3 text-xs text-slate-400">{preset.summary}</p>
-              <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+              <p className="mt-2 text-compact text-slate-400">{preset.summary}</p>
+              <span className="mt-2 inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-400">
                 <span className="h-1.5 w-1.5 rounded-full bg-slate-500 transition group-hover:bg-sky-400" aria-hidden="true" />
                 Apply preset
               </span>

--- a/site/src/components/ProfileControls.tsx
+++ b/site/src/components/ProfileControls.tsx
@@ -68,168 +68,172 @@ export function ProfileControls(): JSX.Element {
   return (
     <section
       aria-labelledby="profile-controls-heading"
-      className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-900/40 backdrop-blur"
+      className="flex flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-2.5 shadow-lg shadow-slate-900/40 backdrop-blur"
     >
-      <div className="flex items-start justify-between">
-        <div>
-          <h2 id="profile-controls-heading" className="text-lg font-semibold">
-            Profile Controls
-          </h2>
-          <p className="mt-1 text-sm text-slate-400">
-            Tune lifestyle assumptions for <span className="font-semibold text-slate-200">{profileId}</span>. Updates
-            propagate to the compute API automatically.
-          </p>
-        </div>
-      </div>
-      <PresetGallery />
-      <form className="mt-6 space-y-7" aria-describedby="profile-controls-heading">
-        <fieldset className="space-y-4">
-          <legend className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Commute cadence</legend>
-          <label className="block space-y-2">
-            <span className="flex items-center justify-between text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
-              <span>Days in office</span>
-              <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] font-semibold text-slate-200">
-                {pluraliseDays(controls.commuteDaysPerWeek)}
+      <header className="sticky top-0 z-10 -mx-2.5 -mt-2.5 rounded-t-2xl bg-black/30 px-2.5 py-1.5 backdrop-blur-sm">
+        <h2 id="profile-controls-heading" className="text-[13px] font-semibold tracking-tight">
+          Profile Controls
+        </h2>
+        <p className="mt-1 text-compact text-slate-400">
+          Tune lifestyle assumptions for <span className="font-semibold text-slate-200">{profileId}</span>. Updates
+          propagate to the compute API automatically.
+        </p>
+      </header>
+      <div className="mt-2.5 space-y-2.5">
+        <PresetGallery />
+        <form className="grid grid-cols-2 gap-2.5" aria-describedby="profile-controls-heading">
+          <fieldset className="relative col-span-2 space-y-2.5 rounded-xl border border-slate-800/70 bg-slate-950/40 p-2.5">
+            <legend className="sticky top-0 z-10 -mx-2.5 -mt-2.5 bg-black/30 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-slate-300 backdrop-blur-sm">
+              Commute cadence
+            </legend>
+            <label className="block space-y-1.5">
+              <span className="flex items-center justify-between text-[10px] uppercase tracking-[0.3em] text-slate-400">
+                <span>Days in office</span>
+                <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] font-semibold text-slate-200">
+                  {pluraliseDays(controls.commuteDaysPerWeek)}
+                </span>
               </span>
-            </span>
-            <input
-              type="range"
-              min={0}
-              max={7}
-              step={1}
-              value={controls.commuteDaysPerWeek}
-              onChange={(event) => setCommuteDays(Number(event.target.value))}
-              className="w-full accent-sky-500"
-              aria-valuetext={`${controls.commuteDaysPerWeek} commute days per week`}
-            />
-          </label>
-          <div className="space-y-4">
-            <div className="flex items-center justify-between text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
-              <span>Mode split</span>
-              <span>{controls.modeSplit.car + controls.modeSplit.transit + controls.modeSplit.bike}%</span>
-            </div>
-            <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
-              {modeSegments.map(({ key, value, metadata }) => (
-                <div
-                  key={key}
-                  className={`${metadata.color} h-full`}
-                  style={{ width: `${value}%` }}
-                  aria-hidden="true"
-                />
-              ))}
-            </div>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              {modeSegments.map(({ key, value, metadata }) => (
-                <div key={key} className="space-y-2 rounded-lg border border-slate-800 bg-slate-900/60 p-3">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-sm font-semibold text-slate-100">{metadata.label}</p>
-                      <p className="text-xs text-slate-400">{metadata.description}</p>
-                    </div>
-                    <span className="text-sm font-semibold text-slate-200">{value}%</span>
-                  </div>
-                  <input
-                    type="range"
-                    min={0}
-                    max={100}
-                    step={1}
-                    value={value}
-                    onChange={(event) => setModeSplit(key, Number(event.target.value))}
-                    className="w-full accent-slate-200"
-                    aria-valuetext={`${metadata.label} ${value}% share`}
-                  />
-                </div>
-              ))}
-            </div>
-          </div>
-        </fieldset>
-
-        <fieldset className="space-y-4">
-          <legend className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Dietary baseline</legend>
-          <div className="grid gap-3 sm:grid-cols-3">
-            {(Object.entries(DIET_COPY) as [DietOption, { label: string; helper: string }][]).map(
-              ([key, copy]) => {
-                const isActive = controls.diet === key;
-                return (
-                  <label
+              <input
+                type="range"
+                min={0}
+                max={7}
+                step={1}
+                value={controls.commuteDaysPerWeek}
+                onChange={(event) => setCommuteDays(Number(event.target.value))}
+                className="w-full accent-sky-500"
+                aria-valuetext={`${controls.commuteDaysPerWeek} commute days per week`}
+              />
+            </label>
+            <div className="space-y-2.5">
+              <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.3em] text-slate-400">
+                <span>Mode split</span>
+                <span>{controls.modeSplit.car + controls.modeSplit.transit + controls.modeSplit.bike}%</span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
+                {modeSegments.map(({ key, value, metadata }) => (
+                  <div
                     key={key}
-                    className={`relative flex cursor-pointer flex-col gap-2 rounded-lg border px-3 py-3 text-left shadow-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 ${
-                      isActive
-                        ? 'border-sky-500 bg-sky-500/10 text-slate-100'
-                        : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
-                    }`}
-                  >
-                    <span className="text-sm font-semibold">{copy.label}</span>
-                    <span className="text-xs text-slate-400">{copy.helper}</span>
+                    className={`${metadata.color} h-full`}
+                    style={{ width: `${value}%` }}
+                    aria-hidden="true"
+                  />
+                ))}
+              </div>
+              <div className="grid gap-2.5 sm:grid-cols-2">
+                {modeSegments.map(({ key, value, metadata }) => (
+                  <div key={key} className="space-y-1.5 rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
+                    <div className="flex items-center justify-between gap-1.5">
+                      <div>
+                        <p className="text-[13px] font-semibold text-slate-100">{metadata.label}</p>
+                        <p className="text-compact text-slate-400">{metadata.description}</p>
+                      </div>
+                      <span className="text-[13px] font-semibold text-slate-200">{value}%</span>
+                    </div>
                     <input
-                      type="radio"
-                      name="diet"
-                      value={key}
-                      checked={isActive}
-                      onChange={() => setDiet(key)}
-                      className="sr-only"
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={1}
+                      value={value}
+                      onChange={(event) => setModeSplit(key, Number(event.target.value))}
+                      className="w-full accent-slate-200"
+                      aria-valuetext={`${metadata.label} ${value}% share`}
                     />
-                    <span
-                      aria-hidden="true"
-                      className={`pointer-events-none absolute right-3 top-3 inline-flex h-2.5 w-2.5 rounded-full ${
-                        isActive ? 'bg-sky-400' : 'bg-slate-700'
+                  </div>
+                ))}
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset className="col-span-2 space-y-2.5 rounded-xl border border-slate-800/70 bg-slate-950/40 p-2.5">
+            <legend className="sticky top-0 z-10 -mx-2.5 -mt-2.5 bg-black/30 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-slate-300 backdrop-blur-sm">
+              Dietary baseline
+            </legend>
+            <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-3">
+              {(Object.entries(DIET_COPY) as [DietOption, { label: string; helper: string }][]).map(
+                ([key, copy]) => {
+                  const isActive = controls.diet === key;
+                  return (
+                    <label
+                      key={key}
+                      className={`relative flex cursor-pointer flex-col gap-1.5 rounded-lg border text-left shadow-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 pad-compact ${
+                        isActive
+                          ? 'border-sky-500 bg-sky-500/10 text-slate-100'
+                          : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
                       }`}
-                    />
-                  </label>
-                );
-              }
-            )}
-          </div>
-        </fieldset>
+                    >
+                      <span className="text-[13px] font-semibold">{copy.label}</span>
+                      <span className="text-compact text-slate-400">{copy.helper}</span>
+                      <input
+                        type="radio"
+                        name="diet"
+                        value={key}
+                        checked={isActive}
+                        onChange={() => setDiet(key)}
+                        className="sr-only"
+                      />
+                      <span
+                        aria-hidden="true"
+                        className={`pointer-events-none absolute right-3 top-3 inline-flex h-2 w-2 rounded-full ${
+                          isActive ? 'bg-sky-400' : 'bg-slate-700'
+                        }`}
+                      />
+                    </label>
+                  );
+                }
+              )}
+            </div>
+          </fieldset>
 
-        <fieldset className="space-y-4">
-          <legend className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
-            Streaming intensity
-          </legend>
-          <label className="block space-y-2">
-            <span className="flex items-center justify-between text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
-              <span>HD streaming</span>
-              <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] font-semibold text-slate-200">
-                {formatHoursPerDay(controls.streamingHoursPerDay)}
+          <fieldset className="col-span-2 space-y-2.5 rounded-xl border border-slate-800/70 bg-slate-950/40 p-2.5">
+            <legend className="sticky top-0 z-10 -mx-2.5 -mt-2.5 bg-black/30 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-slate-300 backdrop-blur-sm">
+              Streaming intensity
+            </legend>
+            <label className="block space-y-1.5">
+              <span className="flex items-center justify-between text-[10px] uppercase tracking-[0.3em] text-slate-400">
+                <span>HD streaming</span>
+                <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] font-semibold text-slate-200">
+                  {formatHoursPerDay(controls.streamingHoursPerDay)}
+                </span>
               </span>
-            </span>
-            <input
-              type="range"
-              min={0}
-              max={6}
-              step={0.1}
-              value={controls.streamingHoursPerDay}
-              onChange={(event) => setStreamingHours(Number(event.target.value))}
-              className="w-full accent-pink-400"
-              aria-valuetext={`${controls.streamingHoursPerDay.toFixed(1)} hours per day of streaming`}
-            />
-          </label>
-        </fieldset>
+              <input
+                type="range"
+                min={0}
+                max={6}
+                step={0.1}
+                value={controls.streamingHoursPerDay}
+                onChange={(event) => setStreamingHours(Number(event.target.value))}
+                className="w-full accent-pink-400"
+                aria-valuetext={`${controls.streamingHoursPerDay.toFixed(1)} hours per day of streaming`}
+              />
+            </label>
+          </fieldset>
 
-        <div className="space-y-3 rounded-xl border border-slate-800 bg-slate-900/40 p-4 text-sm text-slate-400">
-          <p className="font-semibold text-slate-200">Live overrides</p>
-          <dl className="grid gap-2 text-xs md:grid-cols-2">
-            {modeSegments.map(({ key, value, metadata }) => (
-              <Fragment key={`override-${key}`}>
-                <dt className="uppercase tracking-[0.2em] text-slate-500">{metadata.label} days/wk</dt>
-                <dd className="font-semibold text-slate-200">
-                  {((controls.commuteDaysPerWeek * value) / 100).toFixed(2)}
+          <div className="col-span-2 space-y-2.5 rounded-xl border border-slate-800/70 bg-slate-950/30 p-2.5 text-compact text-slate-400">
+            <p className="text-[13px] font-semibold text-slate-200">Live overrides</p>
+            <dl className="grid gap-1.5 md:grid-cols-2">
+              {modeSegments.map(({ key, value, metadata }) => (
+                <Fragment key={`override-${key}`}>
+                  <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-500">{metadata.label} days/wk</dt>
+                  <dd className="text-[13px] font-semibold text-slate-200">
+                    {((controls.commuteDaysPerWeek * value) / 100).toFixed(2)}
+                  </dd>
+                </Fragment>
+              ))}
+              <Fragment key="override-diet">
+                <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-500">Diet selection</dt>
+                <dd className="text-[13px] font-semibold text-slate-200">{DIET_COPY[controls.diet].label}</dd>
+              </Fragment>
+              <Fragment key="override-stream">
+                <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-500">Streaming hours/week</dt>
+                <dd className="text-[13px] font-semibold text-slate-200">
+                  {(controls.streamingHoursPerDay * 7).toFixed(1)}
                 </dd>
               </Fragment>
-            ))}
-            <Fragment key="override-diet">
-              <dt className="uppercase tracking-[0.2em] text-slate-500">Diet selection</dt>
-              <dd className="font-semibold text-slate-200">{DIET_COPY[controls.diet].label}</dd>
-            </Fragment>
-            <Fragment key="override-stream">
-              <dt className="uppercase tracking-[0.2em] text-slate-500">Streaming hours/week</dt>
-              <dd className="font-semibold text-slate-200">
-                {(controls.streamingHoursPerDay * 7).toFixed(1)}
-              </dd>
-            </Fragment>
-          </dl>
-        </div>
-      </form>
+            </dl>
+          </div>
+        </form>
+      </div>
     </section>
   );
 }

--- a/site/src/components/ReferencesDrawer.tsx
+++ b/site/src/components/ReferencesDrawer.tsx
@@ -41,17 +41,12 @@ export function ReferencesDrawer({ id = 'references', open, onToggle }: Referenc
       id={id}
       aria-labelledby="references-heading"
       aria-live="polite"
-      className="rounded-xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-900/40 backdrop-blur"
+      className="flex h-full flex-col rounded-2xl border border-slate-800/70 bg-slate-900/60 p-2.5 shadow-lg shadow-slate-900/40 backdrop-blur"
     >
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 id="references-heading" className="text-lg font-semibold text-slate-100">
-            References
-          </h2>
-          <p className="mt-1 text-sm text-slate-400">
-            Primary sources supporting the figures. Press <kbd className="rounded bg-slate-800 px-1">Esc</kbd> to close.
-          </p>
-        </div>
+      <div className="flex items-center justify-between gap-2">
+        <p id="references-heading" className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300">
+          References
+        </p>
         <button
           type="button"
           aria-expanded={open}
@@ -63,24 +58,38 @@ export function ReferencesDrawer({ id = 'references', open, onToggle }: Referenc
               onToggle();
             }
           }}
-          className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-700 text-slate-200 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
         >
-          <span className="h-1.5 w-1.5 rounded-full bg-sky-400" aria-hidden="true" />
-          {open ? 'Collapse' : 'Expand'}
+          <span className="sr-only">{open ? 'Collapse references' : 'Expand references'}</span>
+          <svg
+            aria-hidden="true"
+            className={`h-3 w-3 transition-transform ${open ? 'rotate-180 text-sky-300' : 'text-slate-400'}`}
+            viewBox="0 0 12 12"
+            fill="currentColor"
+          >
+            <path d="M6 8.5a1 1 0 0 1-.707-.293l-4-4A1 1 0 0 1 2.707 3.793L6 7.086l3.293-3.293a1 1 0 0 1 1.414 1.414l-4 4A1 1 0 0 1 6 8.5Z" />
+          </svg>
         </button>
       </div>
-      <div id={`${id}-content`} hidden={!open} className="mt-6 space-y-4 text-sm text-slate-300">
+      <p className="mt-1.5 text-compact text-slate-400">
+        Primary sources supporting the figures. Press <kbd className="rounded bg-slate-800 px-1">Esc</kbd> to close.
+      </p>
+      <div
+        id={`${id}-content`}
+        hidden={!open}
+        className="mt-2.5 flex-1 overflow-y-auto rounded-xl border border-slate-800/60 bg-slate-950/30 p-2.5 text-compact text-slate-300"
+      >
         {references.length === 0 ? (
-          <p className="text-sm text-slate-400">No references available for the current selection.</p>
+          <p className="text-compact text-slate-400">No references available for the current selection.</p>
         ) : (
-          <ol className="space-y-3" aria-label="Reference list">
+          <ol className="space-y-2.5" aria-label="Reference list">
             {references.map((reference, index) => (
               <li
                 key={reference}
-                className="rounded-lg border border-slate-800/80 bg-slate-950/40 p-3 text-left shadow-inner shadow-slate-900/30"
+                className="rounded-lg border border-slate-800/70 bg-slate-950/60 pad-compact text-left shadow-inner shadow-slate-900/30"
               >
-                <span className="block text-xs uppercase tracking-[0.3em] text-sky-400">[{index + 1}]</span>
-                <p className="mt-1 text-sm text-slate-200">{reference.replace(/^\[[0-9]+\]\s*/, '')}</p>
+                <span className="block text-[11px] uppercase tracking-[0.3em] text-sky-400">[{index + 1}]</span>
+                <p className="mt-1 text-compact text-slate-200">{reference.replace(/^\[[0-9]+\]\s*/, '')}</p>
               </li>
             ))}
           </ol>

--- a/site/src/components/VizCanvas.tsx
+++ b/site/src/components/VizCanvas.tsx
@@ -125,77 +125,79 @@ export function VizCanvas(): JSX.Element {
     <section
       ref={canvasRef}
       aria-labelledby="viz-canvas-heading"
-      className="relative overflow-hidden rounded-2xl border border-slate-800 bg-gradient-to-br from-slate-900/80 via-slate-900 to-slate-950 p-6 shadow-lg shadow-slate-900/50"
+      className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-gradient-to-br from-slate-900/80 via-slate-900 to-slate-950 p-3 shadow-lg shadow-slate-900/50 sm:p-4"
     >
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 id="viz-canvas-heading" className="text-lg font-semibold">
+          <h2 id="viz-canvas-heading" className="text-[13px] font-semibold">
             Visualization Canvas
           </h2>
-          <p className="mt-1 text-sm text-slate-400">
+          <p className="mt-1 text-compact text-slate-400">
             Connected to the live compute API. Figures refresh automatically when controls change.
           </p>
         </div>
-        <div className="flex items-start justify-end gap-3 sm:items-start">
-          <div className="hidden sm:flex sm:flex-col sm:items-end sm:text-xs sm:text-slate-500">
-            <span>Status</span>
-            <span className={`font-semibold ${statusTone}`} aria-live="polite">
+        <div className="flex items-start justify-end gap-1.5 sm:items-start">
+          <div className="hidden sm:flex sm:flex-col sm:items-end">
+            <span className="text-[10px] uppercase tracking-[0.35em] text-slate-500">Status</span>
+            <span className={`text-[13px] font-semibold ${statusTone}`} aria-live="polite">
               {statusLabel}
             </span>
-            <span className="mt-1 text-[11px] uppercase tracking-[0.3em] text-slate-600">
+            <span className="mt-0.5 text-[10px] uppercase tracking-[0.35em] text-slate-600">
               dataset {datasetVersion}
             </span>
           </div>
           <ExportMenu canvasRef={canvasRef} />
         </div>
       </div>
-      <div className="mt-6 rounded-xl border border-slate-800/80 bg-slate-950/60 p-5">
-        {status === 'error' ? (
-          <div className="space-y-3 text-sm text-rose-200">
-            <p className="font-semibold">Unable to refresh results</p>
-            <p>{error ?? 'An unexpected error occurred while requesting /api/compute.'}</p>
-          </div>
-        ) : null}
-        {status !== 'error' && result === null ? (
-          <div className="grid min-h-[260px] place-items-center text-center text-sm text-slate-400">
-            <div className="space-y-2">
-              <p className="text-base font-medium text-slate-200">Ready for the first compute run</p>
-              <p>Adjust the profile controls to trigger a request.</p>
+      <div className="mt-2.5 flex-1 overflow-hidden rounded-xl border border-slate-800/60 bg-slate-950/50">
+        <div className="flex h-full flex-col overflow-y-auto p-3">
+          {status === 'error' ? (
+            <div className="space-y-2 text-compact text-rose-200">
+              <p className="text-[13px] font-semibold">Unable to refresh results</p>
+              <p>{error ?? 'An unexpected error occurred while requesting /api/compute.'}</p>
             </div>
-          </div>
-        ) : null}
-        {status !== 'error' && result !== null ? (
-          <div className="space-y-6">
-            <div className="grid gap-4 sm:grid-cols-3">
-              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Total emissions</p>
-                <p className="mt-2 text-2xl font-semibold text-slate-50">{formatEmission(total)}</p>
-                <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">
-                  {generatedAt ? `run ${new Date(generatedAt).toLocaleString()}` : 'timestamp pending'}
-                </p>
-              </div>
-              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Activities tracked</p>
-                <p className="mt-2 text-2xl font-semibold text-slate-50">{count}</p>
-                <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">
-                  showing top contributors
-                </p>
-              </div>
-              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">References</p>
-                <p className="mt-2 text-2xl font-semibold text-slate-50">
-                  {referenceCount ?? '—'}
-                </p>
-                <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">source citations</p>
+          ) : null}
+          {status !== 'error' && result === null ? (
+            <div className="grid min-h-[200px] flex-1 place-items-center text-center text-compact text-slate-400">
+              <div className="space-y-2">
+                <p className="text-[15px] font-medium text-slate-200">Ready for the first compute run</p>
+                <p>Adjust the profile controls to trigger a request.</p>
               </div>
             </div>
-            <div className="grid gap-4 lg:grid-cols-3">
-              <Stacked data={stackedData} referenceLookup={referenceLookup} />
-              <Bubble data={bubbleData} referenceLookup={referenceLookup} />
-              <Sankey data={sankeyData} referenceLookup={referenceLookup} />
+          ) : null}
+          {status !== 'error' && result !== null ? (
+            <div className="space-y-4">
+              <div className="grid gap-2.5 sm:grid-cols-3">
+                <div className="rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-500">Total emissions</p>
+                  <p className="mt-1.5 text-lg font-semibold text-slate-50">{formatEmission(total)}</p>
+                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-500">
+                    {generatedAt ? `run ${new Date(generatedAt).toLocaleString()}` : 'timestamp pending'}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-500">Activities tracked</p>
+                  <p className="mt-1.5 text-lg font-semibold text-slate-50">{count}</p>
+                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-500">
+                    showing top contributors
+                  </p>
+                </div>
+                <div className="rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-500">References</p>
+                  <p className="mt-1.5 text-lg font-semibold text-slate-50">
+                    {referenceCount ?? '—'}
+                  </p>
+                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-500">source citations</p>
+                </div>
+              </div>
+              <div className="grid gap-2.5 lg:grid-cols-3">
+                <Stacked data={stackedData} referenceLookup={referenceLookup} />
+                <Bubble data={bubbleData} referenceLookup={referenceLookup} />
+                <Sankey data={sankeyData} referenceLookup={referenceLookup} />
+              </div>
             </div>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </div>
     </section>
   );

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -24,3 +24,13 @@ select:focus-visible {
   outline: 2px solid theme('colors.sky.400');
   outline-offset: 2px;
 }
+
+@layer utilities {
+  .pad-compact {
+    @apply px-2.5 py-2.5;
+  }
+
+  .text-compact {
+    @apply text-[11px] leading-[1.45];
+  }
+}


### PR DESCRIPTION
## Summary
- refine the layout shell to keep the responsive grid while tightening header padding for a denser viewport presentation
- further compact ProfileControls and the Preset gallery so all existing sections fit with smaller typography and reduced gaps
- compress the visualization canvas and references drawer while updating compact utility tokens to support the new micro spacing

## Testing
- npm --prefix site run build

------
https://chatgpt.com/codex/tasks/task_e_68db37674554832caab82154fb8752af