### PR TITLE
Add functional unit registry and evaluator

### DIFF
--- a/data/activities.csv
+++ b/data/activities.csv
@@ -1,6 +1,7 @@
 activity_id,layer_id,category,name,default_unit,description,unit_definition,notes
 FOOD.COFFEE.CUP.HOT,professional,food,Coffee—12 oz hot,cup,Cup of coffee,,
 stream,professional,,stream,,HD streaming on TV,,
+MEDIA.STREAM.HD.HOUR,online,media,HD video streaming—per hour,hour,One hour of high-definition video streaming on any device.,,Aggregates playback plus network electricity for representative HD streaming.
 MEDIA.STREAM.HD.HOUR.TV,online,media,HD video streaming on TV—per hour,hour,One hour of high-definition video streaming delivered to a television via broadband.,,Electricity use covers device playback plus network and data-centre demand per hour of 1080p streaming.
 MEDIA.STREAM.UHD.HOUR.TV,online,media,Ultra HD (4K) video streaming on TV—per hour,hour,One hour of ultra-high-definition (4K) streaming to a television.,,EF to be added after validating 4K bandwidth intensity.
 SOCIAL.SCROLL.HOUR.MOBILE,online,social,Mobile social media browsing—per hour,hour,Scrolling a social media feed on a smartphone over mobile or Wi-Fi data.,,Electricity covers handset use plus average data-transfer intensity per hour of social media use.
@@ -10,5 +11,7 @@ AI.LLM.INFER.1K_TOKENS.GENERIC,online,ai,LLM inference—1K token response,1k_to
 DOWNLOAD.GAME.CONSOLE.50GB,online,downloads,Download 50 GB console game,download,Downloading a 50 gigabyte digital game to a console.,"download" equals one 50 GB transfer.,Pending validation against broadband download intensity.
 CLOUD.STORAGE.SYNC.GB_MONTH,online,cloud,Cloud storage sync per GB-month,gb_month,Maintaining one gigabyte of synced cloud storage for one month.,"gb_month" equals one gigabyte stored and synced for one month.,To be updated with hyperscale storage intensity.
 CLOUD.DOWNLOAD.GB,online,downloads,Cloud data download—per GB,GB,Transferring one gigabyte of data from a cloud service to a consumer device.,"GB" refers to a gigabyte of data downloaded.,Electricity covers wide-area data transfer and data-centre egress for cloud content delivery.
+TRAN.SCHOOLRUN.CAR.KM,professional,mobility,School run by car—per kilometre,km,Passenger kilometres for a school run completed by car.,,Passengers default to one when unspecified.
+TRAN.SCHOOLRUN.BIKE.KM,professional,mobility,School run by bike—per kilometre,km,Distance travelled by bicycle for a school run.,,
 IND_LIGHT.LOGISTICS.FORKLIFT.HOUR,industrial_light,logistics,Forklift material handling—per operating hour,hour,Operating an electric or propane forklift for one hour of material handling within a light-industrial facility.,,Pending validated load-factor and fuel split assumptions for forklifts.
 IND_LIGHT.WAREHOUSE.BASE_LOAD.SQFT_MONTH,industrial_light,warehousing,Warehouse base building load—per ft²-month,ft2_month,"Maintaining base building services (lighting, ventilation, idle equipment) for one square foot of light-industrial warehouse over a month.","ft2_month" equals one square foot maintained for one calendar month.,Requires region-specific base-load and occupancy schedule data prior to activation.

--- a/data/activity_fu_map.csv
+++ b/data/activity_fu_map.csv
@@ -1,0 +1,4 @@
+activity_id,functional_unit_id,conversion_formula,assumption_notes
+TRAN.SCHOOLRUN.CAR.KM,FU.PERSON_KM,"fu = distance_km * passengers","Passengers defaults to 1 if not provided"
+TRAN.SCHOOLRUN.BIKE.KM,FU.PERSON_KM,"fu = distance_km * 1",""
+MEDIA.STREAM.HD.HOUR,FU.VIEW_HOUR,"fu = hours * viewers","viewers defaults to 1"

--- a/data/functional_units.csv
+++ b/data/functional_units.csv
@@ -1,0 +1,4 @@
+functional_unit_id,name,domain,si_equiv,notes
+FU.PERSON_KM,person-kilometre,mobility,person*km,"Person travel distance"
+FU.LITRE_DELIVERED,litre delivered,logistics,L,"Beverage or liquid delivered"
+FU.VIEW_HOUR,viewing-hour,information,hour,"One hour of content viewed"

--- a/tests/test_fu_registry.py
+++ b/tests/test_fu_registry.py
@@ -1,0 +1,36 @@
+import pytest
+
+from calc import schema
+from calc.derive import evaluate_functional_unit_formula
+
+
+def test_functional_units_seeded():
+    units = schema.load_functional_units()
+    ids = {unit.functional_unit_id for unit in units}
+    assert {"FU.PERSON_KM", "FU.LITRE_DELIVERED", "FU.VIEW_HOUR"}.issubset(ids)
+
+
+def test_activity_fu_map_validates_references():
+    mappings = schema.load_activity_fu_map()
+    pairs = {(mapping.activity_id, mapping.functional_unit_id) for mapping in mappings}
+    assert (
+        ("TRAN.SCHOOLRUN.CAR.KM", "FU.PERSON_KM") in pairs
+        and ("TRAN.SCHOOLRUN.BIKE.KM", "FU.PERSON_KM") in pairs
+        and ("MEDIA.STREAM.HD.HOUR", "FU.VIEW_HOUR") in pairs
+    )
+
+
+def test_activity_fu_map_rejects_unknowns():
+    with pytest.raises(ValueError):
+        schema.load_activity_fu_map(activities=[])
+    with pytest.raises(ValueError):
+        schema.load_activity_fu_map(functional_units=[])
+
+
+@pytest.mark.parametrize(
+    "variables,expected",
+    [({"distance_km": 5, "passengers": 1.5}, 7.5), ({"distance_km": 5}, None)],
+)
+def test_evaluate_functional_unit_formula(variables, expected):
+    formula = "fu = distance_km * passengers"
+    assert evaluate_functional_unit_formula(formula, variables) == expected


### PR DESCRIPTION
## Summary
- add a functional unit registry CSV and map selected activities with conversion formulas
- extend schema loaders to validate functional unit relations against activities
- implement a safe functional unit conversion evaluator and accompanying tests

## Testing
- pytest -q tests/test_fu_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68dc3900aaf4832c8bb3b752e84c4626