### PR TITLE
fix: allow artifact preflights and purge stale service workers

### DIFF
--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -1,4 +1,10 @@
 const ALLOWED_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "https://boot.industries",
+  "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Max-Age": "86400"
+};
 
 export const onRequest: PagesFunction<{
   CARBON_ACX_ORIGIN: string | undefined;
@@ -11,6 +17,10 @@ export const onRequest: PagesFunction<{
       status: 405,
       headers: { Allow: "GET, HEAD, OPTIONS" },
     });
+  }
+
+  if (method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
 
   const reqUrl = new URL(request.url);
@@ -31,6 +41,9 @@ export const onRequest: PagesFunction<{
       "Cache-Control",
       out.headers.get("Cache-Control") || "public, max-age=86400, s-maxage=86400",
     );
+    for (const [key, value] of Object.entries(CORS_HEADERS)) {
+      out.headers.set(key, value);
+    }
     return out;
   }
 

--- a/scripts/prepare_pages_bundle.py
+++ b/scripts/prepare_pages_bundle.py
@@ -13,6 +13,9 @@ HEADERS_TEMPLATE = textwrap.dedent(
     /artifacts/*
       Cache-Control: public, max-age=31536000, immutable
       Content-Type: application/json; charset=utf-8
+      Access-Control-Allow-Origin: https://boot.industries
+      Access-Control-Allow-Methods: GET, HEAD, OPTIONS
+      Access-Control-Allow-Headers: Content-Type
     """
 ).strip() + "\n"
 

--- a/site/src/lib/fetchLogger.ts
+++ b/site/src/lib/fetchLogger.ts
@@ -1,4 +1,6 @@
 const ARTIFACT_PATH_PATTERN = /\/artifacts\//;
+const ARTIFACT_CACHE_PARAM = 'acx-cache';
+const ARTIFACT_CACHE_VERSION = '2';
 
 function resolveUrl(input: RequestInfo | URL): string {
   if (typeof input === 'string') {
@@ -44,10 +46,20 @@ export function installFetchLogger(): void {
     );
 
     if (isArtifactRequest) {
-      request = new Request(request, {
+      const artifactUrl = new URL(requestUrl, window.location.href);
+      artifactUrl.searchParams.set(ARTIFACT_CACHE_PARAM, ARTIFACT_CACHE_VERSION);
+      request = new Request(artifactUrl.toString(), {
         method: 'GET',
         cache: 'no-store',
-        mode: 'same-origin'
+        mode: 'same-origin',
+        credentials: request.credentials,
+        headers: new Headers(request.headers),
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        integrity: request.integrity,
+        keepalive: request.keepalive,
+        signal: request.signal
       });
     }
 

--- a/site/src/lib/purgeServiceWorkers.ts
+++ b/site/src/lib/purgeServiceWorkers.ts
@@ -1,0 +1,60 @@
+const DEBUG_STORAGE_KEY = 'acx:debug:purge-sw';
+const PURGE_STATE_KEY = 'acx:sw-purge:v20240501';
+
+function debugFlagEnabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (import.meta.env.VITE_DEBUG_PURGE_SERVICE_WORKERS === 'true') {
+    return true;
+  }
+
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('purge-sw') === '1') {
+      window.localStorage.setItem(DEBUG_STORAGE_KEY, '1');
+      return true;
+    }
+    return window.localStorage.getItem(DEBUG_STORAGE_KEY) === '1';
+  } catch (error) {
+    console.warn('[acx] Unable to evaluate service worker purge flag', error);
+    return false;
+  }
+}
+
+export function purgeStaleServiceWorkersOnce(): void {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  const shouldPurge = debugFlagEnabled();
+  if (!shouldPurge) {
+    return;
+  }
+
+  let alreadyPurged = false;
+  try {
+    alreadyPurged = window.localStorage.getItem(PURGE_STATE_KEY) === 'done';
+  } catch (error) {
+    console.warn('[acx] Unable to read purge state', error);
+  }
+
+  if (alreadyPurged) {
+    return;
+  }
+
+  navigator.serviceWorker
+    .getRegistrations()
+    .then((registrations) => Promise.all(registrations.map((registration) => registration.unregister())))
+    .then(() => {
+      try {
+        window.localStorage.setItem(PURGE_STATE_KEY, 'done');
+      } catch (error) {
+        console.warn('[acx] Unable to persist purge state', error);
+      }
+    })
+    .catch((error) => {
+      console.warn('[acx] Failed to purge service workers', error);
+    });
+}

--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import { installFetchLogger } from './lib/fetchLogger';
+import { purgeStaleServiceWorkersOnce } from './lib/purgeServiceWorkers';
 import App from './App';
 import './index.css';
 
 installFetchLogger();
+purgeStaleServiceWorkersOnce();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- emit CORS headers for artifact files and respond to OPTIONS requests in the Pages function
- add a cache-busting query parameter to artifact fetches and gate a one-time service-worker purge behind a debug flag
- initialise the purge helper during client bootstrap so stale workers are cleared when debugging

## Testing
- pytest tests/test_prepare_pages_bundle.py
- npm --prefix site run build

------
https://chatgpt.com/codex/tasks/task_e_68dc2fc07934832ca73745f31462e1d4