### PR TITLE
fix: bundle packaged artifacts and restrict CF Pages methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,11 @@ $(PACKAGED_MANIFEST): $(LATEST_BUILD)
 	PYTHONPATH=. poetry run python -m scripts.package_artifacts --src $(DIST_ARTIFACTS_DIR) --dest $(PACKAGED_ARTIFACTS_DIR)
 
 package: $(PACKAGED_MANIFEST) site sbom
+	PYTHONPATH=. poetry run python -m scripts.prepare_pages_bundle --site $(DIST_SITE_DIR) --artifacts $(PACKAGED_ARTIFACTS_DIR)
 
-ci_build_pages: install lint test site
+ci_build_pages: install lint test package
 
-build-static: site
+build-static: package
 	@echo "Static site available at $(DIST_SITE_DIR)"
 
 app:

--- a/README.md
+++ b/README.md
@@ -182,16 +182,18 @@ The Dash app reads from `calc/outputs` (or a custom `ACX_ARTIFACT_DIR`) and rend
 Render and preview the static site without a live server:
 
 ```bash
-make site
-python -m http.server --directory build/site 8001
+make package
+python -m http.server --directory dist/site 8001
 ```
 
-The build embeds:
+The packaged bundle embeds:
 
 - Pre-rendered Plotly HTML snippets for each figure.
 - Disclosure panel, manifest summary, and grid vintage table.
-- Download links pointing to the packaged artefacts under `build/site/data/`.
+- Download links pointing to the packaged artefacts under `dist/site/artifacts/`.
 - IEEE reference list identical to the Dash experience.
+- Cloudflare Pages metadata (`_headers`, `_redirects`) to configure caching and
+  trailing-slash redirects for `/carbon-acx`.
 
 When ready for production, deploy the contents of `dist/site/` to Cloudflare Pages. The companion function under `functions/carbon-acx/[[path]].ts` can proxy `/carbon-acx/*` routes to the hosted bundle or an upstream origin when `CARBON_ACX_ORIGIN` is set.
 
@@ -235,7 +237,7 @@ Additional configuration:
 ## Build & deployment
 
 1. **Local build** — `make build` -> `dist/artifacts/<hash>` -> `make site` -> `build/site` -> `make package` -> `dist/packaged-artifacts` + `dist/site`.
-2. **Continuous integration** — The CI workflow (replicated by `make ci_build_pages`) runs install, lint, test, and `make build-static`, publishing two artefacts: `dist-artifacts` (data bundle) and `dist-site` (static client).
+2. **Continuous integration** — The CI workflow (replicated by `make ci_build_pages`) runs install, lint, test, and packages the static site (`make package`), publishing two artefacts: `dist-artifacts` (data bundle) and `dist-site` (static client).
 3. **Release** — `make release` is a placeholder for future automated releases; production deploys currently upload `dist/site/` to Cloudflare Pages manually or via upstream automation described in `docs/deploy.md`.
 4. **Routing** — `functions/carbon-acx/[[path]].ts` sits alongside the static bundle to proxy or serve `/carbon-acx/*` traffic with opinionated caching headers (see `docs/routes.md`).
 
@@ -260,7 +262,7 @@ Quality gates are enforced through pytest, ruff, black, and SBOM generation:
 Before submitting a change:
 
 ```bash
-make format lint test build site package
+make format lint test build package
 ```
 
 ---

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -11,18 +11,23 @@ served from the `/carbon-acx` path by the main Carbonplan site.
    ```
 2. Produce fresh derived data artifacts and the static site bundle:
    ```bash
