### PR TITLE
site(prod): disable live compute API usage

### DIFF
--- a/site/.env.production
+++ b/site/.env.production
@@ -1,0 +1,1 @@
+VITE_USE_COMPUTE_API=false

--- a/site/src/components/VizCanvas.tsx
+++ b/site/src/components/VizCanvas.tsx
@@ -5,6 +5,7 @@ import { ExportMenu } from './ExportMenu';
 import { LayerToggles } from './LayerToggles';
 import { Sankey, SankeyData, SankeyLink } from './Sankey';
 import { Stacked, StackedDatum } from './Stacked';
+import { USE_COMPUTE_API } from '../lib/api';
 import { formatEmission } from '../lib/format';
 import { buildReferenceLookup } from '../lib/references';
 import { useProfile } from '../state/profile';
@@ -286,7 +287,9 @@ export function VizCanvas(): JSX.Element {
             Visualization Canvas
           </h2>
           <p className="mt-1 text-compact text-slate-400">
-            Connected to the live compute API. Figures refresh automatically when controls change.
+            {USE_COMPUTE_API
+              ? 'Connected to the live compute API. Figures refresh automatically when controls change.'
+              : 'Static artifacts mode'}
           </p>
         </div>
         <div className="flex items-start justify-end gap-1.5 sm:items-start">

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -4,11 +4,12 @@ export type ComputeRequest = Record<string, unknown>;
 
 export type ComputeOptions = Omit<RequestInit, 'method' | 'body'>;
 
-const ARTIFACT_BASE_PATH = '/carbon-acx/artifacts';
+const BASE_PATH = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '');
+const ARTIFACT_BASE_PATH = `${BASE_PATH}/artifacts`;
 
-function isDevelopment(): boolean {
-  return process.env.NODE_ENV === 'development';
-}
+const RAW_USE_COMPUTE_FLAG = import.meta.env.VITE_USE_COMPUTE_API;
+export const USE_COMPUTE_API =
+  RAW_USE_COMPUTE_FLAG === 'true' || (RAW_USE_COMPUTE_FLAG !== 'false' && import.meta.env.DEV);
 
 function normalisePath(path: string): string {
   return path.replace(/^\/+/, '');
@@ -85,7 +86,7 @@ export async function compute<TResponse = unknown>(
   payload: ComputeRequest,
   options: ComputeOptions = {}
 ): Promise<TResponse> {
-  if (isDevelopment()) {
+  if (USE_COMPUTE_API) {
     const { headers, ...fetchOptions } = options;
     const response = await fetch('/api/compute', {
       method: 'POST',
@@ -117,7 +118,7 @@ export async function exportView(
   payload: ComputeRequest,
   options: ComputeOptions = {}
 ): Promise<Response> {
-  if (isDevelopment()) {
+  if (USE_COMPUTE_API) {
     const { headers, ...fetchOptions } = options;
     const params = new URLSearchParams({ format });
     const accept =


### PR DESCRIPTION
## Summary
- add VITE_USE_COMPUTE_API flag defaulting off in production and reuse it in the client
- route compute and export helpers to artifact files whenever the flag is not enabled
- surface "Static artifacts mode" messaging in the visualization canvas when artifacts are used

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc8af8af7c832c967d12098cde51f9