### PR TITLE
data(schema): scaffold entities/sites/assets/operations registries

### DIFF
--- a/calc/dal/__init__.py
+++ b/calc/dal/__init__.py
@@ -4,7 +4,17 @@ import os
 from pathlib import Path
 from typing import Protocol, Sequence
 
-from ..schema import Activity, ActivitySchedule, EmissionFactor, GridIntensity, Profile
+from ..schema import (
+    Activity,
+    ActivitySchedule,
+    Asset,
+    EmissionFactor,
+    Entity,
+    GridIntensity,
+    Operation,
+    Profile,
+    Site,
+)
 from .csv import CsvStore
 from .duckdb import DuckDbStore
 from ..dal_sql import SqlStore
@@ -12,18 +22,30 @@ from ..dal_sql import SqlStore
 __all__ = [
     "Activity",
     "ActivitySchedule",
+    "Asset",
     "CsvStore",
     "DataStore",
     "DuckDbStore",
     "EmissionFactor",
+    "Entity",
     "GridIntensity",
+    "Operation",
     "Profile",
+    "Site",
     "SqlStore",
     "choose_backend",
 ]
 
 
 class DataStore(Protocol):
+    def load_entities(self) -> Sequence[Entity]: ...
+
+    def load_sites(self) -> Sequence[Site]: ...
+
+    def load_assets(self) -> Sequence[Asset]: ...
+
+    def load_operations(self) -> Sequence[Operation]: ...
+
     def load_activities(self) -> Sequence[Activity]: ...
 
     def load_emission_factors(self) -> Sequence[EmissionFactor]: ...

--- a/calc/dal/csv.py
+++ b/calc/dal/csv.py
@@ -5,7 +5,17 @@ from typing import List, Sequence
 
 import pandas as pd
 
-from ..schema import Activity, ActivitySchedule, EmissionFactor, GridIntensity, Profile
+from ..schema import (
+    Activity,
+    ActivitySchedule,
+    Asset,
+    EmissionFactor,
+    Entity,
+    GridIntensity,
+    Operation,
+    Profile,
+    Site,
+)
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 
@@ -18,6 +28,22 @@ def _load_csv(path: Path) -> List[dict]:
 
 class CsvStore:
     """CSV-backed implementation of DataStore."""
+
+    def load_entities(self) -> Sequence[Entity]:
+        rows = _load_csv(DATA_DIR / "entities.csv")
+        return [Entity(**row) for row in rows]
+
+    def load_sites(self) -> Sequence[Site]:
+        rows = _load_csv(DATA_DIR / "sites.csv")
+        return [Site(**row) for row in rows]
+
+    def load_assets(self) -> Sequence[Asset]:
+        rows = _load_csv(DATA_DIR / "assets.csv")
+        return [Asset(**row) for row in rows]
+
+    def load_operations(self) -> Sequence[Operation]:
+        rows = _load_csv(DATA_DIR / "operations.csv")
+        return [Operation(**row) for row in rows]
 
     def load_activities(self) -> Sequence[Activity]:
         rows = _load_csv(DATA_DIR / "activities.csv")

--- a/calc/dal/duckdb.py
+++ b/calc/dal/duckdb.py
@@ -8,7 +8,17 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - handled lazily
     duckdb = None
 
-from ..schema import Activity, ActivitySchedule, EmissionFactor, GridIntensity, Profile
+from ..schema import (
+    Activity,
+    ActivitySchedule,
+    Asset,
+    EmissionFactor,
+    Entity,
+    GridIntensity,
+    Operation,
+    Profile,
+    Site,
+)
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 
@@ -53,6 +63,22 @@ class DuckDbStore:
             }
             payload.append(record)
         return payload
+
+    def load_entities(self) -> Sequence[Entity]:
+        rows = self._load("entities.csv")
+        return [Entity(**row) for row in rows]
+
+    def load_sites(self) -> Sequence[Site]:
+        rows = self._load("sites.csv")
+        return [Site(**row) for row in rows]
+
+    def load_assets(self) -> Sequence[Asset]:
+        rows = self._load("assets.csv")
+        return [Asset(**row) for row in rows]
+
+    def load_operations(self) -> Sequence[Operation]:
+        rows = self._load("operations.csv")
+        return [Operation(**row) for row in rows]
 
     def load_activities(self) -> Sequence[Activity]:
         rows = self._load("activities.csv")

--- a/calc/dal_sql.py
+++ b/calc/dal_sql.py
@@ -10,7 +10,17 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - handled lazily
     duckdb = None
 
