### PR TITLE
site: auto-detect base path for assets and artifacts

### DIFF
--- a/site/src/basePath.ts
+++ b/site/src/basePath.ts
@@ -1,0 +1,9 @@
+export function basePath() {
+  // If app is served at /carbon-acx/... return '/carbon-acx', else ''
+  const p = window.location.pathname;
+  const m = p.match(/^\/carbon-acx(\/|$)/);
+  return m ? '/carbon-acx' : '';
+}
+
+export const ARTIFACTS = () => `${basePath()}/artifacts`;
+export const ASSETS = () => `${basePath()}/assets`;

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -1,11 +1,9 @@
+import { ARTIFACTS } from '../basePath';
 import type { ComputeResult } from '../state/profile';
 
 export type ComputeRequest = Record<string, unknown>;
 
 export type ComputeOptions = Omit<RequestInit, 'method' | 'body'>;
-
-const BASE_PATH = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '');
-const ARTIFACT_BASE_PATH = `${BASE_PATH}/artifacts`;
 
 const RAW_USE_COMPUTE_FLAG = import.meta.env.VITE_USE_COMPUTE_API;
 export const USE_COMPUTE_API =
@@ -16,7 +14,7 @@ function normalisePath(path: string): string {
 }
 
 function resolveArtifactUrl(path: string): string {
-  return `${ARTIFACT_BASE_PATH}/${normalisePath(path)}`;
+  return `${ARTIFACTS()}/${normalisePath(path)}`;
 }
 
 async function fetchArtifact(

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react-swc';
 
+// Use env override; fall back to '/carbon-acx/' only when deploying under subpath
+const base = process.env.BUILD_BASE || '/';
+
 export default defineConfig({
-  base: '/carbon-acx/',
+  base,
   plugins: [react()],
   server: {
     host: '0.0.0.0'


### PR DESCRIPTION
## Summary
- respect a BUILD_BASE environment override when configuring Vite
- add a runtime helper that discovers the current base path for assets and artifacts
- update artifact fetch helpers to build URLs through the shared resolver

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dc911bbf94832ca441c15581bfa026