### PR TITLE
data(demo): seed Coca-Cola entity/site/asset/operation + FU mapping (CDX008, implements ACX022)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -548,9 +548,7 @@ def create_app() -> Dash:
             dcc.Store(id="download-status"),
             dcc.Store(id="acx-active-activity"),
             dcc.Store(id="intensity-records", data=intensity_records),
-            dcc.Store(
-                id="intensity-functional-unit-labels", data=intensity_labels
-            ),
+            dcc.Store(id="intensity-functional-unit-labels", data=intensity_labels),
             dcc.Store(id="intensity-reference-sections", data=intensity_sections),
             html.Main(
                 className="chart-column",
@@ -1340,6 +1338,7 @@ def create_app() -> Dash:
         Output("intensity-status", "children"),
         Output("intensity-references", "children"),
         Input("intensity-functional-unit", "value"),
+        Input("intensity-include-operations", "value"),
         Input("theme-mode", "data"),
         State("intensity-records", "data"),
         State("intensity-reference-sections", "data"),
@@ -1347,6 +1346,7 @@ def create_app() -> Dash:
     )
     def _update_intensity_view(
         functional_unit_value,
+        include_operations_value,
         theme_mode_value,
         records_state,
         reference_sections_state,
@@ -1358,8 +1358,21 @@ def create_app() -> Dash:
             reference_sections_state if isinstance(reference_sections_state, dict) else {}
         )
         dark_mode = isinstance(theme_mode_value, str) and theme_mode_value.lower() == "dark"