-from .schema import Activity, ActivitySchedule, EmissionFactor, GridIntensity, Profile
+from .schema import (
+    Activity,
+    ActivitySchedule,
+    Asset,
+    EmissionFactor,
+    Entity,
+    GridIntensity,
+    Operation,
+    Profile,
+    Site,
+)
 
 _PLACEHOLDER_NOTE = "__IMPORT_PLACEHOLDER__"
 
@@ -126,6 +136,18 @@ class SqlStore:
             """
         )
         return [GridIntensity(**row) for row in rows]
+
+    def load_entities(self) -> Sequence[Entity]:
+        return []
+
+    def load_sites(self) -> Sequence[Site]:
+        return []
+
+    def load_assets(self) -> Sequence[Asset]:
+        return []
+
+    def load_operations(self) -> Sequence[Operation]:
+        return []
 
     def __enter__(self) -> "SqlStore":
         return self

--- a/calc/derive.py
+++ b/calc/derive.py
@@ -786,7 +786,10 @@ def export_view(
         normalised["layer_id"] = layer_value
         return normalised
 
-    stacked = [_with_layer_id(entry) for entry in figures.slice_stacked(df, reference_map=stacked_reference_map)]
+    stacked = [
+        _with_layer_id(entry)
+        for entry in figures.slice_stacked(df, reference_map=stacked_reference_map)
+    ]
     bubble_points = [
         _with_layer_id(asdict(point))
         for point in figures.slice_bubble(df, reference_map=bubble_reference_map)

--- a/calc/service.py
+++ b/calc/service.py
@@ -246,7 +246,9 @@ def _build_manifest_payload(
             "emission_factors": sorted(manifest_ef_vintages),
             "grid_intensity": sorted(manifest_grid_vintages),
         },
-        "vintage_matrix": {key: manifest_vintage_matrix[key] for key in sorted(manifest_vintage_matrix)},
+        "vintage_matrix": {
+            key: manifest_vintage_matrix[key] for key in sorted(manifest_vintage_matrix)
+        },
     }
     if layer_citation_keys:
         payload["layer_citation_keys"] = layer_citation_keys
@@ -300,18 +302,14 @@ def compute_profile(
     should_close = datastore is None and hasattr(store, "close")
     try:
         activities = {activity.activity_id: activity for activity in store.load_activities()}
-        emission_factors = {
-            ef.activity_id: ef for ef in store.load_emission_factors()
-        }
+        emission_factors = {ef.activity_id: ef for ef in store.load_emission_factors()}
         profiles = {item.profile_id: item for item in store.load_profiles()}
         profile = _resolve_profile(profiles, profile_id)
 
         grid_lookup, grid_by_region = _collect_grid_maps(store.load_grid_intensity())
 
         schedules = [
-            sched
-            for sched in store.load_activity_schedule()
-            if sched.profile_id == profile_id
+            sched for sched in store.load_activity_schedule() if sched.profile_id == profile_id
         ]
         if not schedules:
             raise ValueError(f"profile {profile_id!r} has no associated schedule rows")
@@ -371,7 +369,9 @@ def compute_profile(
                     "activity_id": sched.activity_id,
                     "layer_id": layer_id,
                     "activity_name": activity.name if isinstance(activity, Activity) else None,
-                    "activity_category": activity.category if isinstance(activity, Activity) else None,
+                    "activity_category": (
+                        activity.category if isinstance(activity, Activity) else None
+                    ),
                     "scope_boundary": ef.scope_boundary if isinstance(ef, EmissionFactor) else None,
                     "emission_factor_vintage_year": (
                         int(ef.vintage_year)
@@ -400,7 +400,9 @@ def compute_profile(
                     "profile": profile,
                     "schedule": sched,
                     "activity_id": sched.activity_id,
-                    "activity_category": activity.category if isinstance(activity, Activity) else None,
+                    "activity_category": (
+                        activity.category if isinstance(activity, Activity) else None
+                    ),
                     "emission_factor": ef,
                     "grid_intensity": grid_row,
                     "annual_emissions_g": emission,
@@ -417,7 +419,9 @@ def compute_profile(
         profile_list = sorted(resolved_profiles)
         layers_sorted = sorted(manifest_layers)
 
-        layer_citation_keys, layer_references = _collect_layer_references(derived_rows, citation_keys)
+        layer_citation_keys, layer_references = _collect_layer_references(
+            derived_rows, citation_keys
+        )
 
         stacked_map, bubble_map, sankey_map = _reference_maps(derived_rows, citation_keys)
 

--- a/data/assets.csv
+++ b/data/assets.csv
@@ -1,0 +1,1 @@
+asset_id,site_id,asset_type,name,year,power_rating_kw,fuel_type,notes

--- a/data/entities.csv
+++ b/data/entities.csv
@@ -1,0 +1,1 @@
+entity_id,name,type,parent_entity_id,notes

--- a/data/operations.csv
+++ b/data/operations.csv
@@ -1,0 +1,1 @@
+operation_id,asset_id,activity_id,functional_unit_id,utilization_basis,period_start,period_end,throughput_value,throughput_unit,notes

--- a/data/sites.csv
+++ b/data/sites.csv
@@ -1,0 +1,1 @@
+site_id,entity_id,name,region_code,lat,lon,notes

--- a/scripts/prepare_pages_bundle.py
+++ b/scripts/prepare_pages_bundle.py
@@ -5,8 +5,9 @@ import shutil
 import textwrap
 from pathlib import Path
 
-HEADERS_TEMPLATE = textwrap.dedent(
-    """
+HEADERS_TEMPLATE = (
+    textwrap.dedent(
+        """
     /index.html
       Cache-Control: no-cache
 
@@ -17,7 +18,9 @@ HEADERS_TEMPLATE = textwrap.dedent(
       Access-Control-Allow-Methods: GET, HEAD, OPTIONS
       Access-Control-Allow-Headers: Content-Type
     """
-).strip() + "\n"
+    ).strip()
+    + "\n"
+)
 
 REDIRECTS_TEMPLATE = "/carbon-acx\t/carbon-acx/\t301\n"
 

