### PR TITLE
feat: polish unit labels and tooltips

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -553,6 +553,12 @@ def create_app() -> Dash:
             html.Main(
                 className="app-main",
                 children=[
+                    html.Small(
+                        "Units: g/FU = grams CO₂e per functional unit; "
+                        "kg/yr = kilograms CO₂e per year; "
+                        "pkm = passenger-kilometres; h = hours.",
+                        className="unit-legend",
+                    ),
                     html.Div(
                         id="overview-view",
                         className="overview-view",


### PR DESCRIPTION
## Summary
- abbreviate emissions units to g/FU and kg/yr, adding a single legend for the abbreviations
- normalise chart data to kg/yr, updating formatting helpers and axis labels to preserve thin-space number styling
- enrich intensity tooltips with bounds, scope, region, and source summaries while preventing overlapping axis labels

## Testing
- pytest *(fails: requires csv import columns missing in sqlite fixtures and visual hash updates for refreshed figures)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd4684cf8832c8961506805551456