### PR TITLE
app: refactor overview layout for 33/66 grid

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -551,174 +551,199 @@ def create_app() -> Dash:
             dcc.Store(id="intensity-functional-unit-labels", data=intensity_labels),
             dcc.Store(id="intensity-reference-sections", data=intensity_sections),
             html.Main(
-                className="chart-column",
-                id="overview-main",
+                className="app-main",
                 children=[
-                    html.Header(
-                        [
+                    html.Div(
+                        id="overview-view",
+                        className="overview-view",
+                        children=[
                             html.Div(
-                                [
-                                    html.H1("Carbon ACX emissions overview"),
-                                    html.Button(
-                                        [
-                                            html.Span(
-                                                className="theme-toggle__icon",
-                                                **{"aria-hidden": "true"},
-                                            ),
-                                            html.Span(
-                                                "Theme: System (Light)",
-                                                id="theme-toggle-label",
-                                                className="theme-toggle__label",
-                                            ),
-                                        ],
-                                        id="theme-toggle",
-                                        className="theme-toggle",
-                                        title="Cycle theme (system preference: Light)",
-                                        **{"aria-label": "Cycle theme (system preference: Light)"},
-                                        **{"data-mode": "system"},
-                                    ),
-                                ],
-                                className="page-header__top",
-                            ),
-                            html.P(
-                                "Figures sourced from precomputed artifacts. "
-                                "Hover a chart to see supporting references."
-                            ),
-                            dcc.Tabs(
-                                id="app-view-tabs",
-                                value="overview",
-                                className="chart-tabs",
+                                className="overview-grid",
                                 children=[
-                                    dcc.Tab(
-                                        label="Overview",
-                                        value="overview",
-                                        className="chart-tabs__tab",
-                                        selected_className="chart-tabs__tab--selected",
-                                    ),
-                                    dcc.Tab(
-                                        label="Intensity",
-                                        value="intensity",
-                                        className="chart-tabs__tab",
-                                        selected_className="chart-tabs__tab--selected",
-                                    ),
-                                ],
-                            ),
-                            html.Div(
-                                className="chart-toolbar",
-                                id="overview-toolbar",
-                                children=[
-                                    html.Section(
-                                        className="chart-controls",
+                                    html.Aside(
+                                        className="overview-controls",
                                         children=[
-                                            html.Div(
+                                            html.Header(
                                                 [
-                                                    html.Label(
-                                                        "Select layers",
-                                                        htmlFor="layer-selector",
-                                                        className="chart-controls__label",
-                                                    ),
-                                                    dcc.Checklist(
-                                                        id="layer-selector",
-                                                        options=layer_options,
-                                                        value=default_layers,
-                                                        inline=True,
-                                                        className="chart-controls__checklist",
-                                                    ),
-                                                ],
-                                                className="chart-controls__group",
-                                            ),
-                                            html.Div(
-                                                [
-                                                    html.Label(
-                                                        "View mode",
-                                                        htmlFor="view-mode",
-                                                        className="chart-controls__label",
-                                                    ),
-                                                    dcc.RadioItems(
-                                                        id="view-mode",
-                                                        options=[
-                                                            {
-                                                                "label": "Single layer",
-                                                                "value": "single",
-                                                            },
-                                                            {
-                                                                "label": "Compare layers",
-                                                                "value": "compare",
-                                                            },
+                                                    html.Div(
+                                                        [
+                                                            html.H1("Carbon ACX emissions overview"),
+                                                            html.Button(
+                                                                [
+                                                                    html.Span(
+                                                                        className="theme-toggle__icon",
+                                                                        **{"aria-hidden": "true"},
+                                                                    ),
+                                                                    html.Span(
+                                                                        "Theme: System (Light)",
+                                                                        id="theme-toggle-label",
+                                                                        className="theme-toggle__label",
+                                                                    ),
+                                                                ],
+                                                                id="theme-toggle",
+                                                                className="theme-toggle",
+                                                                title="Cycle theme (system preference: Light)",
+                                                                **{"aria-label": "Cycle theme (system preference: Light)"},
+                                                                **{"data-mode": "system"},
+                                                            ),
                                                         ],
-                                                        value="single",
-                                                        inline=True,
-                                                        className="chart-controls__radios",
+                                                        className="page-header__top",
+                                                    ),
+                                                ]
+                                            ),
+                                            html.P(
+                                                "Figures sourced from precomputed artifacts. "
+                                                "Hover a chart to see supporting references.",
+                                            ),
+                                            dcc.Tabs(
+                                                id="app-view-tabs",
+                                                value="overview",
+                                                className="chart-tabs",
+                                                children=[
+                                                    dcc.Tab(
+                                                        label="Overview",
+                                                        value="overview",
+                                                        className="chart-tabs__tab",
+                                                        selected_className="chart-tabs__tab--selected",
+                                                    ),
+                                                    dcc.Tab(
+                                                        label="Intensity",
+                                                        value="intensity",
+                                                        className="chart-tabs__tab",
+                                                        selected_className="chart-tabs__tab--selected",
                                                     ),
                                                 ],
-                                                className="chart-controls__group",
                                             ),
+                                            html.Section(
+                                                className="chart-controls",
+                                                children=[
+                                                    html.Div(
+                                                        [
+                                                            html.Label(
+                                                                "Select layers",
+                                                                htmlFor="layer-selector",
+                                                                className="chart-controls__label",
+                                                            ),
+                                                            dcc.Checklist(
+                                                                id="layer-selector",
+                                                                options=layer_options,
+                                                                value=default_layers,
+                                                                inline=True,
+                                                                className="chart-controls__checklist",
+                                                            ),
+                                                        ],
+                                                        className="chart-controls__group",
+                                                    ),
+                                                    html.Div(
+                                                        [
+                                                            html.Label(
+                                                                "View mode",
+                                                                htmlFor="view-mode",
+                                                                className="chart-controls__label",
+                                                            ),
+                                                            dcc.RadioItems(
+                                                                id="view-mode",
+                                                                options=[
+                                                                    {
+                                                                        "label": "Single layer",
+                                                                        "value": "single",
+                                                                    },
+                                                                    {
+                                                                        "label": "Compare layers",
+                                                                        "value": "compare",
+                                                                    },
+                                                                ],
+                                                                value="single",
+                                                                inline=True,
+                                                                className="chart-controls__radios",
+                                                            ),
+                                                        ],
+                                                        className="chart-controls__group",
+                                                    ),
+                                                ],
+                                            ),
+                                            html.Div(
+                                                className="chart-downloads",
+                                                children=[
+                                                    html.Button(
+                                                        "Copy link",
+                                                        id="copy-link-btn",
+                                                        className="chart-downloads__button",
+                                                        type="button",
+                                                    ),
+                                                    html.Button(
+                                                        "Download PNG",
+                                                        id="download-png-btn",
+                                                        className="chart-downloads__button",
+                                                        type="button",
+                                                    ),
+                                                    html.Button(
+                                                        "Clear selection",
+                                                        id="clear-activity-selection",
+                                                        className="chart-downloads__button",
+                                                        type="button",
+                                                        disabled=True,
+                                                    ),
+                                                    html.Span(
+                                                        id="share-status",
+                                                        className="chart-downloads__status",
+                                                        **{"aria-live": "polite", "role": "status"},
+                                                    ),
+                                                ],
+                                            ),
+                                            html.Div(
+                                                id="chart-badges",
+                                                className="chart-badges",
+                                            ),
+                                            html.Details(
+                                                className="disclosure-panel",
+                                                id="overview-disclosure",
+                                                open=True,
+                                                children=[
+                                                    html.Summary("Disclosure"),
+                                                    html.Div(
+                                                        disclosure.render(manifest_payload),
+                                                        className="disclosure-panel__content",
+                                                    ),
+                                                ],
+                                            ),
+                                            vintages.render(manifest_payload),
                                         ],
                                     ),
-                                    html.Div(
-                                        className="chart-downloads",
+                                    html.Section(
+                                        id="overview-visualization",
+                                        className="overview-visualization",
                                         children=[
-                                            html.Button(
-                                                "Copy link",
-                                                id="copy-link-btn",
-                                                className="chart-downloads__button",
-                                                type="button",
-                                            ),
-                                            html.Button(
-                                                "Download PNG",
-                                                id="download-png-btn",
-                                                className="chart-downloads__button",
-                                                type="button",
-                                            ),
-                                            html.Button(
-                                                "Clear selection",
-                                                id="clear-activity-selection",
-                                                className="chart-downloads__button",
-                                                type="button",
-                                                disabled=True,
-                                            ),
-                                            html.Span(
-                                                id="share-status",
-                                                className="chart-downloads__status",
+                                            html.Div(id="layer-panels", className="layer-panels"),
+                                            html.Div(
+                                                id="activity-narrative",
+                                                className="chart-narrative",
                                                 **{"aria-live": "polite", "role": "status"},
                                             ),
+                                            html.Details(
+                                                className="references-accordion",
+                                                id="references-accordion",
+                                                open=True,
+                                                **{"data-behavior": "references-accordion"},
+                                                children=[
+                                                    html.Summary("References"),
+                                                    html.Div(
+                                                        references.render_children(
+                                                            initial_reference_keys,
+                                                            include_heading=False,
+                                                        ),
+                                                        id="references",
+                                                        className="references-panel",
+                                                    ),
+                                                ],
+                                            ),
                                         ],
                                     ),
-                                    html.Div(
-                                        id="chart-badges",
-                                        className="chart-badges",
-                                    ),
                                 ],
-                            ),
-                            html.Details(
-                                className="disclosure-panel",
-                                id="overview-disclosure",
-                                open=True,
-                                children=[
-                                    html.Summary("Disclosure"),
-                                    html.Div(
-                                        disclosure.render(manifest_payload),
-                                        className="disclosure-panel__content",
-                                    ),
-                                ],
-                            ),
-                        ]
-                    ),
-                    html.Div(id="layer-panels", className="layer-panels"),
-                    html.Div(
-                        id="activity-narrative",
-                        className="chart-narrative",
-                        **{"aria-live": "polite", "role": "status"},
+                            )
+                        ],
                     ),
                 ],
-            ),
-            html.Div(
-                [
-                    vintages.render(manifest_payload),
-                    references.render(initial_reference_keys),
-                ],
-                className="sidebar-panels",
-                id="overview-sidebar",
             ),
             html.Div(
                 intensity.render_layout(
@@ -736,25 +761,15 @@ def create_app() -> Dash:
     )
 
     @app.callback(
-        Output("overview-main", "style"),
-        Output("overview-sidebar", "style"),
+        Output("overview-view", "style"),
         Output("intensity-view", "style"),
-        Output("overview-toolbar", "style"),
-        Output("overview-disclosure", "style"),
         Input("app-view-tabs", "value"),
     )
     def _toggle_view(tab_value: str | None):
         if tab_value == "intensity":
-            hidden_style = {"display": "none"}
-            return (
-                hidden_style,
-                hidden_style,
-                {"display": "flex"},
-                hidden_style,
-                hidden_style,
-            )
+            return {"display": "none"}, {"display": "block"}
         default_style: dict[str, str] = {}
-        return default_style, default_style, {"display": "none"}, default_style, default_style
+        return default_style, {"display": "none"}
 
     @app.callback(
         Output("layer-selector", "value"),
@@ -1331,7 +1346,10 @@ def create_app() -> Dash:
             }
 
         reference_keys_for_layers = _resolve_reference_keys(ordered_layers, mapping)
-        return references.render_children(reference_keys_for_layers)
+        return references.render_children(
+            reference_keys_for_layers,
+            include_heading=False,
+        )
 
     @app.callback(
         Output("intensity-figure", "figure"),

--- a/app/assets/layout.js
+++ b/app/assets/layout.js
@@ -1,0 +1,31 @@
+(function () {
+  const details = document.querySelector('[data-behavior="references-accordion"]');
+  if (!details || !window.matchMedia) {
+    return;
+  }
+
+  const mq = window.matchMedia('(max-width: 767px)');
+
+  const syncState = () => {
+    if (!details) {
+      return;
+    }
+    if (mq.matches) {
+      details.removeAttribute('open');
+    } else {
+      details.setAttribute('open', '');
+    }
+  };
+
+  if (typeof mq.addEventListener === 'function') {
+    mq.addEventListener('change', syncState);
+  } else if (typeof mq.addListener === 'function') {
+    mq.addListener(syncState);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', syncState, { once: true });
+  } else {
+    syncState();
+  }
+})();

--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -259,6 +259,65 @@ p {
   padding-bottom: var(--space-xl);
 }
 
+.app-container {
+  max-width: 1180px;
+  width: 100%;
+  margin: 0 auto;
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.overview-view {
+  width: 100%;
+}
+
+.overview-grid {
+  display: grid;
+  gap: var(--space-md);
+}
+
+.overview-controls {
+  position: sticky;
+  top: var(--space-md);
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--color-background);
+  border-radius: var(--radius-lg);
+}
+
+.overview-controls .disclosure-panel {
+  border: none;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  box-shadow: none;
+}
+
+.overview-controls .disclosure-panel > summary {
+  padding: var(--space-sm) var(--space-md);
+}
+
+.overview-controls .disclosure-panel__content {
+  padding: var(--space-sm) var(--space-md) var(--space-md);
+}
+
+.overview-controls .info-panel {
+  background: transparent;
+  box-shadow: none;
+  padding: var(--space-sm);
+  gap: var(--space-sm);
+}
+
 .page-shell {
   max-width: 1180px;
   width: 100%;
@@ -267,6 +326,56 @@ p {
   display: flex;
   flex-direction: column;
   gap: clamp(1.5rem, 4vw, 3rem);
+}
+
+.overview-visualization {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  min-width: 0;
+}
+
+.references-accordion {
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--color-background);
+  padding: 0;
+}
+
+.references-accordion > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+.references-accordion > summary::after {
+  content: "\25BC";
+  font-size: 0.75rem;
+  transition: transform 0.2s ease;
+}
+
+.references-accordion[open] > summary::after {
+  transform: rotate(180deg);
+}
+
+.references-accordion > summary::-webkit-details-marker {
+  display: none;
+}
+
+.references-panel {
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.references-panel h2 {
+  display: none;
 }
 
 .page-header {
@@ -927,6 +1036,11 @@ pre {
 }
 
 @media (min-width: 768px) {
+  .overview-grid {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    align-items: start;
+  }
+
   .chart-toolbar {
     align-items: flex-start;
   }
@@ -944,6 +1058,12 @@ pre {
   .layout-grid {
     grid-template-columns: minmax(0, 2.75fr) minmax(260px, 1fr);
     align-items: start;
+  }
+}
+
+@media (min-width: 1024px) {
+  .overview-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   }
 }
 
@@ -974,6 +1094,10 @@ pre {
   }
 
   .sticky {
+    position: static;
+  }
+
+  .overview-controls {
     position: static;
   }
 

--- a/app/components/references.py
+++ b/app/components/references.py
@@ -17,7 +17,11 @@ def _reference_texts(reference_keys: Sequence[str] | None) -> list[str]:
     return references
 
 
-def render_children(reference_keys: Sequence[str] | None) -> list[html.Component]:
+def render_children(
+    reference_keys: Sequence[str] | None,
+    *,
+    include_heading: bool = True,
+) -> list[html.Component]:
     references = _reference_texts(reference_keys)
     has_indices = bool(reference_keys)
     items = []
@@ -26,7 +30,11 @@ def render_children(reference_keys: Sequence[str] | None) -> list[html.Component
         if has_indices:
             attrs["data-reference-index"] = str(idx)
         items.append(html.Li(**attrs))
-    return [html.H2("References"), html.Ol(items, className="references-list")]
+    children: list[html.Component] = []
+    if include_heading:
+        children.append(html.H2("References"))
+    children.append(html.Ol(items, className="references-list"))
+    return children
 
 
 def render(reference_keys: Sequence[str] | None) -> html.Aside:


### PR DESCRIPTION
## Summary
- restructure the overview view into a two-column layout with sticky controls and references beneath the visualization stack
- refresh styling for the new 33/66 grid, responsive breakpoints, and tighter spacing while keeping references collapsible on mobile
- add a lightweight asset script to default the references accordion closed on smaller screens

## Testing
- pytest *(fails: sqlite schema mismatch in test fixtures; unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc99ca646c832c97964a307b8187c3