-   make build-static
+   make package
    ```
 
-This command runs the standard data build and emits the static site to
-`dist/site/`. The directory contains:
+This command runs the standard data build, packages distributable artefacts,
+and emits the static site to `dist/site/`. The directory contains:
 
 - `index.html` – the single-page application shell.
 - `200.html` – a copy of `index.html` used by Cloudflare Pages for SPA
   fallback routing.
 - asset files (CSS, fonts, JavaScript) required by the client.
-- a `data/` folder that mirrors the contents of `dist/artifacts/`, allowing the
-  client to serve JSON/CSV artifacts relative to the deployed path.
+- an `artifacts/` folder that mirrors the packaged outputs, allowing the
+  production deployment to serve JSON/CSV downloads relative to
+  `/carbon-acx/artifacts/*`.
+- a `_headers` file that configures Cloudflare Pages caching (`index.html`
+  served with `Cache-Control: no-cache`, immutable caching for
+  `/artifacts/*`).
+- a `_redirects` file that forces `/carbon-acx` to `/carbon-acx/`.
 
 All asset links are written as relative paths, so the bundle can be mounted at
 `/carbon-acx` without additional rewrites.
@@ -32,4 +37,4 @@ All asset links are written as relative paths, so the bundle can be mounted at
 Upload the contents of `dist/site/` to a Cloudflare Pages project. The main
 Carbonplan site proxies requests under `/carbon-acx/*` to this bundle, so the
 relative asset paths must remain intact. If you add new artifact files to the
-build, confirm that they appear under `dist/site/data/` before deploying.
+build, confirm that they appear under `dist/site/artifacts/` before deploying.

--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -1,7 +1,18 @@
+const ALLOWED_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
 export const onRequest: PagesFunction<{
   CARBON_ACX_ORIGIN: string | undefined;
 }> = async (ctx) => {
   const { request, env, next } = ctx;
+  const method = request.method.toUpperCase();
+
+  if (!ALLOWED_METHODS.has(method)) {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD, OPTIONS" },
+    });
+  }
+
   const reqUrl = new URL(request.url);
 
   const suffix = reqUrl.pathname.replace(/^\/carbon-acx/, "") + (reqUrl.search || "");
@@ -11,9 +22,8 @@ export const onRequest: PagesFunction<{
   if (origin) {
     const target = origin + (suffix || "/");
     const init: RequestInit = {
-      method: request.method,
+      method,
       headers: request.headers,
-      body: request.body,
     };
     const resp = await fetch(new Request(target, init));
     const out = new Response(resp.body, resp);

--- a/scripts/prepare_pages_bundle.py
+++ b/scripts/prepare_pages_bundle.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import textwrap
+from pathlib import Path
+
+HEADERS_TEMPLATE = textwrap.dedent(
+    """
+    /index.html
+      Cache-Control: no-cache
+
+    /artifacts/*
+      Cache-Control: public, max-age=31536000, immutable
+      Content-Type: application/json; charset=utf-8
+    """
+).strip() + "\n"
+
+REDIRECTS_TEMPLATE = "/carbon-acx\t/carbon-acx/\t301\n"
+
+
+def _write_headers(site_root: Path) -> None:
+    headers_path = site_root / "_headers"
+    headers_path.write_text(HEADERS_TEMPLATE, encoding="utf-8")
+
+
+def _write_redirects(site_root: Path) -> None:
+    redirects_path = site_root / "_redirects"
+    redirects_path.write_text(REDIRECTS_TEMPLATE, encoding="utf-8")
+
+
+def prepare_pages_bundle(site_root: Path, artifacts_dir: Path) -> None:
+    """Copy packaged artefacts into the static bundle and emit Pages metadata."""
+
+    if not site_root.is_dir():
+        raise FileNotFoundError(f"Static site directory not found: {site_root}")
+
+    if not artifacts_dir.is_dir():
+        raise FileNotFoundError(f"Packaged artefacts directory not found: {artifacts_dir}")
+
+    target = site_root / "artifacts"
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(artifacts_dir, target)
+
+    _write_headers(site_root)
+    _write_redirects(site_root)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare the Cloudflare Pages bundle with artefacts and metadata.",
+    )
+    parser.add_argument(
+        "--site",
+        type=Path,
+        default=Path("dist/site"),
+        help="Path to the built static site root (default: dist/site)",
+    )
+    parser.add_argument(
+        "--artifacts",
+        type=Path,
+        default=Path("dist/packaged-artifacts"),
+        help="Directory containing packaged artefacts to publish",
+    )
+    args = parser.parse_args()
+
+    prepare_pages_bundle(args.site, args.artifacts)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_prepare_pages_bundle.py
+++ b/tests/test_prepare_pages_bundle.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.prepare_pages_bundle import HEADERS_TEMPLATE, REDIRECTS_TEMPLATE, prepare_pages_bundle
+
+
+def _write_site_stub(site_root: Path) -> None:
+    site_root.mkdir(parents=True, exist_ok=True)
+    # create placeholder to ensure the copy step replaces existing content
+    old_headers = site_root / "_headers"
+    old_headers.write_text("stale", encoding="utf-8")
+    stale_artifact = site_root / "artifacts"
+    stale_artifact.mkdir()
+    (stale_artifact / "old.json").write_text("{}", encoding="utf-8")
+
+
+def _write_artifacts_stub(artifacts_dir: Path) -> None:
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    (artifacts_dir / "manifest.json").write_text("{\"generated_at\": \"2024-01-01T00:00:00Z\"}", encoding="utf-8")
+    nested = artifacts_dir / "figures"
+    nested.mkdir()
+    (nested / "stacked.json").write_text("{}", encoding="utf-8")
+
+
+def test_prepare_pages_bundle_copies_artifacts_and_metadata(tmp_path: Path) -> None:
+    site_root = tmp_path / "dist" / "site"
+    artifacts_dir = tmp_path / "dist" / "packaged-artifacts"
+
+    _write_site_stub(site_root)
+    _write_artifacts_stub(artifacts_dir)
+
+    prepare_pages_bundle(site_root, artifacts_dir)
+
+    copied_manifest = (site_root / "artifacts" / "manifest.json").read_text(encoding="utf-8")
+    assert "generated_at" in copied_manifest
+
+    headers_content = (site_root / "_headers").read_text(encoding="utf-8")
+    assert headers_content == HEADERS_TEMPLATE
+
+    redirects_content = (site_root / "_redirects").read_text(encoding="utf-8")
+    assert redirects_content == REDIRECTS_TEMPLATE
+
+
+def test_prepare_pages_bundle_requires_directories(tmp_path: Path) -> None:
+    site_root = tmp_path / "missing-site"
+    artifacts_dir = tmp_path / "missing-artifacts"
+
+    with pytest.raises(FileNotFoundError):
+        prepare_pages_bundle(site_root, artifacts_dir)
+
+    site_root.mkdir()
+    with pytest.raises(FileNotFoundError):
+        prepare_pages_bundle(site_root, artifacts_dir)


### PR DESCRIPTION
## Summary
- restrict the Cloudflare Pages function to GET/HEAD/OPTIONS and stop forwarding request bodies
- add a `prepare_pages_bundle` utility that copies packaged artefacts into the static bundle and writes `_headers`/`_redirects`, wiring it into the Makefile and deployment docs
- document the updated deployment flow and cover the bundling helper with unit tests

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbf8af41a4832c90ce2bf60e94410e