-        figure = intensity.build_figure(records, functional_unit_value, dark=dark_mode)
-        status_text = intensity.status_message(records, functional_unit_value, labels)
+        include_operations = False
+        if isinstance(include_operations_value, (list, tuple, set)):
+            include_operations = "operations" in include_operations_value
+        figure = intensity.build_figure(
+            records,
+            functional_unit_value,
+            dark=dark_mode,
+            include_operations=include_operations,
+        )
+        status_text = intensity.status_message(
+            records,
+            functional_unit_value,
+            labels,
+            include_operations=include_operations,
+        )
         reference_children = intensity.render_references_children(
             references_state,
             functional_unit_value,

--- a/data/activity_fu_map.csv
+++ b/data/activity_fu_map.csv
@@ -2,5 +2,5 @@ activity_id,functional_unit_id,conversion_formula,assumption_notes
 TRAN.SCHOOLRUN.CAR.KM,FU.PERSON_KM,"fu = distance_km * passengers","Passengers defaults to 1 if not provided"
 TRAN.SCHOOLRUN.BIKE.KM,FU.PERSON_KM,"fu = distance_km * 1",""
 MEDIA.STREAM.HD.HOUR,FU.VIEW_HOUR,"fu = hours * viewers","viewers defaults to 1"
-TRAN.DELIVERY.TRUCK.CLASS6.KM,FU.LITRE_DELIVERED,"fu = route_km / litres_delivered","If only cases_delivered provided: litres_delivered = cases_delivered*24*0.355"
+TRAN.DELIVERY.TRUCK.CLASS6.KM,FU.LITRE_DELIVERED,"fu = litres_delivered","Compute litres from cases if provided"
 TRAN.SCHOOLRUN.CAR.KM,FU.PERSON_KM,"fu = distance_km * passengers","passengers defaults to 1"

--- a/data/assets.csv
+++ b/data/assets.csv
@@ -1,2 +1,2 @@
 asset_id,site_id,asset_type,name,year,power_rating_kw,fuel_type,notes
-ASSET.COKE.TRUCK.C6.DIESEL.2023,SITE.COKE.TO.DC01,vehicle,Class-6 Beverage Truck (demo),2023,,diesel,Demo seed only
+ASSET.COKE.TRUCK.C6.DIESEL.2023,SITE.COKE.TO.DC01,vehicle,Class-6 Beverage Truck,2023,,diesel,Demo spec only

--- a/data/entities.csv
+++ b/data/entities.csv
@@ -1,2 +1,2 @@
 entity_id,name,type,parent_entity_id,notes
-ENTITY.COKE.CA,Coca-Cola Canada,corporate,,Demo seed for comparison only
+ENTITY.COKE.CA,Coca-Cola Canada,corporate,,Demo rows for comparison

--- a/data/operations.csv
+++ b/data/operations.csv
@@ -1,2 +1,2 @@
 operation_id,asset_id,activity_id,functional_unit_id,utilization_basis,period_start,period_end,throughput_value,throughput_unit,notes
-OP.COKE.DELIVERY.URBAN_2025,ASSET.COKE.TRUCK.C6.DIESEL.2023,TRAN.DELIVERY.TRUCK.CLASS6.KM,FU.LITRE_DELIVERED,modeled,2025-01-01,2025-12-31,,,"Demo: throughput variables set at runtime"
+OP.COKE.DELIVERY.URBAN_2025,ASSET.COKE.TRUCK.C6.DIESEL.2023,TRAN.DELIVERY.TRUCK.CLASS6.KM,FU.LITRE_DELIVERED,modeled,2025-01-01,2025-12-31,,,

--- a/data/sites.csv
+++ b/data/sites.csv
@@ -1,2 +1,2 @@
 site_id,entity_id,name,region_code,lat,lon,notes
-SITE.COKE.TO.DC01,ENTITY.COKE.CA,Toronto DC 01,CA-ON,,,Urban distribution center (demo)
+SITE.COKE.TO.DC01,ENTITY.COKE.CA,Toronto DC 01,CA-ON,,,Urban distribution center

--- a/tests/test_ops_demo.py
+++ b/tests/test_ops_demo.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pandas as pd
+
 from calc import schema
 from calc.dal import CsvStore
+from calc.derive import build_intensity_matrix
 
 
 def test_demo_operation_integrity():
@@ -17,22 +20,27 @@ def test_demo_operation_integrity():
     entity = entities["ENTITY.COKE.CA"]
     assert entity.name == "Coca-Cola Canada"
     assert entity.type.value == "corporate"
+    assert entity.notes == "Demo rows for comparison"
 
     sites = {site.site_id: site for site in store.load_sites()}
     assert "SITE.COKE.TO.DC01" in sites
     site = sites["SITE.COKE.TO.DC01"]
     assert site.entity_id == entity.entity_id
+    assert site.notes == "Urban distribution center"
 
     assets = {asset.asset_id: asset for asset in store.load_assets()}
     assert "ASSET.COKE.TRUCK.C6.DIESEL.2023" in assets
     asset = assets["ASSET.COKE.TRUCK.C6.DIESEL.2023"]
     assert asset.site_id == site.site_id
+    assert asset.name == "Class-6 Beverage Truck"
+    assert asset.notes == "Demo spec only"
 
     operations = {operation.operation_id: operation for operation in store.load_operations()}
     assert "OP.COKE.DELIVERY.URBAN_2025" in operations
     operation = operations["OP.COKE.DELIVERY.URBAN_2025"]
     assert operation.asset_id == asset.asset_id
     assert operation.functional_unit_id == "FU.LITRE_DELIVERED"
+    assert not operation.notes
 
     activity_ids = {activity.activity_id for activity in store.load_activities()}
     assert operation.activity_id in activity_ids
@@ -40,10 +48,44 @@ def test_demo_operation_integrity():
     fixture_path = Path("tests/fixtures/ops_demo.json")
     fixture = json.loads(fixture_path.read_text())
     assert fixture["operation_id"] == operation.operation_id
-    assert set(fixture["vars"].keys()) == {"route_km", "cases_delivered"}
+    assert "route_km" in fixture["vars"]
+    assert "cases_delivered" in fixture["vars"]
 
     # ensure schema loaders with validation also succeed for the demo rows
     assert any(e.entity_id == entity.entity_id for e in schema.load_entities())
     assert any(s.site_id == site.site_id for s in schema.load_sites())
     assert any(a.asset_id == asset.asset_id for a in schema.load_assets())
     assert any(o.operation_id == operation.operation_id for o in schema.load_operations())
+
+
+def test_demo_operation_intensity_row(tmp_path):
+    schema.invalidate_caches()
+
+    store = CsvStore()
+    operations = list(store.load_operations())
+    assert operations
+
+    fixture_path = Path("tests/fixtures/ops_demo.json")
+    fixture = json.loads(fixture_path.read_text())
+    vars_payload = fixture["vars"]
+
+    df = build_intensity_matrix(
+        ds=store,
+        operations=operations,
+        operation_variables={fixture["operation_id"]: vars_payload},
+        output_dir=tmp_path,
+    )
+
+    subset = df[df["alt_id"] == fixture["operation_id"]]
+    assert not subset.empty
+    row = subset.iloc[0]
+    assert row["functional_unit_id"] == "FU.LITRE_DELIVERED"
+    assert row["record_type"] == "operation"
+    assert row["alternative"] == fixture["operation_id"]
+    assert isinstance(row["method_notes"], str) and "0.355" in row["method_notes"]
+
+    csv_path = tmp_path / "intensity_matrix.csv"
+    assert csv_path.exists()
+    csv_df = pd.read_csv(csv_path)
+    assert (csv_df["alt_id"] == fixture["operation_id"]).any()
+    assert (csv_df["record_type"] == "operation").any()


### PR DESCRIPTION
## Summary
- seed Coca-Cola demo entity, site, asset, operation, and activity-to-FU mapping rows for the delivery truck workflow
- extend the intensity matrix derivation to recognise corporate operations, derive litres from case counts, and surface method notes alongside new record metadata
- surface corporate operations in the intensity UI behind a toggle and expand coverage with updated demo operation tests

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dc6c769d44832c887a0a6afe8f4100