### PR TITLE
chore: harden compute worker and add smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,14 @@ jobs:
         run: |
           set -euo pipefail
           make db_init db_import build_db
-          sqlite_outputs="$(python -c \"import json, pathlib; manifest=json.load(open('dist/artifacts/latest-build.json')); artifact_dir=pathlib.Path(manifest['artifact_dir']).expanduser().resolve(); print(artifact_dir / 'calc' / 'outputs')\")"
+          sqlite_outputs="$(python -c \"import json, pathlib; manifest=json.load(open('dist/artifacts/latest-build.json')); artifact_dir=pathlib.Path(manifest['artifact_dir']).expanduser().resolve(); print(str(artifact_dir / 'calc' / 'outputs'))\")"
           if [ ! -d "${sqlite_outputs}" ]; then
             echo "SQLite build outputs not found at ${sqlite_outputs}" >&2
             exit 1
           fi
           echo "SQLITE_OUTPUTS=${sqlite_outputs}" >> "${GITHUB_ENV}"
           make build_csv
-          csv_outputs="$(python -c \"import json, pathlib; manifest=json.load(open('dist/artifacts/latest-build.json')); artifact_dir=pathlib.Path(manifest['artifact_dir']).expanduser().resolve(); print(artifact_dir / 'calc' / 'outputs')\")"
+          csv_outputs="$(python -c \"import json, pathlib; manifest=json.load(open('dist/artifacts/latest-build.json')); artifact_dir=pathlib.Path(manifest['artifact_dir']).expanduser().resolve(); print(str(artifact_dir / 'calc' / 'outputs'))\")"
           if [ ! -d "${csv_outputs}" ]; then
             echo "CSV build outputs not found at ${csv_outputs}" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,47 +48,9 @@ jobs:
         run: |
           set -euo pipefail
           make db_init db_import build_db
-          python - "SQLite" "SQLITE_OUTPUTS" <<'PY'
-import json
-import os
-import pathlib
-import sys
-
-manifest_path = pathlib.Path("dist/artifacts/latest-build.json")
-if not manifest_path.exists():
-    raise SystemExit("latest-build.json not found after database build")
-
-manifest = json.loads(manifest_path.read_text())
-artifact_dir = pathlib.Path(manifest["artifact_dir"]).expanduser().resolve()
-outputs_dir = artifact_dir / "calc" / "outputs"
-if not outputs_dir.is_dir():
-    raise SystemExit(f"{sys.argv[1]} build outputs not found at {outputs_dir}")
-
-print(f"{sys.argv[1]} build outputs: {outputs_dir}")
-with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
-    print(f"{sys.argv[2]}={outputs_dir}", file=env_file)
-PY
+          python tools/record_calc_outputs.py "SQLite" "SQLITE_OUTPUTS"
           make build_csv
-          python - "CSV" "CSV_OUTPUTS" <<'PY'
-import json
-import os
-import pathlib
-import sys
-
-manifest_path = pathlib.Path("dist/artifacts/latest-build.json")
-if not manifest_path.exists():
-    raise SystemExit("latest-build.json not found after CSV build")
-
-manifest = json.loads(manifest_path.read_text())
-artifact_dir = pathlib.Path(manifest["artifact_dir"]).expanduser().resolve()
-outputs_dir = artifact_dir / "calc" / "outputs"
-if not outputs_dir.is_dir():
-    raise SystemExit(f"{sys.argv[1]} build outputs not found at {outputs_dir}")
-
-print(f"{sys.argv[1]} build outputs: {outputs_dir}")
-with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
-    print(f"{sys.argv[2]}={outputs_dir}", file=env_file)
-PY
+          python tools/record_calc_outputs.py "CSV" "CSV_OUTPUTS"
 
       - name: Diff CSV and SQLite outputs
         if: matrix.backend == 'csv'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,34 +48,14 @@ jobs:
         run: |
           set -euo pipefail
           make db_init db_import build_db
-          sqlite_outputs="$(python - <<'PY'
-import json
-from pathlib import Path
-
-manifest_path = Path("dist/artifacts/latest-build.json")
-data = json.loads(manifest_path.read_text())
-artifact_dir = Path(data["artifact_dir"]).expanduser().resolve()
-outputs_dir = artifact_dir / "calc" / "outputs"
-print(outputs_dir)
-PY
-)"
+          sqlite_outputs="$(python -c \"import json, pathlib; manifest=json.load(open('dist/artifacts/latest-build.json')); artifact_dir=pathlib.Path(manifest['artifact_dir']).expanduser().resolve(); print(artifact_dir / 'calc' / 'outputs')\")"
           if [ ! -d "${sqlite_outputs}" ]; then
             echo "SQLite build outputs not found at ${sqlite_outputs}" >&2
             exit 1
           fi
           echo "SQLITE_OUTPUTS=${sqlite_outputs}" >> "${GITHUB_ENV}"
           make build_csv
-          csv_outputs="$(python - <<'PY'
-import json
-from pathlib import Path
-
-manifest_path = Path("dist/artifacts/latest-build.json")
-data = json.loads(manifest_path.read_text())
-artifact_dir = Path(data["artifact_dir"]).expanduser().resolve()
-outputs_dir = artifact_dir / "calc" / "outputs"
-print(outputs_dir)
-PY
-)"
+          csv_outputs="$(python -c \"import json, pathlib; manifest=json.load(open('dist/artifacts/latest-build.json')); artifact_dir=pathlib.Path(manifest['artifact_dir']).expanduser().resolve(); print(artifact_dir / 'calc' / 'outputs')\")"
           if [ ! -d "${csv_outputs}" ]; then
             echo "CSV build outputs not found at ${csv_outputs}" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,19 +48,47 @@ jobs:
         run: |
           set -euo pipefail
           make db_init db_import build_db
-          sqlite_outputs="$(python -c \"import json, pathlib; manifest=json.load(open('dist/artifacts/latest-build.json')); artifact_dir=pathlib.Path(manifest['artifact_dir']).expanduser().resolve(); print(str(artifact_dir / 'calc' / 'outputs'))\")"
-          if [ ! -d "${sqlite_outputs}" ]; then
-            echo "SQLite build outputs not found at ${sqlite_outputs}" >&2
-            exit 1
-          fi
-          echo "SQLITE_OUTPUTS=${sqlite_outputs}" >> "${GITHUB_ENV}"
+          python - "SQLite" "SQLITE_OUTPUTS" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+manifest_path = pathlib.Path("dist/artifacts/latest-build.json")
+if not manifest_path.exists():
+    raise SystemExit("latest-build.json not found after database build")
+
+manifest = json.loads(manifest_path.read_text())
+artifact_dir = pathlib.Path(manifest["artifact_dir"]).expanduser().resolve()
+outputs_dir = artifact_dir / "calc" / "outputs"
+if not outputs_dir.is_dir():
+    raise SystemExit(f"{sys.argv[1]} build outputs not found at {outputs_dir}")
+
+print(f"{sys.argv[1]} build outputs: {outputs_dir}")
+with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+    print(f"{sys.argv[2]}={outputs_dir}", file=env_file)
+PY
           make build_csv
-          csv_outputs="$(python -c \"import json, pathlib; manifest=json.load(open('dist/artifacts/latest-build.json')); artifact_dir=pathlib.Path(manifest['artifact_dir']).expanduser().resolve(); print(str(artifact_dir / 'calc' / 'outputs'))\")"
-          if [ ! -d "${csv_outputs}" ]; then
-            echo "CSV build outputs not found at ${csv_outputs}" >&2
-            exit 1
-          fi
-          echo "CSV_OUTPUTS=${csv_outputs}" >> "${GITHUB_ENV}"
+          python - "CSV" "CSV_OUTPUTS" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+manifest_path = pathlib.Path("dist/artifacts/latest-build.json")
+if not manifest_path.exists():
+    raise SystemExit("latest-build.json not found after CSV build")
+
+manifest = json.loads(manifest_path.read_text())
+artifact_dir = pathlib.Path(manifest["artifact_dir"]).expanduser().resolve()
+outputs_dir = artifact_dir / "calc" / "outputs"
+if not outputs_dir.is_dir():
+    raise SystemExit(f"{sys.argv[1]} build outputs not found at {outputs_dir}")
+
+print(f"{sys.argv[1]} build outputs: {outputs_dir}")
+with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+    print(f"{sys.argv[2]}={outputs_dir}", file=env_file)
+PY
 
       - name: Diff CSV and SQLite outputs
         if: matrix.backend == 'csv'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,55 @@ PY
       - name: Diff backend exports
         run: python tools/diff_exports.py parity/csv/export_view.json parity/duckdb/export_view.json
 
+  compute-smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install site dependencies
+        run: npm --prefix site ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Seed development database
+        run: npm run dev:seed
+
+      - name: Run compute smoke test
+        env:
+          CI: 'true'
+        run: bash scripts/doctor_post_pr13.sh
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-artifacts
+          path: |
+            playwright-report
+            test-results
+          if-no-files-found: ignore
+
+      - name: Upload smoke logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doctor-logs
+          path: /tmp/doctor-post-pr13*.log
+          if-no-files-found: ignore
+
   deploy-pages:
-    needs: [build, backend-parity]
+    needs: [build, backend-parity, compute-smoke]
     if: github.ref == 'refs/heads/main'
     permissions:
       pages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
         run: |
           set -euo pipefail
           make db_init db_import build_db
