### PR TITLE
deploy(headers): normalize content-type + caching for artifacts via Pages Function (CDX010)

### DIFF
--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -47,5 +47,15 @@ export const onRequest: PagesFunction<{
     return out;
   }
 
-  return next();
+  const nextResponse = await next();
+  const headers = nextResponse.headers;
+
+  if (reqUrl.pathname.startsWith("/carbon-acx/artifacts/")) {
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+    if (!headers.has("content-type")) {
+      headers.set("content-type", "application/json; charset=utf-8");
+    }
+  }
+
+  return nextResponse;
 };


### PR DESCRIPTION
## Summary
- add long-lived cache-control headers for carbon-acx artifact responses
- ensure artifact JSON responses default to application/json

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc73da74fc832cb19eb77ae7d9c31c