--- a/tests/test_entities_schema.py
+++ b/tests/test_entities_schema.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from calc import schema
+
+
+CSV_HEADERS = {
+    "entities.csv": "entity_id,name,type,parent_entity_id,notes",
+    "sites.csv": "site_id,entity_id,name,region_code,lat,lon,notes",
+    "assets.csv": "asset_id,site_id,asset_type,name,year,power_rating_kw,fuel_type,notes",
+    "operations.csv": (
+        "operation_id,asset_id,activity_id,functional_unit_id,utilization_basis,"
+        "period_start,period_end,throughput_value,throughput_unit,notes"
+    ),
+    "activities.csv": "activity_id,layer_id,category,name,default_unit,description,unit_definition,notes",
+}
+
+
+@pytest.fixture()
+def empty_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    data_dir = tmp_path
+    for name, header in CSV_HEADERS.items():
+        (data_dir / name).write_text(header + "\n", encoding="utf-8")
+    monkeypatch.setattr(schema, "DATA_DIR", data_dir)
+    schema.invalidate_caches()
+    return data_dir
+
+
+def test_loaders_accept_empty_csvs(empty_registry: Path) -> None:
+    assert schema.load_entities() == []
+    assert schema.load_sites() == []
+    assert schema.load_assets() == []
+    assert schema.load_operations() == []
+
+
+def test_entity_type_enum_enforced(empty_registry: Path) -> None:
+    (empty_registry / "entities.csv").write_text(
+        "entity_id,name,type,parent_entity_id,notes\ncorp-1,Acme,invalid,,\n",
+        encoding="utf-8",
+    )
+    schema.invalidate_caches()
+    with pytest.raises(ValidationError):
+        schema.load_entities()

--- a/tests/test_prepare_pages_bundle.py
+++ b/tests/test_prepare_pages_bundle.py
@@ -19,7 +19,9 @@ def _write_site_stub(site_root: Path) -> None:
 
 def _write_artifacts_stub(artifacts_dir: Path) -> None:
     artifacts_dir.mkdir(parents=True, exist_ok=True)
-    (artifacts_dir / "manifest.json").write_text("{\"generated_at\": \"2024-01-01T00:00:00Z\"}", encoding="utf-8")
+    (artifacts_dir / "manifest.json").write_text(
+        '{"generated_at": "2024-01-01T00:00:00Z"}', encoding="utf-8"
+    )
     nested = artifacts_dir / "figures"
     nested.mkdir()
     (nested / "stacked.json").write_text("{}", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add empty CSV registries for entities, sites, assets, and operations
- extend schema/DAL loaders with entity type enums, utilization basis, and FK validation helpers
- add coverage for the new schema loaders and format supporting modules

## Testing
- make validate
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc35c34194832c97eb0a76f5470b5d