-          python tools/record_calc_outputs.py "SQLite" "SQLITE_OUTPUTS"
+          python tools/record_calc_outputs.py "SQLite" "SQLITE_OUTPUTS" sqlite
           make build_csv
-          python tools/record_calc_outputs.py "CSV" "CSV_OUTPUTS"
+          python tools/record_calc_outputs.py "CSV" "CSV_OUTPUTS" csv
 
       - name: Diff CSV and SQLite outputs
         if: matrix.backend == 'csv'
@@ -59,7 +59,15 @@ jobs:
           if [ -z "${SQLITE_OUTPUTS:-}" ] && [ -f dist/.calc-outputs/SQLITE_OUTPUTS.path ]; then
             SQLITE_OUTPUTS="$(cat dist/.calc-outputs/SQLITE_OUTPUTS.path)"
           fi
+          if [ -z "${SQLITE_OUTPUTS:-}" ]; then
+            python tools/record_calc_outputs.py "SQLite" "SQLITE_OUTPUTS" sqlite
+            SQLITE_OUTPUTS="$(cat dist/.calc-outputs/SQLITE_OUTPUTS.path)"
+          fi
           if [ -z "${CSV_OUTPUTS:-}" ] && [ -f dist/.calc-outputs/CSV_OUTPUTS.path ]; then
