### PR TITLE
data(map): expand activity→FU mappings (person-km, litre delivered)

### DIFF
--- a/data/activity_fu_map.csv
+++ b/data/activity_fu_map.csv
@@ -2,3 +2,5 @@ activity_id,functional_unit_id,conversion_formula,assumption_notes
 TRAN.SCHOOLRUN.CAR.KM,FU.PERSON_KM,"fu = distance_km * passengers","Passengers defaults to 1 if not provided"
 TRAN.SCHOOLRUN.BIKE.KM,FU.PERSON_KM,"fu = distance_km * 1",""
 MEDIA.STREAM.HD.HOUR,FU.VIEW_HOUR,"fu = hours * viewers","viewers defaults to 1"
+TRAN.DELIVERY.TRUCK.CLASS6.KM,FU.LITRE_DELIVERED,"fu = route_km / litres_delivered","If only cases_delivered provided: litres_delivered = cases_delivered*24*0.355"
+TRAN.SCHOOLRUN.CAR.KM,FU.PERSON_KM,"fu = distance_km * passengers","passengers defaults to 1"


### PR DESCRIPTION
## Summary
- append FU mapping for class 6 delivery trucks expressed per litre delivered
- append FU mapping for school run cars expressed per person-km

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc59778464832c8954db2365ddba65