### PR TITLE
Add temporary fetch logging for artifact requests

### DIFF
--- a/site/src/lib/fetchLogger.ts
+++ b/site/src/lib/fetchLogger.ts
@@ -1,0 +1,81 @@
+const ARTIFACT_PATH_PATTERN = /\/artifacts\//;
+
+function resolveUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return new URL(input, window.location.href).toString();
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+}
+
+function cloneRequest(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Request {
+  if (input instanceof Request) {
+    return init ? new Request(input, init) : input;
+  }
+  return new Request(input, init);
+}
+
+export function installFetchLogger(): void {
+  if (typeof window === 'undefined' || typeof window.fetch !== 'function') {
+    return;
+  }
+  const globalWindow = window as typeof window & { __acxFetchLogged?: boolean };
+  if (globalWindow.__acxFetchLogged) {
+    return;
+  }
+  globalWindow.__acxFetchLogged = true;
+
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> => {
+    let request = cloneRequest(input, init);
+
+    const requestUrl = resolveUrl(request);
+    const isArtifactRequest = ARTIFACT_PATH_PATTERN.test(
+      new URL(requestUrl, window.location.href).pathname
+    );
+
+    if (isArtifactRequest) {
+      request = new Request(request, {
+        method: 'GET',
+        cache: 'no-store',
+        mode: 'same-origin'
+      });
+    }
+
+    const method = request.method.toUpperCase();
+    const logPrefix = '[fetch]';
+    // eslint-disable-next-line no-console
+    console.info(`${logPrefix} request`, {
+      url: request.url,
+      method
+    });
+    try {
+      const response = await originalFetch(request);
+      // eslint-disable-next-line no-console
+      console.info(`${logPrefix} response`, {
+        url: request.url,
+        method,
+        status: response.status,
+        contentType: response.headers.get('content-type')
+      });
+      return response;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`${logPrefix} error`, {
+        url: request.url,
+        method,
+        error
+      });
+      throw error;
+    }
+  };
+}

--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
+import { installFetchLogger } from './lib/fetchLogger';
 import App from './App';
 import './index.css';
+
+installFetchLogger();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- wrap the browser fetch implementation with a temporary logger that forces artifact requests to use GET with no-store caching and same-origin mode
- install the fetch logger in the site entrypoint so artifact loads emit URL, method, status, and content-type diagnostics

## Testing
- make package

------
https://chatgpt.com/codex/tasks/task_e_68dbebca4e9c832c95a80742e0d07e5e