### PR TITLE
site(config): set vite base to /carbon-acx/ and strip /api/compute fetches (CDX020)

### DIFF
--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -1,28 +1,113 @@
+import type { ComputeResult } from '../state/profile';
+
 export type ComputeRequest = Record<string, unknown>;
 
 export type ComputeOptions = Omit<RequestInit, 'method' | 'body'>;
+
+const ARTIFACT_BASE_PATH = '/carbon-acx/artifacts';
+
+function isDevelopment(): boolean {
+  return process.env.NODE_ENV === 'development';
+}
+
+function normalisePath(path: string): string {
+  return path.replace(/^\/+/, '');
+}
+
+function resolveArtifactUrl(path: string): string {
+  return `${ARTIFACT_BASE_PATH}/${normalisePath(path)}`;
+}
+
+async function fetchArtifact(
+  path: string,
+  init: RequestInit = {}
+): Promise<Response> {
+  const response = await fetch(resolveArtifactUrl(path), {
+    method: 'GET',
+    cache: 'no-store',
+    credentials: 'same-origin',
+    ...init
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Artifact request failed with status ${response.status}`);
+  }
+
+  return response;
+}
+
+async function loadArtifactJson(path: string, signal?: AbortSignal): Promise<unknown> {
+  const response = await fetchArtifact(path, { signal, headers: { Accept: 'application/json' } });
+  return response.json();
+}
+
+async function loadArtifactText(path: string, signal?: AbortSignal): Promise<string> {
+  const response = await fetchArtifact(path, { signal, headers: { Accept: 'text/plain' } });
+  return response.text();
+}
+
+async function loadComputeArtifacts(signal?: AbortSignal): Promise<ComputeResult> {
+  const [manifestJson, stackedJson, bubbleJson, sankeyJson, referencesText] = await Promise.all([
+    loadArtifactJson('manifest.json', signal),
+    loadArtifactJson('figures/stacked.json', signal),
+    loadArtifactJson('figures/bubble.json', signal),
+    loadArtifactJson('figures/sankey.json', signal),
+    loadArtifactText('references/export_view_refs.txt', signal)
+  ]);
+
+  const references = referencesText
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  const result = {
+    manifest: manifestJson,
+    figures: {
+      stacked: stackedJson,
+      bubble: bubbleJson,
+      sankey: sankeyJson
+    },
+    references
+  } as ComputeResult;
+
+  const manifestRecord = manifestJson as { [key: string]: unknown };
+  if (typeof manifestRecord.dataset_version === 'string') {
+    result.datasetId = manifestRecord.dataset_version;
+  } else if (typeof manifestRecord.build_hash === 'string') {
+    result.datasetId = manifestRecord.build_hash;
+  }
+
+  return result;
+}
 
 export async function compute<TResponse = unknown>(
   payload: ComputeRequest,
   options: ComputeOptions = {}
 ): Promise<TResponse> {
-  const { headers, ...fetchOptions } = options;
-  const response = await fetch('/api/compute', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(headers ?? {})
-    },
-    body: JSON.stringify(payload),
-    ...fetchOptions
-  });
+  if (isDevelopment()) {
+    const { headers, ...fetchOptions } = options;
+    const response = await fetch('/api/compute', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(headers ?? {})
+      },
+      body: JSON.stringify(payload),
+      ...fetchOptions
+    });
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Request failed with status ${response.status}`);
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || `Request failed with status ${response.status}`);
+    }
+
+    return (await response.json()) as TResponse;
   }
 
-  return (await response.json()) as TResponse;
+  const signal = options.signal ?? undefined;
+  const artifactResult = await loadComputeArtifacts(signal);
+  return artifactResult as TResponse;
 }
 
 export type ExportFormat = 'csv' | 'json' | 'txt';
@@ -32,25 +117,37 @@ export async function exportView(
   payload: ComputeRequest,
   options: ComputeOptions = {}
 ): Promise<Response> {
-  const { headers, ...fetchOptions } = options;
-  const params = new URLSearchParams({ format });
-  const accept =
-    format === 'csv' ? 'text/csv' : format === 'txt' ? 'text/plain' : 'application/json';
-  const response = await fetch(`/api/compute/export?${params.toString()}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: accept,
-      ...(headers ?? {})
-    },
-    body: JSON.stringify(payload),
-    ...fetchOptions
-  });
+  if (isDevelopment()) {
+    const { headers, ...fetchOptions } = options;
+    const params = new URLSearchParams({ format });
+    const accept =
+      format === 'csv' ? 'text/csv' : format === 'txt' ? 'text/plain' : 'application/json';
+    const response = await fetch(`/api/compute/export?${params.toString()}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: accept,
+        ...(headers ?? {})
+      },
+      body: JSON.stringify(payload),
+      ...fetchOptions
+    });
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Request failed with status ${response.status}`);
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || `Request failed with status ${response.status}`);
+    }
+
+    return response;
   }
 
-  return response;
+  const signal = options.signal ?? undefined;
+  const path =
+    format === 'csv'
+      ? 'export_view.csv'
+      : format === 'json'
+        ? 'export_view.json'
+        : 'references/export_view_refs.txt';
+
+  return fetchArtifact(path, { signal, headers: options.headers });
 }

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({
+  base: '/carbon-acx/',
   plugins: [react()],
   server: {
     host: '0.0.0.0'


### PR DESCRIPTION
## Summary
- configure Vite to emit assets under the /carbon-acx/ base path for static hosting
- swap compute and export helpers to load prebuilt artifacts outside development, retaining POSTs only for dev workers

## Testing
- npm run build
- make build
- npx --yes serve dist -l 0

------
https://chatgpt.com/codex/tasks/task_e_68dc86358750832ca763f16356f40c06