+            CSV_OUTPUTS="$(cat dist/.calc-outputs/CSV_OUTPUTS.path)"
+          fi
+          if [ -z "${CSV_OUTPUTS:-}" ]; then
+            python tools/record_calc_outputs.py "CSV" "CSV_OUTPUTS" csv
             CSV_OUTPUTS="$(cat dist/.calc-outputs/CSV_OUTPUTS.path)"
           fi
           if [ -z "${CSV_OUTPUTS:-}" ] || [ -z "${SQLITE_OUTPUTS:-}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
         if: matrix.backend == 'csv'
         run: |
           set -euo pipefail
+          if [ -z "${SQLITE_OUTPUTS:-}" ] && [ -f dist/.calc-outputs/SQLITE_OUTPUTS.path ]; then
+            SQLITE_OUTPUTS="$(cat dist/.calc-outputs/SQLITE_OUTPUTS.path)"
+          fi
+          if [ -z "${CSV_OUTPUTS:-}" ] && [ -f dist/.calc-outputs/CSV_OUTPUTS.path ]; then
+            CSV_OUTPUTS="$(cat dist/.calc-outputs/CSV_OUTPUTS.path)"
+          fi
           if [ -z "${CSV_OUTPUTS:-}" ] || [ -z "${SQLITE_OUTPUTS:-}" ]; then
             echo "Expected calc/outputs directories for CSV and SQLite builds" >&2
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ calc/outputs/
 .pytest_cache/
 node_modules/
 *.csv~
+acx.db
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Each module is self-documenting with inline comments and docstrings. Start with 
 - Execute the pytest suite: `make test`
 - Run lint + tests together: `make validate`
 - Generate a CycloneDX SBOM: `make sbom`
+- Run the full worker + site smoke test (seeds DB, verifies health, and executes Playwright): `bash scripts/doctor_post_pr13.sh`
 
 ### Production builds
 

--- a/calc/derive.py
+++ b/calc/derive.py
@@ -786,7 +786,10 @@ def export_view(
         normalised["layer_id"] = layer_value
         return normalised
 
-    stacked = [_with_layer_id(entry) for entry in figures.slice_stacked(df, reference_map=stacked_reference_map)]
+    stacked = [
+        _with_layer_id(entry)
+        for entry in figures.slice_stacked(df, reference_map=stacked_reference_map)
+    ]
     bubble_points = [
         _with_layer_id(asdict(point))
         for point in figures.slice_bubble(df, reference_map=bubble_reference_map)

--- a/calc/service.py
+++ b/calc/service.py
@@ -246,7 +246,9 @@ def _build_manifest_payload(
             "emission_factors": sorted(manifest_ef_vintages),
             "grid_intensity": sorted(manifest_grid_vintages),
         },
-        "vintage_matrix": {key: manifest_vintage_matrix[key] for key in sorted(manifest_vintage_matrix)},
+        "vintage_matrix": {
+            key: manifest_vintage_matrix[key] for key in sorted(manifest_vintage_matrix)
+        },
     }
     if layer_citation_keys:
         payload["layer_citation_keys"] = layer_citation_keys
@@ -300,18 +302,14 @@ def compute_profile(
     should_close = datastore is None and hasattr(store, "close")
     try:
         activities = {activity.activity_id: activity for activity in store.load_activities()}
-        emission_factors = {
-            ef.activity_id: ef for ef in store.load_emission_factors()
-        }
+        emission_factors = {ef.activity_id: ef for ef in store.load_emission_factors()}
         profiles = {item.profile_id: item for item in store.load_profiles()}
         profile = _resolve_profile(profiles, profile_id)
 
         grid_lookup, grid_by_region = _collect_grid_maps(store.load_grid_intensity())
 
         schedules = [
-            sched
-            for sched in store.load_activity_schedule()
-            if sched.profile_id == profile_id
+            sched for sched in store.load_activity_schedule() if sched.profile_id == profile_id
         ]
         if not schedules:
             raise ValueError(f"profile {profile_id!r} has no associated schedule rows")
@@ -371,7 +369,9 @@ def compute_profile(
                     "activity_id": sched.activity_id,
                     "layer_id": layer_id,
                     "activity_name": activity.name if isinstance(activity, Activity) else None,
-                    "activity_category": activity.category if isinstance(activity, Activity) else None,
+                    "activity_category": (
+                        activity.category if isinstance(activity, Activity) else None
+                    ),
                     "scope_boundary": ef.scope_boundary if isinstance(ef, EmissionFactor) else None,
                     "emission_factor_vintage_year": (
                         int(ef.vintage_year)
@@ -400,7 +400,9 @@ def compute_profile(
                     "profile": profile,
                     "schedule": sched,
                     "activity_id": sched.activity_id,
-                    "activity_category": activity.category if isinstance(activity, Activity) else None,
+                    "activity_category": (
+                        activity.category if isinstance(activity, Activity) else None
+                    ),
                     "emission_factor": ef,
                     "grid_intensity": grid_row,
                     "annual_emissions_g": emission,
@@ -417,7 +419,9 @@ def compute_profile(
         profile_list = sorted(resolved_profiles)
         layers_sorted = sorted(manifest_layers)
 
-        layer_citation_keys, layer_references = _collect_layer_references(derived_rows, citation_keys)
+        layer_citation_keys, layer_references = _collect_layer_references(
+            derived_rows, citation_keys
+        )
 
         stacked_map, bubble_map, sankey_map = _reference_maps(derived_rows, citation_keys)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1995 @@
+{
+  "name": "carbon-acx-monorepo",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "carbon-acx-monorepo",
+      "version": "0.0.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20240919.0",
+        "@playwright/test": "^1.46.1",
+        "concurrently": "^8.2.2",
+        "typescript": "^5.4.5",
+        "wrangler": "^3.80.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250927.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250927.0.tgz",
+      "integrity": "sha512-XcFVTMNhHROLQ+AbmK6KQuis72iGCdQXrjVl2xX98ac7w3fzUiNfTsu+SKBXN9dSEjgJEhhj0EXSAXh0b8lSww==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20250718.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.1.tgz",
+      "integrity": "sha512-9QAOHVKIVHmnQ1dJT9Fls8aVA8R5JjEizzV889Dinq/+bEPltqIepCvm9Z+fbNUgLvV7D/H1NUk8VdlLRgp9Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/miniflare/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
+    },
+    "node_modules/stacktracey": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
+      "integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.14",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.14.tgz",
+      "integrity": "sha512-zytHJn5+S47sqgUHi71ieSSP44yj9mKsj0sTUCsY+Tw5zbH8EzB1d9JbRk2KHg7HFM1WpoTI7518EExPGenAmg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "carbon-acx-monorepo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev:seed": "python3 scripts/seed_dev_db.py",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240919.0",
+    "@playwright/test": "^1.46.1",
+    "concurrently": "^8.2.2",
+    "typescript": "^5.4.5",
+    "wrangler": "^3.80.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+const SITE_PORT = Number(process.env.PLAYWRIGHT_SITE_PORT ?? 4173);
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 60_000,
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${SITE_PORT}`,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  },
+  webServer: [
+    {
+      command: 'npx wrangler dev --local --persist --port 8787',
+      port: 8787,
+      reuseExistingServer: true,
+      timeout: 60_000
+    },
+    {
+      command: `npm --prefix site run dev -- --host 127.0.0.1 --port ${SITE_PORT}`,
+      port: SITE_PORT,
+      reuseExistingServer: true,
+      timeout: 60_000
+    }
+  ]
+});

--- a/scripts/doctor_post_pr13.sh
+++ b/scripts/doctor_post_pr13.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_FILE="$(mktemp -t doctor-post-pr13.XXXXXX.log)"
+DEV_PID=""
+
+cleanup() {
+  if [[ -n "${DEV_PID}" ]]; then
+    kill "${DEV_PID}" >/dev/null 2>&1 || true
+    wait "${DEV_PID}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+cd "${ROOT_DIR}"
+
+echo "=== env"
+echo "PUBLIC_BASE_PATH=${PUBLIC_BASE_PATH:-/}"
+echo "ACX_DATA_BACKEND=${ACX_DATA_BACKEND:-unset}"
+
+echo "=== wrangler diagnostic"
+if ! npx wrangler whoami >/dev/null 2>&1; then
+  echo "wrangler whoami unavailable (continuing)"
+fi
+if ! npx wrangler versions >/dev/null 2>&1; then
+  echo "wrangler versions unavailable (continuing)"
+fi
+
+echo "=== seed dev DB"
+npm run dev:seed || true
+
+echo "=== start dev (background)"
+set +e
+npx concurrently -k --names "worker,site" --prefix-colors "cyan,magenta" \
+  "npx wrangler dev --local --persist --port 8787" \
+  "npm --prefix site run dev -- --host 127.0.0.1 --port 4173" \
+  >"${LOG_FILE}" 2>&1 &
+DEV_PID=$!
+set -e
+
+sleep 5
+
+echo "=== probe health"
+if ! curl -sS http://127.0.0.1:8787/api/health | jq .; then
+  echo "Health probe failed" >&2
+  exit 1
+fi
+
+echo "=== compute smoke"
+if ! curl -sS -X POST http://127.0.0.1:8787/api/compute \
+  -H 'content-type: application/json' \
+  -d '{"profile_id":"PRO.TO.24_39.HYBRID.2025","overrides":{"MEDIA.STREAM.HD.HOUR":2}}' | jq .; then
+  echo "Compute probe failed" >&2
+  exit 1
+fi
+
+echo "=== playwright e2e"
+npx playwright test tests/e2e/compute.spec.ts
+
+echo "=== DONE"
+echo "Background logs: ${LOG_FILE}"

--- a/scripts/seed_dev_db.py
+++ b/scripts/seed_dev_db.py
@@ -7,63 +7,212 @@ import sqlite3
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-DB_PATH = PROJECT_ROOT / 'acx.db'
-SCHEMA_PATH = PROJECT_ROOT / 'db' / 'schema.sql'
+DB_PATH = PROJECT_ROOT / "acx.db"
+SCHEMA_PATH = PROJECT_ROOT / "db" / "schema.sql"
 
 UNITS = [
-    ('day', 'frequency', 1.0, 'Day'),
-    ('week', 'frequency', 7.0, 'Week'),
-    ('hour', 'duration', 1.0, 'Hour'),
+    ("day", "frequency", 1.0, "Day"),
+    ("week", "frequency", 7.0, "Week"),
+    ("hour", "duration", 1.0, "Hour"),
 ]
 
 SOURCES = [
-    ('SRC.COMMUTE.AUTO', 'Transport Canada. Commuter Vehicle Emissions, 2023.', 'https://tc.canada.ca', 2023, 'CC-BY'),
-    ('SRC.COMMUTE.TRANSIT', 'Canadian Urban Transit Association. Ridership and Emissions Profile, 2023.', None, 2023, 'CC-BY'),
-    ('SRC.COMMUTE.BIKE', 'City of Vancouver. Active Transportation Emissions Study, 2022.', None, 2022, 'CC-BY'),
-    ('SRC.DIET', 'Agriculture and Agri-Food Canada. Diet-based Life Cycle Assessment, 2022.', None, 2022, 'CC-BY'),
-    ('SRC.MEDIA', 'CRTC. Streaming Electricity Intensity in Canadian Households, 2023.', None, 2023, 'CC-BY'),
+    (
+        "SRC.COMMUTE.AUTO",
+        "Transport Canada. Commuter Vehicle Emissions, 2023.",
+        "https://tc.canada.ca",
+        2023,
+        "CC-BY",
+    ),
+    (
+        "SRC.COMMUTE.TRANSIT",
+        "Canadian Urban Transit Association. Ridership and Emissions Profile, 2023.",
+        None,
+        2023,
+        "CC-BY",
+    ),
+    (
+        "SRC.COMMUTE.BIKE",
+        "City of Vancouver. Active Transportation Emissions Study, 2022.",
+        None,
+        2022,
+        "CC-BY",
+    ),
+    (
+        "SRC.DIET",
+        "Agriculture and Agri-Food Canada. Diet-based Life Cycle Assessment, 2022.",
+        None,
+        2022,
+        "CC-BY",
+    ),
+    (
+        "SRC.MEDIA",
+        "CRTC. Streaming Electricity Intensity in Canadian Households, 2023.",
+        None,
+        2023,
+        "CC-BY",
+    ),
 ]
 
 ACTIVITIES = [
-    ('TRAVEL.COMMUTE.CAR.WORKDAY', 'professional', 'Commute', 'Drive to office', 'day'),
-    ('TRAVEL.COMMUTE.TRANSIT.WORKDAY', 'professional', 'Commute', 'Transit to office', 'day'),
-    ('TRAVEL.COMMUTE.BIKE.WORKDAY', 'professional', 'Commute', 'Bike to office', 'day'),
-    ('FOOD.DIET.OMNIVORE.WEEK', 'lifestyle', 'Diet', 'Omnivore diet', 'week'),
-    ('FOOD.DIET.VEGETARIAN.WEEK', 'lifestyle', 'Diet', 'Vegetarian diet', 'week'),
-    ('FOOD.DIET.VEGAN.WEEK', 'lifestyle', 'Diet', 'Vegan diet', 'week'),
-    ('MEDIA.STREAM.HD.HOUR.TV', 'lifestyle', 'Media', 'HD streaming', 'hour'),
+    ("TRAVEL.COMMUTE.CAR.WORKDAY", "professional", "Commute", "Drive to office", "day"),
+    ("TRAVEL.COMMUTE.TRANSIT.WORKDAY", "professional", "Commute", "Transit to office", "day"),
+    ("TRAVEL.COMMUTE.BIKE.WORKDAY", "professional", "Commute", "Bike to office", "day"),
+    ("FOOD.DIET.OMNIVORE.WEEK", "lifestyle", "Diet", "Omnivore diet", "week"),
+    ("FOOD.DIET.VEGETARIAN.WEEK", "lifestyle", "Diet", "Vegetarian diet", "week"),
+    ("FOOD.DIET.VEGAN.WEEK", "lifestyle", "Diet", "Vegan diet", "week"),
+    ("MEDIA.STREAM.HD.HOUR.TV", "lifestyle", "Media", "HD streaming", "hour"),
 ]
 
 EMISSION_FACTORS = [
-    ('EF-COMMUTE-CAR', 'TRAVEL.COMMUTE.CAR.WORKDAY', 'day', 7200.0, 0, None, None, None, None, None, None, None, 'SRC.COMMUTE.AUTO', None, None, None),
-    ('EF-COMMUTE-TRANSIT', 'TRAVEL.COMMUTE.TRANSIT.WORKDAY', 'day', 2100.0, 0, None, None, None, None, None, None, None, 'SRC.COMMUTE.TRANSIT', None, None, None),
-    ('EF-COMMUTE-BIKE', 'TRAVEL.COMMUTE.BIKE.WORKDAY', 'day', 320.0, 0, None, None, None, None, None, None, None, 'SRC.COMMUTE.BIKE', None, None, None),
-    ('EF-DIET-OMNI', 'FOOD.DIET.OMNIVORE.WEEK', 'week', 5400.0, 0, None, None, None, None, None, None, None, 'SRC.DIET', None, None, None),
-    ('EF-DIET-VEG', 'FOOD.DIET.VEGETARIAN.WEEK', 'week', 3600.0, 0, None, None, None, None, None, None, None, 'SRC.DIET', None, None, None),
-    ('EF-DIET-VEGAN', 'FOOD.DIET.VEGAN.WEEK', 'week', 2800.0, 0, None, None, None, None, None, None, None, 'SRC.DIET', None, None, None),
-    ('EF-MEDIA-HD', 'MEDIA.STREAM.HD.HOUR.TV', 'hour', 180.0, 0, None, None, None, None, None, None, None, 'SRC.MEDIA', None, None, None),
+    (
+        "EF-COMMUTE-CAR",
+        "TRAVEL.COMMUTE.CAR.WORKDAY",
+        "day",
+        7200.0,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "SRC.COMMUTE.AUTO",
+        None,
+        None,
+        None,
+    ),
+    (
+        "EF-COMMUTE-TRANSIT",
+        "TRAVEL.COMMUTE.TRANSIT.WORKDAY",
+        "day",
+        2100.0,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "SRC.COMMUTE.TRANSIT",
+        None,
+        None,
+        None,
+    ),
+    (
+        "EF-COMMUTE-BIKE",
+        "TRAVEL.COMMUTE.BIKE.WORKDAY",
+        "day",
+        320.0,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "SRC.COMMUTE.BIKE",
+        None,
+        None,
+        None,
+    ),
+    (
+        "EF-DIET-OMNI",
+        "FOOD.DIET.OMNIVORE.WEEK",
+        "week",
+        5400.0,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "SRC.DIET",
+        None,
+        None,
+        None,
+    ),
+    (
+        "EF-DIET-VEG",
+        "FOOD.DIET.VEGETARIAN.WEEK",
+        "week",
+        3600.0,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "SRC.DIET",
+        None,
+        None,
+        None,
+    ),
+    (
+        "EF-DIET-VEGAN",
+        "FOOD.DIET.VEGAN.WEEK",
+        "week",
+        2800.0,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "SRC.DIET",
+        None,
+        None,
+        None,
+    ),
+    (
+        "EF-MEDIA-HD",
+        "MEDIA.STREAM.HD.HOUR.TV",
+        "hour",
+        180.0,
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "SRC.MEDIA",
+        None,
+        None,
+        None,
+    ),
 ]
 
 PROFILE = (
-    'PRO.TO.24_39.HYBRID.2025',
-    'professional',
-    'Hybrid worker (demo)',
-    'CA-ON',
-    'fixed',
+    "PRO.TO.24_39.HYBRID.2025",
+    "professional",
+    "Hybrid worker (demo)",
+    "CA-ON",
+    "fixed",
     None,
     None,
     3.0,
-    'Seed dataset for local development'
+    "Seed dataset for local development",
 )
 
 SCHEDULE = [
-    ('TRAVEL.COMMUTE.CAR.WORKDAY', None, 1.8),
-    ('TRAVEL.COMMUTE.TRANSIT.WORKDAY', None, 0.9),
-    ('TRAVEL.COMMUTE.BIKE.WORKDAY', None, 0.3),
-    ('FOOD.DIET.OMNIVORE.WEEK', 7.0, None),
-    ('FOOD.DIET.VEGETARIAN.WEEK', 0.0, None),
-    ('FOOD.DIET.VEGAN.WEEK', 0.0, None),
-    ('MEDIA.STREAM.HD.HOUR.TV', None, 10.5),
+    ("TRAVEL.COMMUTE.CAR.WORKDAY", None, 1.8),
+    ("TRAVEL.COMMUTE.TRANSIT.WORKDAY", None, 0.9),
+    ("TRAVEL.COMMUTE.BIKE.WORKDAY", None, 0.3),
+    ("FOOD.DIET.OMNIVORE.WEEK", 7.0, None),
+    ("FOOD.DIET.VEGETARIAN.WEEK", 0.0, None),
+    ("FOOD.DIET.VEGAN.WEEK", 0.0, None),
+    ("MEDIA.STREAM.HD.HOUR.TV", None, 10.5),
 ]
 
 
@@ -80,36 +229,36 @@ def main() -> None:
 
     db = sqlite3.connect(DB_PATH)
     try:
-        db.executescript(SCHEMA_PATH.read_text(encoding='utf-8'))
-        db.execute('PRAGMA user_version = 1')
+        db.executescript(SCHEMA_PATH.read_text(encoding="utf-8"))
+        db.execute("PRAGMA user_version = 1")
 
         _execute_many(
             db,
-            'INSERT INTO units (unit_code, unit_type, si_conversion_factor, notes) VALUES (?, ?, ?, ?)',
+            "INSERT INTO units (unit_code, unit_type, si_conversion_factor, notes) VALUES (?, ?, ?, ?)",
             UNITS,
         )
         _execute_many(
             db,
-            'INSERT INTO sources (source_id, ieee_citation, url, year, license) VALUES (?, ?, ?, ?, ?)',
+            "INSERT INTO sources (source_id, ieee_citation, url, year, license) VALUES (?, ?, ?, ?, ?)",
             SOURCES,
         )
         _execute_many(
             db,
-            'INSERT INTO activities (activity_id, layer_id, category, name, default_unit, description, unit_definition, notes) '
-            'VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL)',
+            "INSERT INTO activities (activity_id, layer_id, category, name, default_unit, description, unit_definition, notes) "
+            "VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL)",
             ACTIVITIES,
         )
         db.execute(
-            'INSERT INTO profiles (profile_id, layer_id, name, region_code_default, grid_strategy, grid_mix_json, cohort_id, '
-            'office_days_per_week, assumption_notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            "INSERT INTO profiles (profile_id, layer_id, name, region_code_default, grid_strategy, grid_mix_json, cohort_id, "
+            "office_days_per_week, assumption_notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             PROFILE,
         )
         _execute_many(
             db,
-            'INSERT INTO emission_factors (ef_id, activity_id, unit, value_g_per_unit, is_grid_indexed, '
-            'electricity_kwh_per_unit, electricity_kwh_per_unit_low, electricity_kwh_per_unit_high, region, scope_boundary, '
-            'gwp_horizon, vintage_year, source_id, method_notes, uncert_low_g_per_unit, uncert_high_g_per_unit) '
-            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            "INSERT INTO emission_factors (ef_id, activity_id, unit, value_g_per_unit, is_grid_indexed, "
+            "electricity_kwh_per_unit, electricity_kwh_per_unit_low, electricity_kwh_per_unit_high, region, scope_boundary, "
+            "gwp_horizon, vintage_year, source_id, method_notes, uncert_low_g_per_unit, uncert_high_g_per_unit) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             EMISSION_FACTORS,
         )
 
@@ -117,7 +266,10 @@ def main() -> None:
             (
                 PROFILE[0],
                 activity_id,
-                next((activity[1] for activity in ACTIVITIES if activity[0] == activity_id), 'professional'),
+                next(
+                    (activity[1] for activity in ACTIVITIES if activity[0] == activity_id),
+                    "professional",
+                ),
                 freq_per_day,
                 freq_per_week,
                 0,
@@ -128,16 +280,16 @@ def main() -> None:
         ]
         _execute_many(
             db,
-            'INSERT INTO activity_schedule (profile_id, activity_id, layer_id, freq_per_day, freq_per_week, '
-            'office_days_only, region_override, schedule_notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            "INSERT INTO activity_schedule (profile_id, activity_id, layer_id, freq_per_day, freq_per_week, "
+            "office_days_only, region_override, schedule_notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             schedule_rows,
         )
 
         db.commit()
-        print(f'Seeded development database at {DB_PATH}')
+        print(f"Seeded development database at {DB_PATH}")
     finally:
         db.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/seed_dev_db.py
+++ b/scripts/seed_dev_db.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Seed a minimal development SQLite database for local compute."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = PROJECT_ROOT / 'acx.db'
+SCHEMA_PATH = PROJECT_ROOT / 'db' / 'schema.sql'
+
+UNITS = [
+    ('day', 'frequency', 1.0, 'Day'),
+    ('week', 'frequency', 7.0, 'Week'),
+    ('hour', 'duration', 1.0, 'Hour'),
+]
+
+SOURCES = [
+    ('SRC.COMMUTE.AUTO', 'Transport Canada. Commuter Vehicle Emissions, 2023.', 'https://tc.canada.ca', 2023, 'CC-BY'),
+    ('SRC.COMMUTE.TRANSIT', 'Canadian Urban Transit Association. Ridership and Emissions Profile, 2023.', None, 2023, 'CC-BY'),
+    ('SRC.COMMUTE.BIKE', 'City of Vancouver. Active Transportation Emissions Study, 2022.', None, 2022, 'CC-BY'),
+    ('SRC.DIET', 'Agriculture and Agri-Food Canada. Diet-based Life Cycle Assessment, 2022.', None, 2022, 'CC-BY'),
+    ('SRC.MEDIA', 'CRTC. Streaming Electricity Intensity in Canadian Households, 2023.', None, 2023, 'CC-BY'),
+]
+
+ACTIVITIES = [
+    ('TRAVEL.COMMUTE.CAR.WORKDAY', 'professional', 'Commute', 'Drive to office', 'day'),
+    ('TRAVEL.COMMUTE.TRANSIT.WORKDAY', 'professional', 'Commute', 'Transit to office', 'day'),
+    ('TRAVEL.COMMUTE.BIKE.WORKDAY', 'professional', 'Commute', 'Bike to office', 'day'),
+    ('FOOD.DIET.OMNIVORE.WEEK', 'lifestyle', 'Diet', 'Omnivore diet', 'week'),
+    ('FOOD.DIET.VEGETARIAN.WEEK', 'lifestyle', 'Diet', 'Vegetarian diet', 'week'),
+    ('FOOD.DIET.VEGAN.WEEK', 'lifestyle', 'Diet', 'Vegan diet', 'week'),
+    ('MEDIA.STREAM.HD.HOUR.TV', 'lifestyle', 'Media', 'HD streaming', 'hour'),
+]
+
+EMISSION_FACTORS = [
+    ('EF-COMMUTE-CAR', 'TRAVEL.COMMUTE.CAR.WORKDAY', 'day', 7200.0, 0, None, None, None, None, None, None, None, 'SRC.COMMUTE.AUTO', None, None, None),
+    ('EF-COMMUTE-TRANSIT', 'TRAVEL.COMMUTE.TRANSIT.WORKDAY', 'day', 2100.0, 0, None, None, None, None, None, None, None, 'SRC.COMMUTE.TRANSIT', None, None, None),
+    ('EF-COMMUTE-BIKE', 'TRAVEL.COMMUTE.BIKE.WORKDAY', 'day', 320.0, 0, None, None, None, None, None, None, None, 'SRC.COMMUTE.BIKE', None, None, None),
+    ('EF-DIET-OMNI', 'FOOD.DIET.OMNIVORE.WEEK', 'week', 5400.0, 0, None, None, None, None, None, None, None, 'SRC.DIET', None, None, None),
+    ('EF-DIET-VEG', 'FOOD.DIET.VEGETARIAN.WEEK', 'week', 3600.0, 0, None, None, None, None, None, None, None, 'SRC.DIET', None, None, None),
+    ('EF-DIET-VEGAN', 'FOOD.DIET.VEGAN.WEEK', 'week', 2800.0, 0, None, None, None, None, None, None, None, 'SRC.DIET', None, None, None),
+    ('EF-MEDIA-HD', 'MEDIA.STREAM.HD.HOUR.TV', 'hour', 180.0, 0, None, None, None, None, None, None, None, 'SRC.MEDIA', None, None, None),
+]
+
+PROFILE = (
+    'PRO.TO.24_39.HYBRID.2025',
+    'professional',
+    'Hybrid worker (demo)',
+    'CA-ON',
+    'fixed',
+    None,
+    None,
+    3.0,
+    'Seed dataset for local development'
+)
+
+SCHEDULE = [
+    ('TRAVEL.COMMUTE.CAR.WORKDAY', None, 1.8),
+    ('TRAVEL.COMMUTE.TRANSIT.WORKDAY', None, 0.9),
+    ('TRAVEL.COMMUTE.BIKE.WORKDAY', None, 0.3),
+    ('FOOD.DIET.OMNIVORE.WEEK', 7.0, None),
+    ('FOOD.DIET.VEGETARIAN.WEEK', 0.0, None),
+    ('FOOD.DIET.VEGAN.WEEK', 0.0, None),
+    ('MEDIA.STREAM.HD.HOUR.TV', None, 10.5),
+]
+
+
+def _execute_many(cursor: sqlite3.Cursor, sql: str, rows: list[tuple[object, ...]]) -> None:
+    cursor.executemany(sql, rows)
+
+
+def main() -> None:
+    if not SCHEMA_PATH.exists():
+        raise SystemExit(f"Schema file not found at {SCHEMA_PATH}")
+
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+
+    db = sqlite3.connect(DB_PATH)
+    try:
+        db.executescript(SCHEMA_PATH.read_text(encoding='utf-8'))
+        db.execute('PRAGMA user_version = 1')
+
+        _execute_many(
+            db,
+            'INSERT INTO units (unit_code, unit_type, si_conversion_factor, notes) VALUES (?, ?, ?, ?)',
+            UNITS,
+        )
+        _execute_many(
+            db,
+            'INSERT INTO sources (source_id, ieee_citation, url, year, license) VALUES (?, ?, ?, ?, ?)',
+            SOURCES,
+        )
+        _execute_many(
+            db,
+            'INSERT INTO activities (activity_id, layer_id, category, name, default_unit, description, unit_definition, notes) '
+            'VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL)',
+            ACTIVITIES,
+        )
+        db.execute(
+            'INSERT INTO profiles (profile_id, layer_id, name, region_code_default, grid_strategy, grid_mix_json, cohort_id, '
+            'office_days_per_week, assumption_notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            PROFILE,
+        )
+        _execute_many(
+            db,
+            'INSERT INTO emission_factors (ef_id, activity_id, unit, value_g_per_unit, is_grid_indexed, '
+            'electricity_kwh_per_unit, electricity_kwh_per_unit_low, electricity_kwh_per_unit_high, region, scope_boundary, '
+            'gwp_horizon, vintage_year, source_id, method_notes, uncert_low_g_per_unit, uncert_high_g_per_unit) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            EMISSION_FACTORS,
+        )
+
+        schedule_rows = [
+            (
+                PROFILE[0],
+                activity_id,
+                next((activity[1] for activity in ACTIVITIES if activity[0] == activity_id), 'professional'),
+                freq_per_day,
+                freq_per_week,
+                0,
+                None,
+                None,
+            )
+            for activity_id, freq_per_week, freq_per_day in SCHEDULE
+        ]
+        _execute_many(
+            db,
+            'INSERT INTO activity_schedule (profile_id, activity_id, layer_id, freq_per_day, freq_per_week, '
+            'office_days_only, region_override, schedule_notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            schedule_rows,
+        )
+
+        db.commit()
+        print(f'Seeded development database at {DB_PATH}')
+    finally:
+        db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/site/public/outputs/baseline.json
+++ b/site/public/outputs/baseline.json
@@ -1,0 +1,264 @@
+{
+  "manifest": {
+    "profile_id": "PRO.TO.24_39.HYBRID.2025",
+    "dataset_version": "dev",
+    "overrides": {},
+    "generated_at": "2025-09-30T04:10:41.404Z",
+    "sources": [
+      "SRC.COMMUTE.AUTO",
+      "SRC.COMMUTE.TRANSIT",
+      "SRC.COMMUTE.BIKE",
+      "SRC.DIET",
+      "SRC.MEDIA"
+    ]
+  },
+  "figures": {
+    "stacked": {
+      "data": [
+        {
+          "category": "Diet",
+          "layer_id": "lifestyle",
+          "values": {
+            "mean": 1965600,
+            "low": 1769040,
+            "high": 2162160
+          }
+        },
+        {
+          "category": "Commute",
+          "layer_id": "professional",
+          "values": {
+            "mean": 777192,
+            "low": 655200,
+            "high": 899184
+          }
+        },
+        {
+          "category": "Media",
+          "layer_id": "lifestyle",
+          "values": {
+            "mean": 98280,
+            "low": 68796,
+            "high": 127764
+          }
+        }
+      ],
+      "citation_keys": [
+        "SRC.COMMUTE.AUTO",
+        "SRC.COMMUTE.TRANSIT",
+        "SRC.COMMUTE.BIKE",
+        "SRC.DIET",
+        "SRC.MEDIA"
+      ]
+    },
+    "bubble": {
+      "data": [
+        {
+          "activity_id": "FOOD.DIET.OMNIVORE.WEEK",
+          "activity_name": "Omnivore diet",
+          "category": "Diet",
+          "layer_id": "lifestyle",
+          "annual_emissions_g": 1965600,
+          "values": {
+            "mean": 1965600,
+            "low": 1769040,
+            "high": 2162160
+          }
+        },
+        {
+          "activity_id": "TRAVEL.COMMUTE.CAR.WORKDAY",
+          "activity_name": "Drive to office",
+          "category": "Commute",
+          "layer_id": "professional",
+          "annual_emissions_g": 673920,
+          "values": {
+            "mean": 673920,
+            "low": 572832,
+            "high": 775008
+          }
+        },
+        {
+          "activity_id": "TRAVEL.COMMUTE.TRANSIT.WORKDAY",
+          "activity_name": "Transit to office",
+          "category": "Commute",
+          "layer_id": "professional",
+          "annual_emissions_g": 98280,
+          "values": {
+            "mean": 98280,
+            "low": 78624,
+            "high": 117936
+          }
+        },
+        {
+          "activity_id": "MEDIA.STREAM.HD.HOUR.TV",
+          "activity_name": "HD streaming",
+          "category": "Media",
+          "layer_id": "lifestyle",
+          "annual_emissions_g": 98280,
+          "values": {
+            "mean": 98280,
+            "low": 68796,
+            "high": 127764
+          }
+        },
+        {
+          "activity_id": "TRAVEL.COMMUTE.BIKE.WORKDAY",
+          "activity_name": "Bike to office",
+          "category": "Commute",
+          "layer_id": "professional",
+          "annual_emissions_g": 4992,
+          "values": {
+            "mean": 4992,
+            "low": 3744,
+            "high": 6240
+          }
+        }
+      ],
+      "citation_keys": [
+        "SRC.COMMUTE.AUTO",
+        "SRC.COMMUTE.TRANSIT",
+        "SRC.COMMUTE.BIKE",
+        "SRC.DIET",
+        "SRC.MEDIA"
+      ]
+    },
+    "sankey": {
+      "data": {
+        "nodes": [
+          {
+            "id": "category-commute",
+            "label": "Commute",
+            "type": "category"
+          },
+          {
+            "id": "activity-travel-commute-car-workday",
+            "label": "Drive to office",
+            "type": "activity"
+          },
+          {
+            "id": "activity-travel-commute-transit-workday",
+            "label": "Transit to office",
+            "type": "activity"
+          },
+          {
+            "id": "activity-travel-commute-bike-workday",
+            "label": "Bike to office",
+            "type": "activity"
+          },
+          {
+            "id": "category-diet",
+            "label": "Diet",
+            "type": "category"
+          },
+          {
+            "id": "activity-food-diet-omnivore-week",
+            "label": "Omnivore diet",
+            "type": "activity"
+          },
+          {
+            "id": "category-media",
+            "label": "Media",
+            "type": "category"
+          },
+          {
+            "id": "activity-media-stream-hd-hour-tv",
+            "label": "HD streaming",
+            "type": "activity"
+          }
+        ],
+        "links": [
+          {
+            "source": "category-commute",
+            "target": "activity-travel-commute-car-workday",
+            "category": "Commute",
+            "layer_id": "professional",
+            "values": {
+              "mean": 673920,
+              "low": 572832,
+              "high": 775008
+            }
+          },
+          {
+            "source": "category-commute",
+            "target": "activity-travel-commute-transit-workday",
+            "category": "Commute",
+            "layer_id": "professional",
+            "values": {
+              "mean": 98280,
+              "low": 78624,
+              "high": 117936
+            }
+          },
+          {
+            "source": "category-commute",
+            "target": "activity-travel-commute-bike-workday",
+            "category": "Commute",
+            "layer_id": "professional",
+            "values": {
+              "mean": 4992,
+              "low": 3744,
+              "high": 6240
+            }
+          },
+          {
+            "source": "category-diet",
+            "target": "activity-food-diet-omnivore-week",
+            "category": "Diet",
+            "layer_id": "lifestyle",
+            "values": {
+              "mean": 1965600,
+              "low": 1769040,
+              "high": 2162160
+            }
+          },
+          {
+            "source": "category-media",
+            "target": "activity-media-stream-hd-hour-tv",
+            "category": "Media",
+            "layer_id": "lifestyle",
+            "values": {
+              "mean": 98280,
+              "low": 68796,
+              "high": 127764
+            }
+          }
+        ]
+      },
+      "citation_keys": [
+        "SRC.COMMUTE.AUTO",
+        "SRC.COMMUTE.TRANSIT",
+        "SRC.COMMUTE.BIKE",
+        "SRC.DIET",
+        "SRC.MEDIA"
+      ]
+    }
+  },
+  "references": [
+    {
+      "key": "SRC.COMMUTE.AUTO",
+      "n": 1,
+      "text": "Transport Canada. Commuter Vehicle Emissions, 2023. https://tc.canada.ca"
+    },
+    {
+      "key": "SRC.COMMUTE.TRANSIT",
+      "n": 2,
+      "text": "Canadian Urban Transit Association. Ridership and Emissions Profile, 2023."
+    },
+    {
+      "key": "SRC.COMMUTE.BIKE",
+      "n": 3,
+      "text": "City of Vancouver. Active Transportation Emissions Study, 2022."
+    },
+    {
+      "key": "SRC.DIET",
+      "n": 4,
+      "text": "Agriculture and Agri-Food Canada. Diet-based Life Cycle Assessment, 2022."
+    },
+    {
+      "key": "SRC.MEDIA",
+      "n": 5,
+      "text": "CRTC. Streaming Electricity Intensity in Canadian Households, 2023."
+    }
+  ],
+  "datasetId": "sha256:fb9c0aa7a501b7047312f0392a6626f1:6c979714"
+}

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,66 +1,93 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { ProfileControls } from './components/ProfileControls';
 import { ReferencesDrawer } from './components/ReferencesDrawer';
 import { Layout } from './components/Layout';
 import { VizCanvas } from './components/VizCanvas';
-import { ProfileProvider } from './state/profile';
+import { ProfileProvider, useProfile } from './state/profile';
 
-export default function App(): JSX.Element {
-  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(() => {
+function OfflineToast(): JSX.Element | null {
+  const { mode } = useProfile();
+  if (mode !== 'static') {
+    return null;
+  }
+  return (
+    <div className="pointer-events-none fixed left-1/2 top-20 z-40 flex -translate-x-1/2 justify-center px-4">
+      <div
+        role="status"
+        aria-live="polite"
+        className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-amber-400/40 bg-amber-500/15 px-4 py-2 text-[13px] font-medium text-amber-100 shadow-lg shadow-amber-900/30"
+      >
+        <span className="h-2 w-2 rounded-full bg-amber-300" aria-hidden="true" />
+        Live compute offline — showing baseline.
+      </div>
+    </div>
+  );
+}
+
+function AppShell(): JSX.Element {
+  const initialDrawerState = useMemo(() => {
     if (typeof window === 'undefined') {
       return true;
     }
     return window.matchMedia('(min-width: 1280px)').matches;
-  });
+  }, []);
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(initialDrawerState);
 
   return (
-    <ProfileProvider>
-      <div className="flex min-h-screen w-screen flex-col bg-slate-950 text-slate-100">
-        <a
-          href="#main"
-          className="absolute left-4 top-4 z-50 -translate-y-20 rounded-lg bg-sky-500 px-3 py-2 font-semibold text-slate-900 transition focus:translate-y-0 focus:outline-none"
-        >
-          Skip to main content
-        </a>
-        <header className="border-b border-slate-800/60 bg-slate-950/70 backdrop-blur">
-          <div className="flex items-center justify-between px-4 py-2.5 sm:px-5 lg:px-6">
-            <div>
-              <p className="text-[10px] uppercase tracking-[0.35em] text-sky-400">Carbon</p>
-              <h1 className="text-base font-semibold">Analysis Console</h1>
-            </div>
-            <button
-              type="button"
-              className="inline-flex items-center gap-1 rounded-lg border border-slate-700 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-slate-100 shadow-sm transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:hidden"
-              aria-expanded={isDrawerOpen}
-              aria-controls="references-panel"
-              onClick={() => setIsDrawerOpen((open) => !open)}
-              onKeyDown={(event) => {
-                if (event.key.toLowerCase() === 'r') {
-                  event.preventDefault();
-                  setIsDrawerOpen((open) => !open);
-                }
-              }}
-            >
-              <span className="h-2 w-2 rounded-full bg-sky-400" aria-hidden="true" />
-              References
-            </button>
+    <div className="flex min-h-screen w-screen flex-col bg-slate-950 text-slate-100">
+      <OfflineToast />
+      <a
+        href="#main"
+        className="absolute left-4 top-4 z-50 -translate-y-20 rounded-lg bg-sky-500 px-3 py-2 font-semibold text-slate-900 transition focus:translate-y-0 focus:outline-none"
+      >
+        Skip to main content
+      </a>
+      <header className="border-b border-slate-800/60 bg-slate-950/70 backdrop-blur">
+        <div className="flex items-center justify-between px-4 py-2.5 sm:px-5 lg:px-6">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.35em] text-sky-400">Carbon</p>
+            <h1 className="text-base font-semibold">Analysis Console</h1>
           </div>
-        </header>
-        <main id="main" className="flex min-h-0 flex-1 flex-col px-4 py-4 sm:px-5 lg:px-6">
-          <Layout
-            controls={<ProfileControls />}
-            canvas={<VizCanvas />}
-            references={
-              <ReferencesDrawer
-                id="references-panel"
-                open={isDrawerOpen}
-                onToggle={() => setIsDrawerOpen((open) => !open)}
-              />
-            }
-          />
-        </main>
-      </div>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded-lg border border-slate-700 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-slate-100 shadow-sm transition hover:border-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:hidden"
+            aria-expanded={isDrawerOpen}
+            aria-controls="references-panel"
+            onClick={() => setIsDrawerOpen((open) => !open)}
+            onKeyDown={(event) => {
+              if (event.key.toLowerCase() === 'r') {
+                event.preventDefault();
+                setIsDrawerOpen((open) => !open);
+              }
+            }}
+          >
+            <span className="h-2 w-2 rounded-full bg-sky-400" aria-hidden="true" />
+            References
+          </button>
+        </div>
+      </header>
+      <main id="main" className="flex min-h-0 flex-1 flex-col px-4 py-4 sm:px-5 lg:px-6">
+        <Layout
+          controls={<ProfileControls />}
+          canvas={<VizCanvas />}
+          references={
+            <ReferencesDrawer
+              id="references-panel"
+              open={isDrawerOpen}
+              onToggle={() => setIsDrawerOpen((open) => !open)}
+            />
+          }
+        />
+      </main>
+    </div>
+  );
+}
+
+export default function App(): JSX.Element {
+  return (
+    <ProfileProvider>
+      <AppShell />
     </ProfileProvider>
   );
 }

--- a/site/src/components/AlertInline.tsx
+++ b/site/src/components/AlertInline.tsx
@@ -1,0 +1,37 @@
+interface AlertInlineProps {
+  tone?: 'info' | 'warning' | 'error' | 'success';
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+const TONE_STYLES: Record<NonNullable<AlertInlineProps['tone']>, string> = {
+  info: 'border-sky-500/40 bg-sky-500/10 text-sky-100',
+  warning: 'border-amber-400/40 bg-amber-500/10 text-amber-50',
+  error: 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+  success: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100'
+};
+
+export function AlertInline({ tone = 'info', message, actionLabel, onAction }: AlertInlineProps): JSX.Element {
+  const baseClass =
+    'flex min-h-[40px] items-center justify-between gap-3 rounded-lg border px-3 py-2 text-[13px] shadow-inner shadow-slate-950/40';
+  const toneClass = TONE_STYLES[tone] ?? TONE_STYLES.info;
+  return (
+    <div
+      className={`${baseClass} ${toneClass}`}
+      role={tone === 'error' ? 'alert' : 'status'}
+      aria-live="polite"
+    >
+      <span className="flex-1 text-left font-medium leading-tight">{message}</span>
+      {actionLabel && onAction ? (
+        <button
+          type="button"
+          onClick={onAction}
+          className="inline-flex h-8 items-center justify-center rounded-md border border-current px-3 text-[11px] font-semibold uppercase tracking-[0.25em] text-inherit transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current"
+        >
+          {actionLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/site/src/components/ProfileControls.tsx
+++ b/site/src/components/ProfileControls.tsx
@@ -102,6 +102,7 @@ export function ProfileControls(): JSX.Element {
                 onChange={(event) => setCommuteDays(Number(event.target.value))}
                 className="w-full accent-sky-500"
                 aria-valuetext={`${controls.commuteDaysPerWeek} commute days per week`}
+                data-testid="days-in-office-slider"
               />
             </label>
             <div className="space-y-2.5">
@@ -121,7 +122,11 @@ export function ProfileControls(): JSX.Element {
               </div>
               <div className="grid gap-2.5 sm:grid-cols-2">
                 {modeSegments.map(({ key, value, metadata }) => (
-                  <div key={key} className="space-y-1.5 rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
+                  <div
+                    key={key}
+                    className="space-y-1.5 rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact"
+                    data-testid={`mode-split-${key}`}
+                  >
                     <div className="flex items-center justify-between gap-1.5">
                       <div>
                         <p className="text-[13px] font-semibold text-slate-100">{metadata.label}</p>
@@ -161,6 +166,7 @@ export function ProfileControls(): JSX.Element {
                           ? 'border-sky-500 bg-sky-500/10 text-slate-100'
                           : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-slate-600'
                       }`}
+                      data-testid={`diet-option-${key}`}
                     >
                       <span className="text-[13px] font-semibold">{copy.label}</span>
                       <span className="text-compact text-slate-400">{copy.helper}</span>

--- a/site/src/components/__tests__/ReferencesDrawer.test.tsx
+++ b/site/src/components/__tests__/ReferencesDrawer.test.tsx
@@ -5,7 +5,10 @@ import { ReferencesDrawer } from '../ReferencesDrawer';
 
 vi.mock('../../state/profile', () => ({
   useProfile: () => ({
-    activeReferences: ['First reference.', 'Second reference.']
+    activeReferences: [
+      { text: 'First reference.', n: 1 },
+      { text: 'Second reference.', n: 2 }
+    ]
   })
 }));
 

--- a/site/src/components/__tests__/__snapshots__/ReferencesDrawer.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/ReferencesDrawer.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`ReferencesDrawer > renders references and closes on escape 1`] = `
       >
         <li
           class="rounded-lg border border-slate-800/70 bg-slate-950/60 pad-compact text-left shadow-inner shadow-slate-900/30"
+          data-testid="reference-item"
         >
           <span
             class="block text-[11px] uppercase tracking-[0.3em] text-sky-400"
@@ -75,6 +76,7 @@ exports[`ReferencesDrawer > renders references and closes on escape 1`] = `
         </li>
         <li
           class="rounded-lg border border-slate-800/70 bg-slate-950/60 pad-compact text-left shadow-inner shadow-slate-900/30"
+          data-testid="reference-item"
         >
           <span
             class="block text-[11px] uppercase tracking-[0.3em] text-sky-400"

--- a/site/src/env.d.ts
+++ b/site/src/env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __PUBLIC_BASE_PATH__: string;

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -2,10 +2,75 @@ export type ComputeRequest = Record<string, unknown>;
 
 export type ComputeOptions = Omit<RequestInit, 'method' | 'body'>;
 
-export async function compute<TResponse = unknown>(
+export interface ReferenceEntry {
+  key?: string;
+  n?: number;
+  text?: string;
+}
+
+export interface ComputeResponse {
+  manifest?: Record<string, unknown>;
+  figures?: Record<string, unknown>;
+  references?: ReferenceEntry[];
+  datasetId?: string;
+  [key: string]: unknown;
+}
+
+export interface HealthResponse {
+  ok: boolean;
+  dataset: string | null;
+  error?: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toReferenceEntry(value: unknown): ReferenceEntry | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const text = typeof value.text === 'string' ? value.text.trim() : null;
+  if (!text) {
+    return null;
+  }
+  const entry: ReferenceEntry = { text };
+  if (typeof value.key === 'string' && value.key.trim()) {
+    entry.key = value.key.trim();
+  }
+  if (typeof value.n === 'number' && Number.isFinite(value.n)) {
+    entry.n = Math.trunc(value.n);
+  }
+  return entry;
+}
+
+export function parseComputeResponse(payload: unknown): ComputeResponse {
+  if (!isRecord(payload)) {
+    throw new Error('Invalid compute response payload');
+  }
+  if (!isRecord(payload.figures)) {
+    throw new Error('Compute response missing figures');
+  }
+  if (typeof payload.datasetId !== 'string' || !payload.datasetId.trim()) {
+    throw new Error('Compute response missing datasetId');
+  }
+
+  const references = Array.isArray(payload.references)
+    ? payload.references
+        .map((entry) => toReferenceEntry(entry))
+        .filter((entry): entry is ReferenceEntry => entry !== null)
+    : [];
+
+  return {
+    ...payload,
+    references
+  } satisfies ComputeResponse;
+}
+
+export async function compute(
   payload: ComputeRequest,
   options: ComputeOptions = {}
-): Promise<TResponse> {
+): Promise<ComputeResponse> {
   const { headers, ...fetchOptions } = options;
   const response = await fetch('/api/compute', {
     method: 'POST',
@@ -17,12 +82,44 @@ export async function compute<TResponse = unknown>(
     ...fetchOptions
   });
 
+  const body = await response.json().catch(() => {
+    throw new Error('Failed to parse compute response');
+  });
+
   if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Request failed with status ${response.status}`);
+    const message = (isRecord(body) && typeof body.error === 'string' && body.error) ||
+      (typeof body === 'string' && body) ||
+      `Request failed with status ${response.status}`;
+    throw new Error(message);
   }
 
-  return (await response.json()) as TResponse;
+  return parseComputeResponse(body);
+}
+
+export async function health(options: RequestInit = {}): Promise<HealthResponse> {
+  const response = await fetch('/api/health', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      ...(options.headers ?? {})
+    },
+    ...options
+  });
+
+  const body = await response.json().catch(() => ({}));
+
+  if (!isRecord(body) || typeof body.ok !== 'boolean') {
+    throw new Error('Health response malformed');
+  }
+
+  const dataset = typeof body.dataset === 'string' ? body.dataset : null;
+  const error = typeof body.error === 'string' ? body.error : null;
+
+  if (!response.ok || !body.ok) {
+    throw new Error(error || `Health check failed with status ${response.status}`);
+  }
+
+  return { ok: true, dataset, error } satisfies HealthResponse;
 }
 
 export type ExportFormat = 'csv' | 'json' | 'txt';

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,10 +1,34 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react-swc';
 
+function normaliseBasePath(value: string | undefined): string {
+  if (!value) {
+    return '/';
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '/';
+  }
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return withLeading.endsWith('/') ? withLeading : `${withLeading}/`;
+}
+
+const publicBasePath = normaliseBasePath(process.env.PUBLIC_BASE_PATH);
+
 export default defineConfig({
+  base: publicBasePath,
+  define: {
+    __PUBLIC_BASE_PATH__: JSON.stringify(publicBasePath)
+  },
   plugins: [react()],
   server: {
-    host: '0.0.0.0'
+    host: '0.0.0.0',
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8787',
+        changeOrigin: true
+      }
+    }
   },
   test: {
     environment: 'jsdom',

--- a/tests/e2e/compute.spec.ts
+++ b/tests/e2e/compute.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const waitForCompute = async (page: Page, action: () => Promise<unknown>) => {
+  await Promise.all([
+    page.waitForResponse((response) =>
+      response.url().includes('/api/compute') && response.request().method() === 'POST'
+    ),
+    action()
+  ]);
+};
+
+test.describe('Compute integration', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('responds to control changes and surfaces references', async ({ page }) => {
+    await page.goto('/');
+
+    const datasetLocator = page.getByTestId('dataset-id');
+    await expect(datasetLocator).toContainText('sha256:');
+
+    const totalLocator = page.getByTestId('total-emissions-value');
+    await expect(totalLocator).toBeVisible();
+    const initialTotal = (await totalLocator.textContent())?.trim() ?? '';
+
+    await waitForCompute(page, () =>
+      page.getByTestId('days-in-office-slider').fill('5')
+    );
+    await expect(totalLocator).not.toHaveText(initialTotal);
+
+    await waitForCompute(page, async () => {
+      await page.getByTestId('diet-option-vegan').click();
+    });
+
+    const referenceItem = page.getByTestId('reference-item').first();
+    await expect(referenceItem).toBeVisible();
+    await expect(referenceItem).toContainText('[');
+  });
+});

--- a/tools/record_calc_outputs.py
+++ b/tools/record_calc_outputs.py
@@ -34,6 +34,11 @@ def main(label: str, env_var: str) -> None:
     with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
         print(f"{env_var}={outputs_dir}", file=env_file)
 
+    cache_dir = pathlib.Path("dist/.calc-outputs")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_file = cache_dir / f"{env_var}.path"
+    cache_file.write_text(f"{outputs_dir}\n", encoding="utf-8")
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:

--- a/tools/record_calc_outputs.py
+++ b/tools/record_calc_outputs.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Resolve calc build outputs from manifest and record them in GITHUB_ENV."""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+from typing import Final
+
+MANIFEST_PATH: Final = pathlib.Path("dist/artifacts/latest-build.json")
+
+
+def main(label: str, env_var: str) -> None:
+    if "GITHUB_ENV" not in os.environ:
+        raise SystemExit("GITHUB_ENV is not set")
+
+    manifest_path = MANIFEST_PATH
+    if not manifest_path.exists():
+        raise SystemExit("latest-build.json not found")
+
+    manifest = json.loads(manifest_path.read_text())
+    try:
+        artifact_dir_raw = manifest["artifact_dir"]
+    except KeyError as exc:  # pragma: no cover - defensive guard for CI
+        raise SystemExit("latest-build manifest missing 'artifact_dir'") from exc
+
+    artifact_dir = pathlib.Path(artifact_dir_raw).expanduser().resolve()
+    outputs_dir = artifact_dir / "calc" / "outputs"
+    if not outputs_dir.is_dir():
+        raise SystemExit(f"{label} build outputs not found at {outputs_dir}")
+
+    print(f"{label} build outputs: {outputs_dir}")
+    with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+        print(f"{env_var}={outputs_dir}", file=env_file)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: record_calc_outputs.py <label> <env-var>")
+    main(sys.argv[1], sys.argv[2])

--- a/workers/compute/index.ts
+++ b/workers/compute/index.ts
@@ -1,12 +1,35 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import { z } from 'zod';
+
 import { computeFigures, getDatasetVersion, OverrideMap } from './runtime';
 
 const JSON_TYPE = 'application/json; charset=utf-8';
 const ALLOWED_ORIGIN = '*';
 
-interface ComputeRequestPayload {
-  profile_id: unknown;
-  overrides: unknown;
+interface Env {
+  DB?: D1Database;
+  ACX_DATA_BACKEND?: string;
+  ACX_DATASET_VERSION?: string;
+  PUBLIC_BASE_PATH?: string;
 }
+
+interface ResolvedBackend {
+  name: 'd1' | 'sqlite';
+  binding: D1Database | null;
+  source: 'binding' | 'file';
+}
+
+const ComputeRequestSchema = z.object({
+  profile_id: z
+    .string({ required_error: 'profile_id is required', invalid_type_error: 'profile_id must be a string' })
+    .trim()
+    .min(1, 'profile_id must be a non-empty string'),
+  overrides: z
+    .record(z.union([z.number(), z.string(), z.null()]), {
+      invalid_type_error: 'overrides must be an object map'
+    })
+    .optional()
+});
 
 function withCors(response: Response): Response {
   const headers = new Headers(response.headers);
@@ -27,29 +50,32 @@ function jsonError(status: number, message: string): Response {
   return jsonResponse({ error: message }, { status });
 }
 
-function normalisePath(pathname: string): string {
-  if (pathname.startsWith('/carbon-acx/')) {
-    return pathname.slice('/carbon-acx'.length);
+function normalisePath(pathname: string, basePath: string): string {
+  if (!basePath || basePath === '/') {
+    return pathname;
+  }
+  if (pathname === basePath) {
+    return '/';
+  }
+  if (pathname.startsWith(`${basePath}/`)) {
+    return pathname.slice(basePath.length);
   }
   return pathname;
 }
 
-function normaliseOverrides(value: unknown): OverrideMap {
-  if (value == null) {
+function normaliseOverrides(value: Record<string, unknown> | undefined): OverrideMap {
+  if (!value) {
     return {};
   }
-  if (typeof value !== 'object' || Array.isArray(value)) {
-    throw new TypeError('overrides must be a JSON object');
-  }
   const overrides: OverrideMap = {};
-  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+  for (const [key, raw] of Object.entries(value)) {
     if (typeof key !== 'string' || key.trim().length === 0) {
       throw new TypeError('override keys must be non-empty strings');
     }
     if (raw == null) {
       continue;
     }
-    const numeric = Number(raw);
+    const numeric = typeof raw === 'string' ? Number.parseFloat(raw) : Number(raw);
     if (!Number.isFinite(numeric)) {
       throw new TypeError(`override value for ${key} must be numeric`);
     }
@@ -58,60 +84,126 @@ function normaliseOverrides(value: unknown): OverrideMap {
   return overrides;
 }
 
-function resolveRequestPayload(payload: ComputeRequestPayload): { profileId: string; overrides: OverrideMap } {
-  const profileId = payload.profile_id;
-  if (typeof profileId !== 'string' || profileId.trim().length === 0) {
-    throw new TypeError('profile_id must be a non-empty string');
+function resolveBackend(env: Env): ResolvedBackend {
+  const specified = env.ACX_DATA_BACKEND?.trim().toLowerCase();
+  if (specified === 'd1') {
+    if (!env.DB) {
+      console.warn('ACX_DATA_BACKEND=d1 but DB binding is missing; falling back to local SQLite file');
+      return { name: 'sqlite', binding: null, source: 'file' };
+    }
+    return { name: 'd1', binding: env.DB, source: 'binding' };
   }
-  const overrides = normaliseOverrides(payload.overrides);
-  return { profileId: profileId.trim(), overrides };
+  if (specified === 'sqlite') {
+    return { name: 'sqlite', binding: env.DB ?? null, source: env.DB ? 'binding' : 'file' };
+  }
+  if (specified && specified.length > 0) {
+    throw new Error(`Unsupported ACX_DATA_BACKEND value: ${specified}`);
+  }
+  if (env.DB) {
+    return { name: 'd1', binding: env.DB, source: 'binding' };
+  }
+  console.warn('No ACX_DATA_BACKEND set and no D1 binding detected; defaulting to local SQLite');
+  return { name: 'sqlite', binding: null, source: 'file' };
 }
 
-async function handleCompute(request: Request): Promise<Response> {
+function resolveDatasetVersion(env: Env): string {
+  const fromEnv = env.ACX_DATASET_VERSION?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return getDatasetVersion();
+}
+
+async function computeDatasetFingerprint(env: Env, backend: ResolvedBackend): Promise<string> {
+  const encoder = new TextEncoder();
+  const datasetVersion = resolveDatasetVersion(env);
+  const source = backend.source === 'binding' ? backend.name : `${backend.name}-fs`;
+  const digestInput = encoder.encode(`${datasetVersion}|${backend.name}|${source}`);
+  const hash = await crypto.subtle.digest('SHA-256', digestInput);
+  const hex = Array.from(new Uint8Array(hash))
+    .map((value) => value.toString(16).padStart(2, '0'))
+    .join('');
+  return `sha256:${hex.slice(0, 32)}`;
+}
+
+async function resolveRequestPayload(request: Request): Promise<{ profileId: string; overrides: OverrideMap }> {
+  let parsed;
+  try {
+    const payload = (await request.json()) as unknown;
+    parsed = ComputeRequestSchema.parse(payload);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const message = error.issues[0]?.message ?? 'invalid payload';
+      throw new TypeError(message);
+    }
+    throw new TypeError(error instanceof Error ? error.message : 'invalid JSON payload');
+  }
+  const overrides = normaliseOverrides(parsed.overrides);
+  return { profileId: parsed.profile_id, overrides };
+}
+
+async function handleCompute(request: Request, env: Env): Promise<Response> {
   if (request.method !== 'POST') {
     return jsonError(405, 'method not allowed');
   }
 
-  let payload: ComputeRequestPayload;
-  try {
-    payload = (await request.json()) as ComputeRequestPayload;
-  } catch (error) {
-    return jsonError(400, error instanceof Error ? error.message : 'invalid JSON payload');
-  }
-
   let context;
   try {
-    context = resolveRequestPayload(payload);
+    context = await resolveRequestPayload(request);
   } catch (error) {
     return jsonError(400, error instanceof Error ? error.message : 'invalid payload');
   }
 
-  const result = computeFigures({ profileId: context.profileId, overrides: context.overrides });
+  const backend = resolveBackend(env);
+  const datasetVersion = resolveDatasetVersion(env);
+  const datasetFingerprint = await computeDatasetFingerprint(env, backend);
+
+  console.log(
+    `[compute] backend=${backend.name} source=${backend.source} dataset=${datasetVersion} fingerprint=${datasetFingerprint}`
+  );
+
+  const result = computeFigures(
+    { profileId: context.profileId, overrides: context.overrides },
+    { datasetVersion, datasetFingerprint, backend: backend.name }
+  );
   return jsonResponse(result, { status: 200 });
 }
 
-function handleHealth(): Response {
-  return jsonResponse({ ok: true, dataset: getDatasetVersion() });
+async function handleHealth(env: Env): Promise<Response> {
+  try {
+    const backend = resolveBackend(env);
+    const datasetFingerprint = await computeDatasetFingerprint(env, backend);
+    const datasetVersion = resolveDatasetVersion(env);
+    console.log(
+      `[health] ok backend=${backend.name} source=${backend.source} dataset=${datasetVersion} fingerprint=${datasetFingerprint}`
+    );
+    return jsonResponse({ ok: true, dataset: datasetFingerprint });
+  } catch (error) {
+    console.error('[health] failed', error);
+    return jsonResponse({ ok: false, dataset: null, error: error instanceof Error ? error.message : 'unknown error' }, { status: 500 });
+  }
 }
 
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request: Request, env: Env): Promise<Response> {
     if (request.method === 'OPTIONS') {
       return withCors(new Response(null, { status: 204 }));
     }
 
     const url = new URL(request.url);
-    const pathname = normalisePath(url.pathname);
+    const basePath = (env.PUBLIC_BASE_PATH ?? '/').replace(/\/+/g, '/').replace(/\/+$|^$/, '');
+    const resolvedBase = basePath.length > 0 ? (basePath.startsWith('/') ? basePath : `/${basePath}`) : '';
+    const pathname = normalisePath(url.pathname, resolvedBase || '/');
 
     if (pathname === '/api/health') {
       if (request.method !== 'GET') {
         return jsonError(405, 'method not allowed');
       }
-      return handleHealth();
+      return handleHealth(env);
     }
 
     if (pathname === '/api/compute') {
-      return handleCompute(request);
+      return handleCompute(request, env);
     }
 
     if (pathname.startsWith('/api/compute/')) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,5 +5,14 @@ compatibility_date = "2024-05-01"
 [vars]
 ACX_DATASET_VERSION = "dev"
 
+routes = [
+  { pattern = "/api/*", script = "compute" }
+]
+
 [dev]
 port = 8787
+
+[[d1_databases]]
+binding = "DB"
+database_name = "acx"
+database_id = "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
## Summary
- harden the compute worker with runtime validation, backend selection, and a health endpoint
- add frontend offline fallback handling, skeleton states, and inline alerts around the visualization canvas
- introduce Playwright smoke coverage with a doctor script, dev database seed, and CI wiring

## Testing
- npm run dev:seed

------
https://chatgpt.com/codex/tasks/task_e_68db4cc2f20c832caf4b8e9351059844