### PR TITLE
feat(viz): add optional layer toggles

### DIFF
--- a/site/src/components/Bubble.tsx
+++ b/site/src/components/Bubble.tsx
@@ -9,6 +9,7 @@ import {
 } from '../lib/references';
 
 export interface BubbleDatum extends ReferenceCarrier {
+  layer_id?: string | null;
   activity_id?: string | null;
   activity_name?: string | null;
   category?: string | null;

--- a/site/src/components/LayerToggles.tsx
+++ b/site/src/components/LayerToggles.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+
+interface LayerOption {
+  id: string;
+  label: string;
+  description: string;
+}
+
+const OPTIONAL_LAYERS: LayerOption[] = [
+  {
+    id: 'online',
+    label: 'Online services',
+    description: 'Include remote work and SaaS activity layers.'
+  },
+  {
+    id: 'industrial_light',
+    label: 'Industrial (Light)',
+    description: 'Add laboratory, prototyping, and light fabrication workloads.'
+  },
+  {
+    id: 'industrial_heavy',
+    label: 'Industrial (Heavy)',
+    description: 'Surface high-intensity manufacturing and heavy industry activity.'
+  }
+];
+
+export interface LayerTogglesProps {
+  baseLayer: string;
+  availableLayers: readonly string[];
+  activeLayers: readonly string[];
+  onChange: (layers: string[]) => void;
+}
+
+function normaliseLayerList(values: readonly string[] | undefined): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values.map((value) => value.trim()).filter((value) => value.length > 0);
+}
+
+export function LayerToggles({
+  baseLayer,
+  availableLayers,
+  activeLayers,
+  onChange
+}: LayerTogglesProps): JSX.Element | null {
+  const available = useMemo(() => new Set(normaliseLayerList(availableLayers)), [availableLayers]);
+  const activeSet = useMemo(() => new Set(normaliseLayerList(activeLayers)), [activeLayers]);
+
+  if (!baseLayer || !available.has(baseLayer)) {
+    return null;
+  }
+
+  const options = OPTIONAL_LAYERS.filter((option) => available.has(option.id));
+  if (options.length === 0) {
+    return null;
+  }
+
+  const handleToggle = (layerId: string) => {
+    const next = new Set<string>(activeSet);
+    if (next.has(layerId)) {
+      next.delete(layerId);
+    } else {
+      next.add(layerId);
+    }
+    next.add(baseLayer);
+    const ordered: string[] = [];
+    available.forEach((layer) => {
+      if (next.has(layer)) {
+        ordered.push(layer);
+        next.delete(layer);
+      }
+    });
+    next.forEach((layer) => ordered.push(layer));
+    onChange(ordered);
+  };
+
+  return (
+    <fieldset className="rounded-xl border border-slate-800/70 bg-slate-900/60 p-3 shadow-inner shadow-slate-900/30">
+      <legend className="px-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-400">
+        Optional layers
+      </legend>
+      <p className="mt-1 text-xs text-slate-400">
+        Toggle additional layers to compare with the baseline professional footprint. References update
+        automatically.
+      </p>
+      <div className="mt-3 flex flex-col gap-2.5 sm:flex-row">
+        {options.map((option) => {
+          const isActive = activeSet.has(option.id);
+          return (
+            <label
+              key={option.id}
+              className={`flex cursor-pointer flex-1 items-start gap-3 rounded-lg border px-3 py-2 transition ${
+                isActive
+                  ? 'border-sky-400/60 bg-sky-500/10 text-slate-100'
+                  : 'border-slate-800/70 bg-slate-950/40 text-slate-300 hover:border-slate-700'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={isActive}
+                onChange={() => handleToggle(option.id)}
+                className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-900 text-sky-400 focus:ring-sky-400"
+              />
+              <span className="space-y-1">
+                <span className="block text-sm font-semibold text-slate-100">{option.label}</span>
+                <span className="block text-xs text-slate-400">{option.description}</span>
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/site/src/components/ReferencesDrawer.tsx
+++ b/site/src/components/ReferencesDrawer.tsx
@@ -18,9 +18,9 @@ function normaliseReferences(value: unknown): string[] {
 }
 
 export function ReferencesDrawer({ id = 'references', open, onToggle }: ReferencesDrawerProps): JSX.Element {
-  const { result } = useProfile();
+  const { activeReferences } = useProfile();
 
-  const references = useMemo(() => normaliseReferences(result?.references), [result]);
+  const references = useMemo(() => normaliseReferences(activeReferences), [activeReferences]);
 
   useEffect(() => {
     if (!open) {

--- a/site/src/components/Sankey.tsx
+++ b/site/src/components/Sankey.tsx
@@ -17,6 +17,7 @@ export interface SankeyNode {
 export interface SankeyLink extends ReferenceCarrier {
   source: string;
   target: string;
+  layer_id?: string | null;
   category?: string | null;
   values?: {
     mean?: number | null;

--- a/site/src/components/Stacked.tsx
+++ b/site/src/components/Stacked.tsx
@@ -9,6 +9,7 @@ import {
 } from '../lib/references';
 
 export interface StackedDatum extends ReferenceCarrier {
+  layer_id?: string | null;
   category?: string | null;
   values?: {
     mean?: number | null;

--- a/site/src/components/__tests__/ReferencesDrawer.test.tsx
+++ b/site/src/components/__tests__/ReferencesDrawer.test.tsx
@@ -5,9 +5,7 @@ import { ReferencesDrawer } from '../ReferencesDrawer';
 
 vi.mock('../../state/profile', () => ({
   useProfile: () => ({
-    result: {
-      references: ['[1] First reference.', '[2] Second reference.']
-    }
+    activeReferences: ['First reference.', 'Second reference.']
   })
 }));
 

--- a/site/src/state/profile.tsx
+++ b/site/src/state/profile.tsx
@@ -485,12 +485,22 @@ export function ProfileProvider({ children }: { children: React.ReactNode }): JS
       const fallback = availableLayers.includes(PRIMARY_LAYER_ID)
         ? PRIMARY_LAYER_ID
         : availableLayers[0] ?? PRIMARY_LAYER_ID;
+      const availableSet = new Set(availableLayers);
       const nextSet = new Set<string>();
       previous.forEach((layer) => {
-        if (typeof layer === 'string' && availableLayers.includes(layer)) {
+        if (typeof layer === 'string' && availableSet.has(layer)) {
           nextSet.add(layer);
         }
       });
+
+      if (availableSet.size === 0) {
+        return [fallback];
+      }
+
+      if (nextSet.size === 0 || (nextSet.size === 1 && nextSet.has(fallback))) {
+        return Array.from(availableSet);
+      }
+
       nextSet.add(fallback);
       const ordered: string[] = [];
       availableLayers.forEach((layer) => {


### PR DESCRIPTION
## Summary
- add LayerToggles UI and filter chart data and references by the selected layers
- extend profile context to manage active layer metadata and reference unions for the drawer
- ensure derived figure slices persist layer_id on stacked, bubble, and sankey outputs

## Testing
- npm --prefix site test

------
https://chatgpt.com/codex/tasks/task_e_68db436a68a8832cbff26230ae66d199