### PR TITLE
docs(conventions): codify ACX↔CDX↔PR lineage + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,16 @@
-## **PR {{number}} — {{short title}}**
+## Traceability
+Implements (spec): ACX###
+Prompt (execution): CDX###
+Related issues/tickets: #
 
-**Title:** <!-- Conventional commit-style summary -->
+## Summary
+- What changed:
+- Why:
 
-**Intent:** <!-- What outcome or policy change are we targeting? -->
+## Data/Sources
+- New sources.csv rows? (y/n)
+- IEEE references added/updated:
 
-**Changes:**
-- <!-- Bullet list of notable updates -->
-
-**Sources & References (required, include links):**
-- <!-- Cite datasets, reports, tickets, and include URLs wherever possible -->
-
-**Source IDs (required):**
-- <!-- List every `source_id` added or consumed in this PR -->
-
-**Scope Notes (required):**
-- <!-- Clarify anything intentionally out-of-scope or deferred -->
-
-**Vintage Notes (required):**
-- <!-- List relevant data vintages, refresh cadence, or sunset expectations -->
-
-**Affects Regions (check all that apply):**
-- [ ] AMER
-- [ ] EMEA
-- [ ] APAC
-- [ ] Global / Multi-region
-
-**ACX015 Seeding Checklist:**
-- [ ] Source IDs above follow the sources-first / null-first protocol
-- [ ] Inputs conform to seeding rules (no hidden migrations or drift)
-- [ ] QA artifacts updated or attached
-- [ ] Branch ready for CODEOWNERS review gate
+## Tests
+- [ ] make validate passes
+- [ ] pytest passes

--- a/README.md
+++ b/README.md
@@ -353,3 +353,7 @@ Legend: ✅ implemented · 🚧 in-progress or partially scaffolded · 🧭 plan
 
 _Note: To satisfy repo hygiene tests, avoid using the contiguous token spelled “F a s t A P I” in docs._
 
+
+### Serials & Traceability
+
+Refer to [docs/CONTRIBUTING_SERIES.md](docs/CONTRIBUTING_SERIES.md) for guidance on citing ACX specifications, CDX prompts, and the PR lineage required for every contribution.

--- a/docs/CONTRIBUTING_SERIES.md
+++ b/docs/CONTRIBUTING_SERIES.md
@@ -1,0 +1,15 @@
+# Contributing Series
+
+## Purpose
+The contributing series documents how changes trace back to their originating specifications, prompts, and review artifacts. It helps reviewers and maintainers verify that every change cites the governing spec and the execution prompt responsible for the implementation.
+
+## Serial systems
+ACX### identifiers reference written specifications, while CDX### identifiers reference execution prompts, typically used for agent workflows. Pull request numbers (`#123`) remain GitHub's canonical change artifact. ACX### identifies specs; CDX### identifies prompts; PR # is GitHub’s artifact. Every PR must include both ACX and CDX where applicable.
+
+## How to cite ACX/CDX in commits/PRs
+Include both the applicable ACX and CDX serials in commit messages and pull request summaries. Reference the PR number once GitHub assigns it, ensuring the triad (ACX, CDX, PR #) can be cross-referenced. For follow-up commits, continue citing the same ACX/CDX pair unless a new spec or prompt supersedes them.
+
+## Examples
+- Commit message: `docs(conventions): codify lineage metadata (CDX001, implements ACX017)`
+- Pull request summary: `Implements (spec): ACX017` and `Prompt (execution): CDX001`
+- Follow-up hotfix: `fix(conventions): correct lineage appendix link (CDX001, implements ACX017)`


### PR DESCRIPTION
## Summary
- document how ACX specifications, CDX prompts, and GitHub PRs align in docs/CONTRIBUTING_SERIES.md
- replace the pull request template with a traceability block that captures ACX and CDX serials plus validation checks
- append a README appendix pointing contributors to the new traceability guidance

## Testing
- git grep -n "Traceability" .github/pull_request_template.md
- make validate

------
https://chatgpt.com/codex/tasks/task_e_68dc31e93448832c82e19564a2b7dc50