### PR TITLE
Stabilize chart snapshots and assert accessibility

### DIFF
--- a/docs/TESTING_NOTES.md
+++ b/docs/TESTING_NOTES.md
@@ -1,0 +1,4 @@
+# Testing Notes
+
+- Snapshot tests focus on the chart SVG (or chart subtree) elements to avoid spurious failures from layout container changes such as accessibility attributes.
+- Accessibility semantics like `role="region"`, `aria-labelledby`, and focus targets (`tabindex="-1"`) are asserted explicitly in the tests so intentional a11y hooks remain covered.

--- a/site/src/components/Bubble.tsx
+++ b/site/src/components/Bubble.tsx
@@ -87,6 +87,7 @@ export function Bubble({ title = 'Activity emissions bubble chart', data, refere
         aria-labelledby="bubble-heading"
         className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
         id="bubble"
+        role="region"
         tabIndex={-1}
       >
         <h3 id="bubble-heading" className="text-base font-semibold text-slate-100">
@@ -108,6 +109,7 @@ export function Bubble({ title = 'Activity emissions bubble chart', data, refere
       aria-labelledby="bubble-heading"
       className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
       id="bubble"
+      role="region"
       tabIndex={-1}
     >
       <h3 id="bubble-heading" className="text-base font-semibold text-slate-100">
@@ -115,6 +117,7 @@ export function Bubble({ title = 'Activity emissions bubble chart', data, refere
       </h3>
       <div className="mt-4 flex flex-col items-stretch">
         <svg
+          data-testid="bubble-svg"
           role="img"
           viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
           className="w-full text-slate-400"

--- a/site/src/components/Sankey.tsx
+++ b/site/src/components/Sankey.tsx
@@ -162,6 +162,7 @@ export function Sankey({ title = 'Emission pathways', data, referenceLookup }: S
         aria-labelledby="sankey-heading"
         className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
         id="sankey"
+        role="region"
         tabIndex={-1}
       >
         <h3 id="sankey-heading" className="text-base font-semibold text-slate-100">
@@ -180,12 +181,18 @@ export function Sankey({ title = 'Emission pathways', data, referenceLookup }: S
       aria-labelledby="sankey-heading"
       className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
       id="sankey"
+      role="region"
       tabIndex={-1}
     >
       <h3 id="sankey-heading" className="text-base font-semibold text-slate-100">
         {title}
       </h3>
-      <svg role="img" viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`} className="mt-4 w-full text-slate-400">
+      <svg
+        data-testid="sankey-svg"
+        role="img"
+        viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+        className="mt-4 w-full text-slate-400"
+      >
         <defs>
           {preparedLinks.map((link) => (
             <linearGradient

--- a/site/src/components/Stacked.tsx
+++ b/site/src/components/Stacked.tsx
@@ -72,6 +72,7 @@ export function Stacked({ title = 'Annual emissions by category', data, referenc
         aria-labelledby="stacked-heading"
         className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
         id="stacked"
+        role="region"
         tabIndex={-1}
       >
         <h3 id="stacked-heading" className="text-base font-semibold text-slate-100">
@@ -87,6 +88,7 @@ export function Stacked({ title = 'Annual emissions by category', data, referenc
       aria-labelledby="stacked-heading"
       className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
       id="stacked"
+      role="region"
       tabIndex={-1}
     >
       <div className="flex items-baseline justify-between gap-4">
@@ -95,7 +97,7 @@ export function Stacked({ title = 'Annual emissions by category', data, referenc
         </h3>
         <p className="text-xs uppercase tracking-[0.3em] text-slate-300">Total {formatEmission(total)}</p>
       </div>
-      <ol role="list" className="mt-5 space-y-3">
+      <ol role="list" className="mt-5 space-y-3" data-testid="stacked-svg">
         {prepared.map((row, index) => {
           const width = total > 0 ? Math.max((row.value / total) * 100, 2) : 0;
           return (

--- a/site/src/components/__tests__/Bubble.test.tsx
+++ b/site/src/components/__tests__/Bubble.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 
 import { Bubble } from '../Bubble';
@@ -25,11 +26,16 @@ const sampleData = [
 
 describe('Bubble', () => {
   it('renders bubble chart with pulsing circles', () => {
-    const { asFragment, getByTestId } = render(
+    const { getByRole, getByTestId } = render(
       <Bubble data={sampleData} referenceLookup={referenceLookup} />
     );
 
-    expect(asFragment()).toMatchSnapshot();
+    // Section is a landmark with an accessible name and focus target.
+    const section = getByRole('region', { name: /bubble/i });
+    expect(section).toHaveAttribute('tabindex', '-1');
+
+    const svg = getByTestId('bubble-svg');
+    expect(svg).toMatchSnapshot();
     const bubble = getByTestId('bubble-point-0');
     const title = bubble.querySelector('title');
     expect(title?.textContent).toContain('[1]');

--- a/site/src/components/__tests__/Sankey.test.tsx
+++ b/site/src/components/__tests__/Sankey.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 
 import { Sankey } from '../Sankey';
@@ -24,11 +25,16 @@ const sampleData = {
 
 describe('Sankey', () => {
   it('renders gradient links with reference hints', () => {
-    const { asFragment, container } = render(
+    const { container, getByRole, getByTestId } = render(
       <Sankey data={sampleData} referenceLookup={referenceLookup} />
     );
 
-    expect(asFragment()).toMatchSnapshot();
+    // Section is a landmark with an accessible name and focus target.
+    const section = getByRole('region', { name: /emission pathways/i });
+    expect(section).toHaveAttribute('tabindex', '-1');
+
+    const svg = getByTestId('sankey-svg');
+    expect(svg).toMatchSnapshot();
     const link = container.querySelector('#sankey-link-0 title');
     expect(link?.textContent).toContain('[1]');
   });

--- a/site/src/components/__tests__/Stacked.test.tsx
+++ b/site/src/components/__tests__/Stacked.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 
 import { Stacked } from '../Stacked';
@@ -22,11 +23,16 @@ const sampleData = [
 
 describe('Stacked', () => {
   it('renders stacked bars with reference hints', () => {
-    const { asFragment, getByTestId } = render(
+    const { getByRole, getByTestId } = render(
       <Stacked data={sampleData} referenceLookup={referenceLookup} />
     );
 
-    expect(asFragment()).toMatchSnapshot();
+    // Section is a landmark with an accessible name and focus target.
+    const section = getByRole('region', { name: /annual emissions by category/i });
+    expect(section).toHaveAttribute('tabindex', '-1');
+
+    const chart = getByTestId('stacked-svg');
+    expect(chart).toMatchSnapshot();
     expect(getByTestId('stacked-bar-0')).toHaveAttribute('title', expect.stringContaining('[1]'));
   });
 });

--- a/site/src/components/__tests__/__snapshots__/Bubble.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/Bubble.test.tsx.snap
@@ -1,189 +1,172 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
-<DocumentFragment>
-  <section
-    aria-labelledby="bubble-heading"
-    class="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
-    id="bubble"
+<svg
+  aria-describedby="bubble-axis-description"
+  class="w-full text-slate-400"
+  data-testid="bubble-svg"
+  role="img"
+  viewBox="0 0 640 360"
+>
+  <defs>
+    <radialgradient
+      cx="50%"
+      cy="50%"
+      id="bubble-fill"
+      r="75%"
+    >
+      <stop
+        offset="0%"
+        stop-color="#38bdf8"
+        stop-opacity="0.9"
+      />
+      <stop
+        offset="100%"
+        stop-color="#0f172a"
+        stop-opacity="0.2"
+      />
+    </radialgradient>
+  </defs>
+  <rect
+    fill="url(#bubble-fill)"
+    fill-opacity="0.08"
+    height="260"
+    rx="24"
+    stroke="rgba(148, 163, 184, 0.25)"
+    width="480"
+    x="80"
+    y="50"
+  />
+  <g
+    class="group"
+    data-testid="bubble-point-0"
+    transform="translate(200, 50)"
   >
-    <h3
-      class="text-base font-semibold text-slate-100"
-      id="bubble-heading"
+    <circle
+      class="fill-sky-400/80 transition-transform duration-300 ease-out group-hover:scale-110 group-focus-within:scale-110"
+      r="42"
+      stroke="rgba(56, 189, 248, 0.4)"
+      stroke-width="2"
     >
-      Activity emissions bubble chart
-    </h3>
-    <div
-      class="mt-4 flex flex-col items-stretch"
+      <title>
+        Cooling — 2.50 kg CO₂e [1]
+      </title>
+    </circle>
+    <text
+      class="fill-slate-300 text-xs font-medium"
+      text-anchor="middle"
+      y="58"
     >
-      <svg
-        aria-describedby="bubble-axis-description"
-        class="w-full text-slate-400"
-        role="img"
-        viewBox="0 0 640 360"
-      >
-        <defs>
-          <radialgradient
-            cx="50%"
-            cy="50%"
-            id="bubble-fill"
-            r="75%"
-          >
-            <stop
-              offset="0%"
-              stop-color="#38bdf8"
-              stop-opacity="0.9"
-            />
-            <stop
-              offset="100%"
-              stop-color="#0f172a"
-              stop-opacity="0.2"
-            />
-          </radialgradient>
-        </defs>
-        <rect
-          fill="url(#bubble-fill)"
-          fill-opacity="0.08"
-          height="260"
-          rx="24"
-          stroke="rgba(148, 163, 184, 0.25)"
-          width="480"
-          x="80"
-          y="50"
-        />
-        <g
-          class="group"
-          data-testid="bubble-point-0"
-          transform="translate(200, 50)"
-        >
-          <circle
-            class="fill-sky-400/80 transition-transform duration-300 ease-out group-hover:scale-110 group-focus-within:scale-110"
-            r="42"
-            stroke="rgba(56, 189, 248, 0.4)"
-            stroke-width="2"
-          >
-            <title>
-              Cooling — 2.50 kg CO₂e [1]
-            </title>
-          </circle>
-          <text
-            class="fill-slate-300 text-xs font-medium"
-            text-anchor="middle"
-            y="58"
-          >
-            Cooling
-          </text>
-        </g>
-        <g
-          class="group"
-          data-testid="bubble-point-1"
-          transform="translate(440, 185.2)"
-        >
-          <circle
-            class="fill-sky-400/80 transition-transform duration-300 ease-out group-hover:scale-110 group-focus-within:scale-110"
-            r="29.09845356715714"
-            stroke="rgba(56, 189, 248, 0.4)"
-            stroke-width="2"
-          >
-            <title>
-              Lighting — 1.20 kg CO₂e [2]
-            </title>
-          </circle>
-          <text
-            class="fill-slate-300 text-xs font-medium"
-            text-anchor="middle"
-            y="45.09845356715714"
-          >
-            Lighting
-          </text>
-        </g>
-        <text
-          class="fill-slate-400 text-xs"
-          text-anchor="middle"
-          x="200"
-          y="348"
-        >
-          HVAC
-        </text>
-        <text
-          class="fill-slate-400 text-xs"
-          text-anchor="middle"
-          x="440"
-          y="348"
-        >
-          Facilities
-        </text>
-        <g>
-          <line
-            stroke="rgba(148, 163, 184, 0.4)"
-            x1="72"
-            x2="80"
-            y1="310"
-            y2="310"
-          />
-          <text
-            class="fill-slate-400 text-xs"
-            text-anchor="end"
-            x="68"
-            y="314"
-          >
-            0.0 kg
-          </text>
-        </g>
-        <g>
-          <line
-            stroke="rgba(148, 163, 184, 0.4)"
-            x1="72"
-            x2="80"
-            y1="180"
-            y2="180"
-          />
-          <text
-            class="fill-slate-400 text-xs"
-            text-anchor="end"
-            x="68"
-            y="184"
-          >
-            1.3 kg
-          </text>
-        </g>
-        <g>
-          <line
-            stroke="rgba(148, 163, 184, 0.4)"
-            x1="72"
-            x2="80"
-            y1="50"
-            y2="50"
-          />
-          <text
-            class="fill-slate-400 text-xs"
-            text-anchor="end"
-            x="68"
-            y="54"
-          >
-            2.5 kg
-          </text>
-        </g>
-        <text
-          class="fill-slate-500 text-xs"
-          id="bubble-axis-description"
-          text-anchor="middle"
-          transform="rotate(-90 32 180)"
-          x="32"
-          y="180"
-        >
-          Annual emissions (kg CO₂e)
-        </text>
-        <text
-          class="fill-slate-500 text-xs"
-          text-anchor="middle"
-          x="320"
-          y="356"
-        >
-          Activity category
-        </text>
-      </svg>
-    </div>
-  </section>
-</DocumentFragment>
+      Cooling
+    </text>
+  </g>
+  <g
+    class="group"
+    data-testid="bubble-point-1"
+    transform="translate(440, 185.2)"
+  >
+    <circle
+      class="fill-sky-400/80 transition-transform duration-300 ease-out group-hover:scale-110 group-focus-within:scale-110"
+      r="29.09845356715714"
+      stroke="rgba(56, 189, 248, 0.4)"
+      stroke-width="2"
+    >
+      <title>
+        Lighting — 1.20 kg CO₂e [2]
+      </title>
+    </circle>
+    <text
+      class="fill-slate-300 text-xs font-medium"
+      text-anchor="middle"
+      y="45.09845356715714"
+    >
+      Lighting
+    </text>
+  </g>
+  <text
+    class="fill-slate-400 text-xs"
+    text-anchor="middle"
+    x="200"
+    y="348"
+  >
+    HVAC
+  </text>
+  <text
+    class="fill-slate-400 text-xs"
+    text-anchor="middle"
+    x="440"
+    y="348"
+  >
+    Facilities
+  </text>
+  <g>
+    <line
+      stroke="rgba(148, 163, 184, 0.4)"
+      x1="72"
+      x2="80"
+      y1="310"
+      y2="310"
+    />
+    <text
+      class="fill-slate-400 text-xs"
+      text-anchor="end"
+      x="68"
+      y="314"
+    >
+      0.0 kg
+    </text>
+  </g>
+  <g>
+    <line
+      stroke="rgba(148, 163, 184, 0.4)"
+      x1="72"
+      x2="80"
+      y1="180"
+      y2="180"
+    />
+    <text
+      class="fill-slate-400 text-xs"
+      text-anchor="end"
+      x="68"
+      y="184"
+    >
+      1.3 kg
+    </text>
+  </g>
+  <g>
+    <line
+      stroke="rgba(148, 163, 184, 0.4)"
+      x1="72"
+      x2="80"
+      y1="50"
+      y2="50"
+    />
+    <text
+      class="fill-slate-400 text-xs"
+      text-anchor="end"
+      x="68"
+      y="54"
+    >
+      2.5 kg
+    </text>
+  </g>
+  <text
+    class="fill-slate-500 text-xs"
+    id="bubble-axis-description"
+    text-anchor="middle"
+    transform="rotate(-90 32 180)"
+    x="32"
+    y="180"
+  >
+    Annual emissions (kg CO₂e)
+  </text>
+  <text
+    class="fill-slate-500 text-xs"
+    text-anchor="middle"
+    x="320"
+    y="356"
+  >
+    Activity category
+  </text>
+</svg>
 `;

--- a/site/src/components/__tests__/__snapshots__/Sankey.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/Sankey.test.tsx.snap
@@ -1,135 +1,122 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Sankey > renders gradient links with reference hints 1`] = `
-<DocumentFragment>
-  <section
-    aria-labelledby="sankey-heading"
-    class="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
-    id="sankey"
+<svg
+  class="mt-4 w-full text-slate-400"
+  data-testid="sankey-svg"
+  role="img"
+  viewBox="0 0 640 360"
+>
+  <defs>
+    <lineargradient
+      gradientUnits="userSpaceOnUse"
+      id="sankey-gradient-0"
+      x1="90"
+      x2="550"
+      y1="58"
+      y2="58"
+    >
+      <stop
+        offset="0%"
+        stop-color="#38bdf8"
+        stop-opacity="0.85"
+      />
+      <stop
+        offset="100%"
+        stop-color="#38bdf8"
+        stop-opacity="0.35"
+      />
+    </lineargradient>
+  </defs>
+  <g>
+    <path
+      class="transition-opacity duration-300 opacity-70"
+      d="M160 58 C 220 58, 420 58, 480 58"
+      fill="none"
+      id="sankey-link-0"
+      stroke="url(#sankey-gradient-0)"
+      stroke-linecap="round"
+      stroke-width="26"
+      tabindex="0"
+    >
+      <title>
+        Cooling → Chiller — 1.80 kg CO₂e [1]
+      </title>
+    </path>
+  </g>
+  <g
+    class="cursor-pointer"
+    data-testid="sankey-node-category:cooling"
+    tabindex="0"
+    transform="translate(20, 40)"
   >
-    <h3
-      class="text-base font-semibold text-slate-100"
-      id="sankey-heading"
+    <rect
+      fill="#38bdf8"
+      fill-opacity="0.55"
+      height="36"
+      rx="18"
+      stroke="rgba(15, 23, 42, 0.6)"
+      stroke-width="1.5"
+      width="140"
     >
-      Emission pathways
-    </h3>
-    <svg
-      class="mt-4 w-full text-slate-400"
-      role="img"
-      viewBox="0 0 640 360"
+      <title>
+        Cooling — 1.80 kg CO₂e [1]
+      </title>
+    </rect>
+    <text
+      alignment-baseline="middle"
+      class="fill-slate-950 text-sm font-semibold"
+      text-anchor="middle"
+      x="70"
+      y="18"
     >
-      <defs>
-        <lineargradient
-          gradientUnits="userSpaceOnUse"
-          id="sankey-gradient-0"
-          x1="90"
-          x2="550"
-          y1="58"
-          y2="58"
-        >
-          <stop
-            offset="0%"
-            stop-color="#38bdf8"
-            stop-opacity="0.85"
-          />
-          <stop
-            offset="100%"
-            stop-color="#38bdf8"
-            stop-opacity="0.35"
-          />
-        </lineargradient>
-      </defs>
-      <g>
-        <path
-          class="transition-opacity duration-300 opacity-70"
-          d="M160 58 C 220 58, 420 58, 480 58"
-          fill="none"
-          id="sankey-link-0"
-          stroke="url(#sankey-gradient-0)"
-          stroke-linecap="round"
-          stroke-width="26"
-          tabindex="0"
-        >
-          <title>
-            Cooling → Chiller — 1.80 kg CO₂e [1]
-          </title>
-        </path>
-      </g>
-      <g
-        class="cursor-pointer"
-        data-testid="sankey-node-category:cooling"
-        tabindex="0"
-        transform="translate(20, 40)"
-      >
-        <rect
-          fill="#38bdf8"
-          fill-opacity="0.55"
-          height="36"
-          rx="18"
-          stroke="rgba(15, 23, 42, 0.6)"
-          stroke-width="1.5"
-          width="140"
-        >
-          <title>
-            Cooling — 1.80 kg CO₂e [1]
-          </title>
-        </rect>
-        <text
-          alignment-baseline="middle"
-          class="fill-slate-950 text-sm font-semibold"
-          text-anchor="middle"
-          x="70"
-          y="18"
-        >
-          Cooling
-        </text>
-        <text
-          class="fill-slate-400 text-xs"
-          text-anchor="middle"
-          x="70"
-          y="50"
-        >
-          1.80 kg CO₂e
-        </text>
-      </g>
-      <g
-        class="cursor-pointer"
-        data-testid="sankey-node-activity:chiller"
-        tabindex="0"
-        transform="translate(480, 40)"
-      >
-        <rect
-          fill="#38bdf8"
-          fill-opacity="0.55"
-          height="36"
-          rx="18"
-          stroke="rgba(15, 23, 42, 0.6)"
-          stroke-width="1.5"
-          width="140"
-        >
-          <title>
-            Chiller — 1.80 kg CO₂e [1]
-          </title>
-        </rect>
-        <text
-          alignment-baseline="middle"
-          class="fill-slate-950 text-sm font-semibold"
-          text-anchor="middle"
-          x="70"
-          y="18"
-        >
-          Chiller
-        </text>
-        <text
-          class="fill-slate-400 text-xs"
-          text-anchor="middle"
-          x="70"
-          y="50"
-        >
-          1.80 kg CO₂e
-        </text>
-      </g>
-    </svg>
-  </section>
-</DocumentFragment>
+      Cooling
+    </text>
+    <text
+      class="fill-slate-400 text-xs"
+      text-anchor="middle"
+      x="70"
+      y="50"
+    >
+      1.80 kg CO₂e
+    </text>
+  </g>
+  <g
+    class="cursor-pointer"
+    data-testid="sankey-node-activity:chiller"
+    tabindex="0"
+    transform="translate(480, 40)"
+  >
+    <rect
+      fill="#38bdf8"
+      fill-opacity="0.55"
+      height="36"
+      rx="18"
+      stroke="rgba(15, 23, 42, 0.6)"
+      stroke-width="1.5"
+      width="140"
+    >
+      <title>
+        Chiller — 1.80 kg CO₂e [1]
+      </title>
+    </rect>
+    <text
+      alignment-baseline="middle"
+      class="fill-slate-950 text-sm font-semibold"
+      text-anchor="middle"
+      x="70"
+      y="18"
+    >
+      Chiller
+    </text>
+    <text
+      class="fill-slate-400 text-xs"
+      text-anchor="middle"
+      x="70"
+      y="50"
+    >
+      1.80 kg CO₂e
+    </text>
+  </g>
+</svg>
 `;

--- a/site/src/components/__tests__/__snapshots__/Stacked.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/Stacked.test.tsx.snap
@@ -1,93 +1,66 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Stacked > renders stacked bars with reference hints 1`] = `
-<DocumentFragment>
-  <section
-    aria-labelledby="stacked-heading"
-    class="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-5 shadow-inner shadow-slate-900/40"
-    id="stacked"
+<ol
+  class="mt-5 space-y-3"
+  data-testid="stacked-svg"
+  role="list"
+>
+  <li
+    class="space-y-1"
+    data-testid="stacked-item-0"
   >
     <div
-      class="flex items-baseline justify-between gap-4"
+      class="flex items-center justify-between text-sm text-slate-300"
     >
-      <h3
-        class="text-base font-semibold text-slate-100"
-        id="stacked-heading"
+      <span
+        class="font-medium text-slate-100"
       >
-        Annual emissions by category
-      </h3>
-      <p
-        class="text-xs uppercase tracking-[0.3em] text-slate-300"
-      >
-        Total 2.00 kg CO₂e
-      </p>
+        Cooling
+      </span>
+      <span>
+        1.20 kg CO₂e
+      </span>
     </div>
-    <ol
-      class="mt-5 space-y-3"
-      role="list"
+    <div
+      class="group relative h-3 overflow-hidden rounded-full bg-slate-800/80"
+      style="transition: all 0.5s ease; width: 100%;"
     >
-      <li
-        class="space-y-1"
-        data-testid="stacked-item-0"
-      >
-        <div
-          class="flex items-center justify-between text-sm text-slate-300"
-        >
-          <span
-            class="font-medium text-slate-100"
-          >
-            Cooling
-          </span>
-          <span>
-            1.20 kg CO₂e
-          </span>
-        </div>
-        <div
-          class="group relative h-3 overflow-hidden rounded-full bg-slate-800/80"
-          style="transition: all 0.5s ease; width: 100%;"
-        >
-          <div
-            class="h-full rounded-full bg-gradient-to-r from-sky-500/80 via-sky-400/70 to-cyan-300/80 transition-all duration-500 ease-out group-hover:from-sky-400 group-hover:to-cyan-200"
-            data-testid="stacked-bar-0"
-            style="width: 60%;"
-            title="1.20 kg CO₂e [1]"
-          />
-        </div>
-      </li>
-      <li
-        class="space-y-1"
-        data-testid="stacked-item-1"
-      >
-        <div
-          class="flex items-center justify-between text-sm text-slate-300"
-        >
-          <span
-            class="font-medium text-slate-100"
-          >
-            Heating
-          </span>
-          <span>
-            800 g CO₂e
-          </span>
-        </div>
-        <div
-          class="group relative h-3 overflow-hidden rounded-full bg-slate-800/80"
-          style="transition: all 0.5s ease; width: 100%;"
-        >
-          <div
-            class="h-full rounded-full bg-gradient-to-r from-sky-500/80 via-sky-400/70 to-cyan-300/80 transition-all duration-500 ease-out group-hover:from-sky-400 group-hover:to-cyan-200"
-            data-testid="stacked-bar-1"
-            style="width: 40%;"
-            title="800 g CO₂e [2]"
-          />
-        </div>
-      </li>
-    </ol>
-    <p
-      class="mt-6 text-xs uppercase tracking-[0.3em] text-slate-300"
+      <div
+        class="h-full rounded-full bg-gradient-to-r from-sky-500/80 via-sky-400/70 to-cyan-300/80 transition-all duration-500 ease-out group-hover:from-sky-400 group-hover:to-cyan-200"
+        data-testid="stacked-bar-0"
+        style="width: 60%;"
+        title="1.20 kg CO₂e [1]"
+      />
+    </div>
+  </li>
+  <li
+    class="space-y-1"
+    data-testid="stacked-item-1"
+  >
+    <div
+      class="flex items-center justify-between text-sm text-slate-300"
     >
-      Annual emissions (adaptive units)
-    </p>
-  </section>
-</DocumentFragment>
+      <span
+        class="font-medium text-slate-100"
+      >
+        Heating
+      </span>
+      <span>
+        800 g CO₂e
+      </span>
+    </div>
+    <div
+      class="group relative h-3 overflow-hidden rounded-full bg-slate-800/80"
+      style="transition: all 0.5s ease; width: 100%;"
+    >
+      <div
+        class="h-full rounded-full bg-gradient-to-r from-sky-500/80 via-sky-400/70 to-cyan-300/80 transition-all duration-500 ease-out group-hover:from-sky-400 group-hover:to-cyan-200"
+        data-testid="stacked-bar-1"
+        style="width: 40%;"
+        title="800 g CO₂e [2]"
+      />
+    </div>
+  </li>
+</ol>
 `;


### PR DESCRIPTION
## Summary
- mark the Bubble, Sankey, and Stacked chart sections as focusable regions and expose stable data test IDs for their chart elements
- update the Vitest suites to assert accessibility hooks and snapshot only the chart subtree for each visualization
- refresh the affected snapshots and document the snapshot strategy for accessibility-related containers

## Testing
- pnpm test
- pnpm test -u


------
https://chatgpt.com/codex/tasks/task_e_68dd78eebfa4832c853a5150a5df9de7