### PR TITLE
chore(a11y): improve focus and contrast in site

### DIFF
--- a/site/src/components/ExportMenu.tsx
+++ b/site/src/components/ExportMenu.tsx
@@ -137,12 +137,14 @@ export function ExportMenu({ canvasRef }: ExportMenuProps): JSX.Element {
   const [feedback, setFeedback] = useState<FeedbackState>(null);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const toggleRef = useRef<HTMLButtonElement | null>(null);
+  const previousOpenRef = useRef(menuOpen);
 
   useEffect(() => {
     if (!menuOpen || typeof document === 'undefined') {
       return;
     }
-    const handlePointer = (event: MouseEvent) => {
+    const handlePointer = (event: MouseEvent | PointerEvent | TouchEvent) => {
       if (!containerRef.current) {
         return;
       }
@@ -155,10 +157,12 @@ export function ExportMenu({ canvasRef }: ExportMenuProps): JSX.Element {
         setMenuOpen(false);
       }
     };
-    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('pointerdown', handlePointer);
+    document.addEventListener('touchstart', handlePointer);
     document.addEventListener('keydown', handleKey);
     return () => {
-      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('pointerdown', handlePointer);
+      document.removeEventListener('touchstart', handlePointer);
       document.removeEventListener('keydown', handleKey);
     };
   }, [menuOpen]);
@@ -248,25 +252,40 @@ export function ExportMenu({ canvasRef }: ExportMenuProps): JSX.Element {
 
   const actionsDisabled = busyAction !== null || !hasResult;
 
+  useEffect(() => {
+    const wasOpen = previousOpenRef.current;
+    if (menuOpen) {
+      const firstAction = containerRef.current?.querySelector<HTMLButtonElement>('[data-export-action="menu-item"]');
+      firstAction?.focus({ preventScroll: true });
+    } else if (wasOpen) {
+      toggleRef.current?.focus({ preventScroll: true });
+    }
+    previousOpenRef.current = menuOpen;
+  }, [menuOpen]);
+
   return (
     <div className="relative" ref={containerRef}>
       <button
         type="button"
-        className="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm font-medium text-slate-100 shadow-sm transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+        id="export-menu-button"
+        ref={toggleRef}
+        className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-slate-600 bg-slate-900/70 px-4 py-2.5 text-sm font-medium text-slate-100 shadow-sm transition hover:border-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
         onClick={handleToggleMenu}
         aria-expanded={menuOpen}
         aria-haspopup="menu"
+        aria-controls="export-menu-options"
       >
         <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden="true" />
         Export
       </button>
       {menuOpen ? (
         <div
-          className="absolute right-0 z-30 mt-2 w-72 rounded-xl border border-slate-800 bg-slate-950/95 p-4 text-sm text-slate-200 shadow-xl ring-1 ring-slate-900/60 backdrop-blur"
+          id="export-menu-options"
+          className="absolute right-0 z-30 mt-2 w-72 rounded-xl border border-slate-700/70 bg-slate-950/95 p-4 text-sm text-slate-100 shadow-xl ring-1 ring-slate-900/60 backdrop-blur"
           role="menu"
           aria-label="Export options"
         >
-          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-500">
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-300">
             <span>Downloads</span>
             <span className="font-mono lowercase tracking-tight text-slate-400">{exportId}</span>
           </div>
@@ -274,7 +293,8 @@ export function ExportMenu({ canvasRef }: ExportMenuProps): JSX.Element {
             <button
               type="button"
               role="menuitem"
-              className="w-full rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-left text-sm font-medium transition hover:border-slate-600 disabled:cursor-not-allowed disabled:opacity-60"
+              data-export-action="menu-item"
+              className="w-full rounded-lg border border-slate-700 bg-slate-900/70 px-3 py-3 text-left text-sm font-medium transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-400"
               onClick={handleExportCsv}
               disabled={actionsDisabled}
             >
@@ -284,7 +304,8 @@ export function ExportMenu({ canvasRef }: ExportMenuProps): JSX.Element {
             <button
               type="button"
               role="menuitem"
-              className="w-full rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-left text-sm font-medium transition hover:border-slate-600 disabled:cursor-not-allowed disabled:opacity-60"
+              data-export-action="menu-item"
+              className="w-full rounded-lg border border-slate-700 bg-slate-900/70 px-3 py-3 text-left text-sm font-medium transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-400"
               onClick={handleExportPng}
               disabled={actionsDisabled}
             >
@@ -294,7 +315,8 @@ export function ExportMenu({ canvasRef }: ExportMenuProps): JSX.Element {
             <button
               type="button"
               role="menuitem"
-              className="w-full rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-left text-sm font-medium transition hover:border-slate-600 disabled:cursor-not-allowed disabled:opacity-60"
+              data-export-action="menu-item"
+              className="w-full rounded-lg border border-slate-700 bg-slate-900/70 px-3 py-3 text-left text-sm font-medium transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-400"
               onClick={handleExportReferences}
               disabled={actionsDisabled}
             >
@@ -303,7 +325,7 @@ export function ExportMenu({ canvasRef }: ExportMenuProps): JSX.Element {
             </button>
           </div>
           {!hasResult ? (
-            <p className="mt-3 text-xs text-slate-500">
+            <p className="mt-3 text-xs text-slate-300">
               Exports unlock after the first compute run.
             </p>
           ) : null}
@@ -317,7 +339,7 @@ export function ExportMenu({ canvasRef }: ExportMenuProps): JSX.Element {
             </div>
           ) : null}
           {status === 'loading' ? (
-            <p className="mt-3 text-[11px] uppercase tracking-[0.3em] text-slate-500">
+            <p className="mt-3 text-[11px] uppercase tracking-[0.3em] text-slate-300">
               Recomputing… latest exports reflect last completed run.
             </p>
           ) : null}

--- a/site/src/components/LayerToggles.tsx
+++ b/site/src/components/LayerToggles.tsx
@@ -90,7 +90,7 @@ export function LayerToggles({
           return (
             <label
               key={option.id}
-              className={`flex cursor-pointer flex-1 items-start gap-3 rounded-lg border px-3 py-2 transition ${
+              className={`flex min-h-[120px] cursor-pointer flex-1 items-start gap-3 rounded-lg border px-3 py-3 transition ${
                 isActive
                   ? 'border-sky-400/60 bg-sky-500/10 text-slate-100'
                   : 'border-slate-800/70 bg-slate-950/40 text-slate-300 hover:border-slate-700'

--- a/site/src/components/PresetGallery.tsx
+++ b/site/src/components/PresetGallery.tsx
@@ -105,7 +105,7 @@ export function PresetGallery(): JSX.Element {
               key={preset.id}
               type="button"
               onClick={() => handleApply(preset)}
-              className={`group flex h-full flex-col justify-between rounded-lg border text-left shadow-sm transition focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 pad-compact ${
+              className={`group flex h-full min-h-[148px] flex-col justify-between rounded-lg border text-left shadow-sm transition focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 pad-compact ${
                 isActive
                   ? 'border-sky-500 bg-sky-500/10 text-slate-100 shadow-sm shadow-sky-900/40'
                   : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'

--- a/site/src/components/ProfileControls.tsx
+++ b/site/src/components/ProfileControls.tsx
@@ -156,7 +156,7 @@ export function ProfileControls(): JSX.Element {
                   return (
                     <label
                       key={key}
-                      className={`relative flex cursor-pointer flex-col gap-1.5 rounded-lg border text-left shadow-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 pad-compact ${
+                      className={`relative flex min-h-[132px] cursor-pointer flex-col gap-1.5 rounded-lg border text-left shadow-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 pad-compact ${
                         isActive
                           ? 'border-sky-500 bg-sky-500/10 text-slate-100'
                           : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
@@ -214,18 +214,18 @@ export function ProfileControls(): JSX.Element {
             <dl className="grid gap-1.5 md:grid-cols-2">
               {modeSegments.map(({ key, value, metadata }) => (
                 <Fragment key={`override-${key}`}>
-                  <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-500">{metadata.label} days/wk</dt>
+                  <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-300">{metadata.label} days/wk</dt>
                   <dd className="text-[13px] font-semibold text-slate-200">
                     {((controls.commuteDaysPerWeek * value) / 100).toFixed(2)}
                   </dd>
                 </Fragment>
               ))}
               <Fragment key="override-diet">
-                <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-500">Diet selection</dt>
+                <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-300">Diet selection</dt>
                 <dd className="text-[13px] font-semibold text-slate-200">{DIET_COPY[controls.diet].label}</dd>
               </Fragment>
               <Fragment key="override-stream">
-                <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-500">Streaming hours/week</dt>
+                <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-300">Streaming hours/week</dt>
                 <dd className="text-[13px] font-semibold text-slate-200">
                   {(controls.streamingHoursPerDay * 7).toFixed(1)}
                 </dd>

--- a/site/src/components/ReferencesDrawer.tsx
+++ b/site/src/components/ReferencesDrawer.tsx
@@ -58,7 +58,7 @@ export function ReferencesDrawer({ id = 'references', open, onToggle }: Referenc
               onToggle();
             }
           }}
-          className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-700 text-slate-200 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          className="inline-flex h-11 w-11 min-h-[44px] min-w-[44px] items-center justify-center rounded-full border border-slate-600 text-slate-100 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
         >
           <span className="sr-only">{open ? 'Collapse references' : 'Expand references'}</span>
           <svg

--- a/site/src/components/Stacked.tsx
+++ b/site/src/components/Stacked.tsx
@@ -91,7 +91,7 @@ export function Stacked({ title = 'Annual emissions by category', data, referenc
         <h3 id="stacked-heading" className="text-base font-semibold text-slate-100">
           {title}
         </h3>
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Total {formatEmission(total)}</p>
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-300">Total {formatEmission(total)}</p>
       </div>
       <ol role="list" className="mt-5 space-y-3">
         {prepared.map((row, index) => {
@@ -122,7 +122,7 @@ export function Stacked({ title = 'Annual emissions by category', data, referenc
           );
         })}
       </ol>
-      <p className="mt-6 text-xs uppercase tracking-[0.3em] text-slate-500">Annual emissions (adaptive units)</p>
+      <p className="mt-6 text-xs uppercase tracking-[0.3em] text-slate-300">Annual emissions (adaptive units)</p>
     </section>
   );
 }

--- a/site/src/components/StorySection.tsx
+++ b/site/src/components/StorySection.tsx
@@ -87,7 +87,7 @@ export function StorySection({
           <button
             type="button"
             onClick={onRequestReferences}
-            className="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-100 transition hover:border-slate-500 hover:text-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+            className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-slate-600/70 bg-slate-900/60 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-slate-100 transition hover:border-slate-400 hover:text-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
           >
             <span className="h-1.5 w-1.5 rounded-full bg-sky-400" aria-hidden="true" />
             View sources {referenceHint ? <span className="text-slate-400">{referenceHint}</span> : null}

--- a/site/src/components/VizCanvas.tsx
+++ b/site/src/components/VizCanvas.tsx
@@ -291,11 +291,11 @@ export function VizCanvas(): JSX.Element {
         </div>
         <div className="flex items-start justify-end gap-1.5 sm:items-start">
           <div className="hidden sm:flex sm:flex-col sm:items-end">
-            <span className="text-[10px] uppercase tracking-[0.35em] text-slate-500">Status</span>
+            <span className="text-[10px] uppercase tracking-[0.35em] text-slate-300">Status</span>
             <span className={`text-[13px] font-semibold ${statusTone}`} aria-live="polite">
               {statusLabel}
             </span>
-            <span className="mt-0.5 text-[10px] uppercase tracking-[0.35em] text-slate-600">
+            <span className="mt-0.5 text-[10px] uppercase tracking-[0.35em] text-slate-300">
               dataset {datasetVersion}
             </span>
           </div>
@@ -316,7 +316,7 @@ export function VizCanvas(): JSX.Element {
                 <button
                   type="button"
                   onClick={refresh}
-                  className="inline-flex items-center rounded-md border border-rose-400/40 bg-rose-500/20 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.25em] text-rose-50 transition hover:bg-rose-500/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-300"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-md border border-rose-400/60 bg-rose-500/20 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.25em] text-rose-50 transition hover:bg-rose-500/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-300"
                 >
                   Retry
                 </button>
@@ -338,25 +338,25 @@ export function VizCanvas(): JSX.Element {
             <div className="space-y-4">
               <div className="grid gap-2.5 sm:grid-cols-3">
                 <div className="rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
-                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-500">Total emissions</p>
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-300">Total emissions</p>
                   <p className="mt-1.5 text-lg font-semibold text-slate-50">{formatEmission(total)}</p>
-                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-500">
+                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-300">
                     {generatedAt ? `run ${new Date(generatedAt).toLocaleString()}` : 'timestamp pending'}
                   </p>
                 </div>
                 <div className="rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
-                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-500">Activities tracked</p>
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-300">Activities tracked</p>
                   <p className="mt-1.5 text-lg font-semibold text-slate-50">{count}</p>
-                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-500">
+                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-300">
                     showing top contributors
                   </p>
                 </div>
                 <div className="rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
-                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-500">References</p>
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-slate-300">References</p>
                   <p className="mt-1.5 text-lg font-semibold text-slate-50">
                     {referenceCount ?? '—'}
                   </p>
-                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-500">source citations</p>
+                  <p className="mt-1.5 text-[10px] uppercase tracking-[0.35em] text-slate-300">source citations</p>
                 </div>
               </div>
               {hasLayerToggles ? (

--- a/site/src/components/Wizard.tsx
+++ b/site/src/components/Wizard.tsx
@@ -119,7 +119,7 @@ export function Wizard({
           <button
             type="button"
             onClick={onSkip}
-            className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400 transition hover:text-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-slate-200 transition hover:text-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
           >
             Skip
           </button>
@@ -142,14 +142,14 @@ export function Wizard({
           type="button"
           onClick={handleBack}
           disabled={isFirstStep}
-          className="inline-flex items-center justify-center rounded-lg border border-slate-700 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-slate-100 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-500"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-slate-600 px-4 py-2.5 text-xs font-semibold uppercase tracking-[0.25em] text-slate-100 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-400"
         >
           Back
         </button>
         <button
           type="button"
           onClick={handleNext}
-          className="inline-flex items-center justify-center rounded-lg bg-sky-500 px-5 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-slate-900 shadow transition hover:bg-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-sky-500 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.25em] text-slate-900 shadow transition hover:bg-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
         >
           {isLastStep ? finishLabel : 'Next'}
         </button>

--- a/site/src/components/__tests__/__snapshots__/ReferencesDrawer.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/ReferencesDrawer.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`ReferencesDrawer > renders references and closes on escape 1`] = `
       <button
         aria-controls="references-content"
         aria-expanded="true"
-        class="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-700 text-slate-200 transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+        class="inline-flex h-11 w-11 min-h-[44px] min-w-[44px] items-center justify-center rounded-full border border-slate-600 text-slate-100 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
         type="button"
       >
         <span

--- a/site/src/components/__tests__/__snapshots__/Stacked.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/Stacked.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Stacked > renders stacked bars with reference hints 1`] = `
         Annual emissions by category
       </h3>
       <p
-        class="text-xs uppercase tracking-[0.3em] text-slate-500"
+        class="text-xs uppercase tracking-[0.3em] text-slate-300"
       >
         Total 2.00 kg CO₂e
       </p>
@@ -84,7 +84,7 @@ exports[`Stacked > renders stacked bars with reference hints 1`] = `
       </li>
     </ol>
     <p
-      class="mt-6 text-xs uppercase tracking-[0.3em] text-slate-500"
+      class="mt-6 text-xs uppercase tracking-[0.3em] text-slate-300"
     >
       Annual emissions (adaptive units)
     </p>

--- a/site/src/routes/Onboarding.tsx
+++ b/site/src/routes/Onboarding.tsx
@@ -153,7 +153,7 @@ export default function Onboarding(): JSX.Element {
                   aria-valuenow={draft.commuteDaysPerWeek}
                   aria-labelledby="commute-days-label"
                 />
-                <div className="mt-3 flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-500">
+                <div className="mt-3 flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-300">
                   <span id="commute-days-label">Days per week</span>
                   <span className="font-semibold text-slate-200">
                     {formatCommuteDays(draft.commuteDaysPerWeek)}
@@ -170,13 +170,13 @@ export default function Onboarding(): JSX.Element {
                 {COMMUTE_STYLES.map((style) => {
                   const isActive = style.id === selectedCommuteStyleId;
                   return (
-                    <label
-                      key={style.id}
-                      className={`group flex h-full cursor-pointer flex-col justify-between rounded-lg border p-4 text-left text-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 ${
-                        isActive
-                          ? 'border-sky-500 bg-sky-500/10 text-slate-100 shadow-sm shadow-sky-900/40'
-                          : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
-                      }`}
+                  <label
+                    key={style.id}
+                    className={`group flex h-full min-h-[148px] cursor-pointer flex-col justify-between rounded-lg border p-4 text-left text-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 ${
+                      isActive
+                        ? 'border-sky-500 bg-sky-500/10 text-slate-100 shadow-sm shadow-sky-900/40'
+                        : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
+                    }`}
                     >
                       <input
                         type="radio"
@@ -195,7 +195,7 @@ export default function Onboarding(): JSX.Element {
                         <p className="text-sm font-semibold text-slate-100">{style.title}</p>
                         <p className="mt-2 text-xs text-slate-400">{style.summary}</p>
                       </div>
-                      <dl className="mt-4 flex flex-wrap gap-x-2 gap-y-1 text-[11px] uppercase tracking-[0.3em] text-slate-500">
+                      <dl className="mt-4 flex flex-wrap gap-x-2 gap-y-1 text-[11px] uppercase tracking-[0.3em] text-slate-300">
                         <div>
                           <dt className="sr-only">Car</dt>
                           <dd>{style.split.car}% car</dd>
@@ -229,7 +229,7 @@ export default function Onboarding(): JSX.Element {
                 return (
                   <label
                     key={option.id}
-                    className={`group flex h-full cursor-pointer flex-col justify-between rounded-lg border p-4 text-left text-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 ${
+                    className={`group flex h-full min-h-[148px] cursor-pointer flex-col justify-between rounded-lg border p-4 text-left text-sm transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-sky-500 ${
                       isActive
                         ? 'border-sky-500 bg-sky-500/10 text-slate-100 shadow-sm shadow-sky-900/40'
                         : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
@@ -288,7 +288,7 @@ export default function Onboarding(): JSX.Element {
                   aria-valuenow={draft.streamingHoursPerDay}
                   aria-labelledby="streaming-hours-label"
                 />
-                <div className="mt-3 flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-500">
+                <div className="mt-3 flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-300">
                   <span id="streaming-hours-label">Hours per day</span>
                   <span className="font-semibold text-slate-200">
                     {draft.streamingHoursPerDay.toFixed(1)} hours
@@ -321,7 +321,7 @@ export default function Onboarding(): JSX.Element {
                   </span>
                 </li>
               </ul>
-              <p className="mt-3 text-[11px] uppercase tracking-[0.3em] text-slate-500">
+              <p className="mt-3 text-[11px] uppercase tracking-[0.3em] text-slate-300">
                 You can fine-tune all of these from the dashboard later on.
               </p>
             </div>
@@ -355,7 +355,7 @@ export default function Onboarding(): JSX.Element {
           </div>
           <a
             href="/"
-            className="hidden text-xs font-semibold uppercase tracking-[0.25em] text-slate-400 transition hover:text-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 sm:inline-flex"
+            className="hidden min-h-[44px] items-center justify-center rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-slate-200 transition hover:text-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 sm:inline-flex"
           >
             Skip onboarding
           </a>

--- a/site/src/routes/Story.tsx
+++ b/site/src/routes/Story.tsx
@@ -261,18 +261,18 @@ function StoryReferencesDrawer({
             Supporting sources for the story. Press <kbd className="rounded bg-slate-800 px-1">Esc</kbd> to close.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={onToggle}
-          className="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-100 transition hover:border-slate-500 hover:text-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-        >
+          <button
+            type="button"
+            onClick={onToggle}
+            className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/60 px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-slate-100 transition hover:border-slate-500 hover:text-sky-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          >
           <span className="h-1.5 w-1.5 rounded-full bg-sky-400" aria-hidden="true" />
           {open ? 'Hide sources' : 'View sources'}
         </button>
       </div>
       <div hidden={!open} className="mt-6 space-y-4 text-sm text-slate-300">
         {references.length === 0 ? (
-          <p className="text-sm text-slate-500">No references available for this story.</p>
+          <p className="text-sm text-slate-300">No references available for this story.</p>
         ) : (
           <ol className="space-y-3" aria-label="Story references">
             {references.map((reference, index) => (


### PR DESCRIPTION
## Summary
- ensure export controls manage focus, pointer dismissal, and accessible contrast while keeping keyboard-only navigation intact
- raise contrast and enforce 44px minimum touch targets across references drawer, wizard buttons, story controls, and onboarding presets
- update component snapshots to reflect the new accessible styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db4939db44832cb9c7f04f813a979d