### PR TITLE
app(debug): harden artifact loading diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Additional configuration:
 2. **Continuous integration** — The CI workflow (replicated by `make ci_build_pages`) runs install, lint, test, and packages the static site (`make package`), publishing two artefacts: `dist-artifacts` (data bundle) and `dist-site` (static client).
 3. **Release** — `make release` is a placeholder for future automated releases; production deploys currently upload `dist/site/` to Cloudflare Pages manually or via upstream automation described in `docs/deploy.md`.
 4. **Routing** — `functions/carbon-acx/[[path]].ts` sits alongside the static bundle to proxy or serve `/carbon-acx/*` traffic with opinionated caching headers (see `docs/routes.md`).
+5. **Base path overrides** — Set `PUBLIC_BASE_PATH` when building the site to align with the deployment prefix (defaults to `/carbon-acx/`). The same value flows through Vite’s `base` config and the runtime fetch helpers.
 
 For reproducible deployments, treat `dist/artifacts/latest-build.json` as the pointer to the most recent build hash and package that directory verbatim.
 
@@ -360,6 +361,9 @@ Legend: ✅ implemented · 🚧 in-progress or partially scaffolded · 🧭 plan
 
 **Where do deployment instructions live?**
 : See `docs/deploy.md` for Cloudflare Pages guidance and `docs/routes.md` for proxy behaviour.
+
+**Debugging data loads**
+: Use `scripts/dev_diag.sh` to compare artifact headers locally and in production. The script respects `PUBLIC_BASE_PATH` so you can verify both the static bundle (`http://127.0.0.1:4173`) and your Pages domain return JSON rather than the SPA fallback.
 
 ---
 

--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -3,13 +3,171 @@ const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "https://boot.industries",
   "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
-  "Access-Control-Max-Age": "86400"
+  "Access-Control-Max-Age": "86400",
 };
+
+const CONTENT_TYPE_BY_SUFFIX: Record<string, string> = {
+  ".json": "application/json",
+  ".csv": "text/csv",
+  ".txt": "text/plain",
+};
+
+interface BasePathInfo {
+  /** Base path without trailing slash (e.g. "/carbon-acx" or "") */
+  prefix: string;
+  /** Base path with trailing slash (e.g. "/carbon-acx/" or "/") */
+  withTrailingSlash: string;
+}
+
+function normaliseBasePath(raw: string | undefined): BasePathInfo {
+  let base = (raw && raw.trim()) || "/carbon-acx/";
+  if (!base.startsWith("/")) {
+    base = `/${base}`;
+  }
+  if (!base.endsWith("/")) {
+    base = `${base}/`;
+  }
+  if (base === "//") {
+    base = "/";
+  }
+  const prefix = base === "/" ? "" : base.slice(0, -1);
+  return { prefix, withTrailingSlash: base };
+}
+
+function stripBasePath(pathname: string, base: BasePathInfo): string {
+  if (!base.prefix) {
+    return pathname;
+  }
+  if (pathname === base.prefix) {
+    return "/";
+  }
+  if (pathname.startsWith(`${base.prefix}/`)) {
+    return pathname.slice(base.prefix.length);
+  }
+  return pathname;
+}
+
+function sanitiseArtifactKey(raw: string): string {
+  const cleaned = raw
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+  return cleaned.join("/");
+}
+
+function resolveContentType(path: string): string | null {
+  const dot = path.lastIndexOf(".");
+  if (dot === -1) {
+    return null;
+  }
+  const suffix = path.slice(dot).toLowerCase();
+  return CONTENT_TYPE_BY_SUFFIX[suffix] ?? null;
+}
+
+function applyArtifactHeaders(
+  response: Response,
+  artifactKey: string,
+  options: { includeDiagHeader: boolean },
+  contentTypeOverride?: string | null,
+): Response {
+  const headers = new Headers(response.headers);
+  if (!headers.has("Cache-Control")) {
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+  }
+  if (contentTypeOverride) {
+    headers.set("content-type", contentTypeOverride);
+  }
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    headers.set(key, value);
+  }
+  if (options.includeDiagHeader) {
+    headers.set("X-Diag-Artifact-Path", artifactKey);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function createJsonResponse(
+  payload: unknown,
+  status: number,
+  artifactKey: string,
+  includeDiagHeader: boolean,
+): Response {
+  const headers = new Headers({ "content-type": "application/json" });
+  headers.set("Cache-Control", "no-store");
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    headers.set(key, value);
+  }
+  if (includeDiagHeader) {
+    headers.set("X-Diag-Artifact-Path", artifactKey);
+  }
+  return new Response(JSON.stringify(payload), { status, headers });
+}
+
+async function handleArtifactRequest(
+  ctx: Parameters<PagesFunction>[0],
+  base: BasePathInfo,
+  origin: string | undefined,
+): Promise<Response> {
+  const { request } = ctx;
+  const url = new URL(request.url);
+  const artifactPrefix = `${base.withTrailingSlash}artifacts/`;
+  const artifactPath = url.pathname.slice(artifactPrefix.length);
+  const sanitizedKey = sanitiseArtifactKey(artifactPath);
+  const artifactKey = sanitizedKey ? `artifacts/${sanitizedKey}` : "artifacts";
+  const includeDiagHeader = !origin;
+  const desiredContentType = resolveContentType(sanitizedKey);
+
+  const staticResponse = await ctx.next();
+  if (staticResponse && staticResponse.status !== 404) {
+    const contentType = staticResponse.headers.get("content-type")?.toLowerCase() ?? "";
+    if (!contentType.includes("text/html")) {
+      return applyArtifactHeaders(staticResponse, artifactKey, { includeDiagHeader }, desiredContentType);
+    }
+  }
+
+  if (origin) {
+    const trimmedOrigin = origin.replace(/\/$/, "");
+    const upstreamUrl = `${trimmedOrigin}/artifacts/${sanitizedKey}${url.search}`;
+    const upstreamRequest = new Request(upstreamUrl, {
+      method: request.method,
+      headers: request.headers,
+    });
+    const upstreamResponse = await fetch(upstreamRequest);
+    if (upstreamResponse.ok) {
+      return applyArtifactHeaders(
+        upstreamResponse,
+        artifactKey,
+        { includeDiagHeader },
+        desiredContentType,
+      );
+    }
+    const snippet = await upstreamResponse.text();
+    return createJsonResponse(
+      {
+        error: "upstream_error",
+        path: artifactKey,
+        status: upstreamResponse.status,
+        statusText: upstreamResponse.statusText,
+        snippet: snippet.slice(0, 200),
+      },
+      upstreamResponse.status || 502,
+      artifactKey,
+      includeDiagHeader,
+    );
+  }
+
+  return createJsonResponse({ error: "not_found", path: artifactKey }, 404, artifactKey, includeDiagHeader);
+}
 
 export const onRequest: PagesFunction<{
   CARBON_ACX_ORIGIN: string | undefined;
+  PUBLIC_BASE_PATH: string | undefined;
 }> = async (ctx) => {
-  const { request, env, next } = ctx;
+  const { request, env } = ctx;
   const method = request.method.toUpperCase();
 
   if (!ALLOWED_METHODS.has(method)) {
@@ -23,11 +181,15 @@ export const onRequest: PagesFunction<{
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
 
-  const reqUrl = new URL(request.url);
+  const base = normaliseBasePath(env.PUBLIC_BASE_PATH);
+  const url = new URL(request.url);
 
-  const suffix = reqUrl.pathname.replace(/^\/carbon-acx/, "") + (reqUrl.search || "");
+  if (url.pathname.startsWith(`${base.withTrailingSlash}artifacts/`)) {
+    return handleArtifactRequest(ctx, base, env.CARBON_ACX_ORIGIN);
+  }
 
-  const origin = (env.CARBON_ACX_ORIGIN || "").replace(/\/$/, "");
+  const suffix = stripBasePath(url.pathname, base) + (url.search || "");
+  const origin = env.CARBON_ACX_ORIGIN?.replace(/\/$/, "");
 
   if (origin) {
     const target = origin + (suffix || "/");
@@ -47,13 +209,13 @@ export const onRequest: PagesFunction<{
     return out;
   }
 
-  const nextResponse = await next();
+  const nextResponse = await ctx.next();
   const headers = nextResponse.headers;
 
-  if (reqUrl.pathname.startsWith("/carbon-acx/artifacts/")) {
+  if (url.pathname.startsWith(`${base.withTrailingSlash}artifacts/`)) {
     headers.set("Cache-Control", "public, max-age=31536000, immutable");
     if (!headers.has("content-type")) {
-      headers.set("content-type", "application/json; charset=utf-8");
+      headers.set("content-type", "application/json");
     }
   }
 

--- a/scripts/dev_diag.sh
+++ b/scripts/dev_diag.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE="${PUBLIC_BASE_PATH:-/carbon-acx/}"
+if [[ "${BASE}" != */ ]]; then
+  BASE="${BASE}/"
+fi
+
+echo "## local"
+curl -i "http://127.0.0.1:4173${BASE}artifacts/layers.json" | sed -n '1,20p'
+
+echo "## prod"
+if [[ -z "${PAGES_DOMAIN:-}" ]]; then
+  echo "Set PAGES_DOMAIN to your Cloudflare Pages domain (e.g. example.pages.dev) to query production." >&2
+else
+  curl -i "https://${PAGES_DOMAIN}${BASE}artifacts/layers.json" | sed -n '1,20p'
+fi

--- a/scripts/prepare_pages_bundle.py
+++ b/scripts/prepare_pages_bundle.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import textwrap
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEV_LAYERS_PATH = REPO_ROOT / "site" / "public" / "artifacts" / "layers.json"
 
 HEADERS_TEMPLATE = (
     textwrap.dedent(
@@ -48,6 +52,24 @@ def prepare_pages_bundle(site_root: Path, artifacts_dir: Path) -> None:
     if target.exists():
         shutil.rmtree(target)
     shutil.copytree(artifacts_dir, target)
+
+    fallback_layers = target / "layers.json"
+    if not fallback_layers.exists() and DEV_LAYERS_PATH.is_file():
+        fallback_layers.write_bytes(DEV_LAYERS_PATH.read_bytes())
+
+    index_path = target / "index.json"
+    if index_path.exists():
+        index_path.unlink()
+
+    entries: list[dict[str, object]] = []
+    for file_path in sorted(target.rglob("*")):
+        if file_path.is_file():
+            relative = file_path.relative_to(target).as_posix()
+            size = file_path.stat().st_size
+            entries.append({"path": relative, "bytes": size})
+
+    index_payload = {"files": entries}
+    index_path.write_text(json.dumps(index_payload, indent=2) + "\n", encoding="utf-8")
 
     _write_headers(site_root)
     _write_redirects(site_root)

--- a/scripts/sync_layers_json.py
+++ b/scripts/sync_layers_json.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_INPUT = Path("data/layers.csv")
+DEFAULT_OUTPUT = Path("site/public/artifacts/layers.json")
+
+
+def _read_rows(path: Path) -> Iterable[dict[str, str]]:
+  if not path.exists():
+    raise FileNotFoundError(f"Layer catalog CSV not found: {path}")
+  with path.open(newline="", encoding="utf-8") as handle:
+    reader = csv.DictReader(handle)
+    for row in reader:
+      yield {key: value or "" for key, value in row.items()}
+
+
+def _normalise_boolean(value: str | None) -> bool | None:
+  if value is None:
+    return None
+  normalised = value.strip().lower()
+  if not normalised:
+    return None
+  if normalised in {"true", "1", "yes"}:
+    return True
+  if normalised in {"false", "0", "no"}:
+    return False
+  return None
+
+
+def _extract_examples(value: str | None) -> list[str]:
+  if not value:
+    return []
+  return [part.strip() for part in value.split(";") if part.strip()]
+
+
+def build_layer_entries(path: Path) -> list[dict[str, object]]:
+  entries: list[dict[str, object]] = []
+  for row in _read_rows(path):
+    layer_id = (row.get("layer_id") or "").strip()
+    if not layer_id:
+      continue
+    title = (row.get("title") or layer_id.replace("_", " ")).strip()
+    summary = (row.get("summary") or "").strip()
+    optional = _normalise_boolean(row.get("ui_optional"))
+    icon = (row.get("icon_slug") or "").strip() or None
+    examples = _extract_examples(row.get("example_activities"))
+    entry: dict[str, object] = {
+      "id": layer_id,
+      "title": title,
+    }
+    if summary:
+      entry["summary"] = summary
+    if optional is not None:
+      entry["optional"] = optional
+    if icon:
+      entry["icon"] = icon
+    if examples:
+      entry["examples"] = examples
+    entries.append(entry)
+  entries.sort(key=lambda item: item["id"])
+  return entries
+
+
+def write_layers(entries: list[dict[str, object]], destination: Path) -> None:
+  destination.parent.mkdir(parents=True, exist_ok=True)
+  with destination.open("w", encoding="utf-8") as handle:
+    json.dump(entries, handle, indent=2, sort_keys=False)
+    handle.write("\n")
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description="Synchronise layers.json for the static site.")
+  parser.add_argument("--csv", type=Path, default=DEFAULT_INPUT, help="Source CSV file (default: data/layers.csv)")
+  parser.add_argument(
+    "--output",
+    type=Path,
+    default=DEFAULT_OUTPUT,
+    help="Destination JSON file (default: site/public/artifacts/layers.json)",
+  )
+  args = parser.parse_args()
+
+  entries = build_layer_entries(args.csv)
+  write_layers(entries, args.output)
+  print(f"Wrote {len(entries)} layers to {args.output}")
+
+
+if __name__ == "__main__":
+  main()

--- a/site/public/artifacts/layers.json
+++ b/site/public/artifacts/layers.json
@@ -1,46 +1,46 @@
 [
   {
-    "id": "professional",
-    "title": "Professional services",
-    "summary": "Baseline knowledge worker footprint anchored to hybrid office routines.",
-    "icon": "professional.svg",
-    "optional": false,
-    "examples": [
-      "Coffee—12 oz hot",
-      "Toronto subway—per passenger-kilometre"
-    ]
-  },
-  {
-    "id": "online",
-    "title": "Online services",
-    "summary": "SaaS, meetings, and streaming workloads for remote-first teams.",
-    "icon": "online.svg",
+    "id": "industrial_heavy",
+    "title": "Industrial (Heavy)",
+    "summary": "Full-scale manufacturing and heavy industry references for R&D insight.",
     "optional": true,
+    "icon": "industrial_heavy.svg",
     "examples": [
-      "Video conferencing hour",
-      "SaaS productivity suite seat"
+      "Steel batch furnace",
+      "Heavy equipment runtime"
     ]
   },
   {
     "id": "industrial_light",
     "title": "Industrial (Light)",
     "summary": "Lab, prototyping, and light fabrication scenarios for innovation hubs.",
-    "icon": "industrial_light.svg",
     "optional": true,
+    "icon": "industrial_light.svg",
     "examples": [
       "Lab bench operation",
       "Prototyping print run"
     ]
   },
   {
-    "id": "industrial_heavy",
-    "title": "Industrial (Heavy)",
-    "summary": "Full-scale manufacturing and heavy industry references for R&D insight.",
-    "icon": "industrial_heavy.svg",
+    "id": "online",
+    "title": "Online services",
+    "summary": "SaaS, meetings, and streaming workloads for remote-first teams.",
     "optional": true,
+    "icon": "online.svg",
     "examples": [
-      "Steel batch furnace",
-      "Heavy equipment runtime"
+      "Video conferencing hour",
+      "SaaS productivity suite seat"
+    ]
+  },
+  {
+    "id": "professional",
+    "title": "Professional services",
+    "summary": "Baseline knowledge worker footprint anchored to hybrid office routines.",
+    "optional": false,
+    "icon": "professional.svg",
+    "examples": [
+      "Coffee\u201412 oz hot",
+      "Toronto subway\u2014per passenger-kilometre"
     ]
   }
 ]

--- a/site/src/basePath.ts
+++ b/site/src/basePath.ts
@@ -1,8 +1,21 @@
-export function basePath() {
-  // If app is served at /carbon-acx/... return '/carbon-acx', else ''
-  const p = window.location.pathname;
-  const m = p.match(/^\/carbon-acx(\/|$)/);
-  return m ? '/carbon-acx' : '';
+import { base } from './lib/paths';
+
+function normaliseBasePath(path: string): string {
+  if (!path) {
+    return '';
+  }
+  let resolved = path;
+  if (!resolved.startsWith('/')) {
+    resolved = `/${resolved}`;
+  }
+  if (resolved !== '/' && resolved.endsWith('/')) {
+    resolved = resolved.slice(0, -1);
+  }
+  return resolved === '/' ? '' : resolved;
+}
+
+export function basePath(): string {
+  return normaliseBasePath(base);
 }
 
 export const ARTIFACTS = () => `${basePath()}/artifacts`;

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -1,4 +1,5 @@
-import { ARTIFACTS } from '../basePath';
+import { artifactUrl } from './paths';
+import { fetchJSON } from './fetchJSON';
 import type { ComputeResult } from '../state/profile';
 
 export type ComputeRequest = Record<string, unknown>;
@@ -14,7 +15,7 @@ function normalisePath(path: string): string {
 }
 
 function resolveArtifactUrl(path: string): string {
-  return `${ARTIFACTS()}/${normalisePath(path)}`;
+  return artifactUrl(normalisePath(path));
 }
 
 const jsonArtifactCache = new Map<string, unknown>();
@@ -44,8 +45,11 @@ async function loadArtifactJson(path: string, signal?: AbortSignal): Promise<unk
   if (jsonArtifactCache.has(path)) {
     return jsonArtifactCache.get(path)!;
   }
-  const response = await fetchArtifact(path, { signal, headers: { Accept: 'application/json' } });
-  const data = await response.json();
+  const data = await fetchJSON<unknown>(resolveArtifactUrl(path), {
+    signal,
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  });
   jsonArtifactCache.set(path, data);
   return data;
 }

--- a/site/src/lib/fetchJSON.test.ts
+++ b/site/src/lib/fetchJSON.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import { fetchJSON, FetchJSONError } from './fetchJSON';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchJSON', () => {
+  it('parses valid JSON payloads', async () => {
+    const payload = { hello: 'world' };
+    const response = new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+    const result = await fetchJSON<typeof payload>('https://example.test/data.json');
+    expect(result).toEqual(payload);
+  });
+
+  it('throws when the response is HTML masquerading as JSON', async () => {
+    const htmlBody = '<!doctype html><html><body>Not Found</body></html>';
+    const response = new Response(htmlBody, {
+      status: 200,
+      headers: { 'content-type': 'text/html' }
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+    await expect(
+      fetchJSON('https://example.test/layers.json').catch((error) => {
+        expect(error).toBeInstanceOf(FetchJSONError);
+        const diag = (error as FetchJSONError).diag;
+        expect(diag.status).toBe(200);
+        expect(diag.bodySnippet).toContain('<!doctype html>');
+        throw error;
+      })
+    ).rejects.toBeInstanceOf(FetchJSONError);
+  });
+
+  it('captures JSON error bodies on non-OK responses', async () => {
+    const body = JSON.stringify({ error: 'not_found' });
+    const response = new Response(body, {
+      status: 404,
+      headers: { 'content-type': 'application/json' }
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+    await expect(
+      fetchJSON('https://example.test/missing.json').catch((error) => {
+        expect(error).toBeInstanceOf(FetchJSONError);
+        const diag = (error as FetchJSONError).diag;
+        expect(diag.status).toBe(404);
+        expect(diag.bodySnippet).toContain('"error"');
+        expect(diag.bodySnippet).toContain('not_found');
+        throw error;
+      })
+    ).rejects.toBeInstanceOf(FetchJSONError);
+  });
+});

--- a/site/src/lib/fetchJSON.ts
+++ b/site/src/lib/fetchJSON.ts
@@ -1,0 +1,103 @@
+export interface FetchJSONDiagnostics {
+  requestUrl: string;
+  finalUrl: string;
+  status: number;
+  statusText: string;
+  contentType: string | null;
+  contentLength: string | null;
+  bodySnippet?: string;
+}
+
+export class FetchJSONError extends Error {
+  public readonly diag: FetchJSONDiagnostics;
+
+  constructor(message: string, diag: FetchJSONDiagnostics) {
+    super(message);
+    this.name = 'FetchJSONError';
+    this.diag = diag;
+  }
+}
+
+function isDebuggingEnabled(): boolean {
+  try {
+    return typeof window !== 'undefined' && window.localStorage.getItem('DEBUG_DATA_LOAD') === '1';
+  } catch {
+    return false;
+  }
+}
+
+function logDebug(message: string, diag: FetchJSONDiagnostics): void {
+  if (isDebuggingEnabled()) {
+    console.debug(message, diag);
+  }
+}
+
+function resolveContentType(response: Response): string | null {
+  const header = response.headers.get('content-type');
+  return header ? header.split(';', 1)[0].trim().toLowerCase() : null;
+}
+
+function buildDiagnostics(request: Request, response: Response | null, bodySnippet?: string): FetchJSONDiagnostics {
+  const contentType = response ? response.headers.get('content-type') : null;
+  const contentLength = response ? response.headers.get('content-length') : null;
+  return {
+    requestUrl: request.url,
+    finalUrl: response ? response.url : request.url,
+    status: response ? response.status : 0,
+    statusText: response ? response.statusText : 'fetch_error',
+    contentType,
+    contentLength,
+    bodySnippet,
+  };
+}
+
+function snippet(input: string): string {
+  return input.length <= 200 ? input : `${input.slice(0, 200)}…`;
+}
+
+export async function fetchJSON<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const request = new Request(input, init);
+  let response: Response;
+
+  try {
+    response = await fetch(request);
+  } catch (error) {
+    const diag = buildDiagnostics(request, null, error instanceof Error ? error.message : String(error));
+    throw new FetchJSONError(`Request failed for ${request.url}`, diag);
+  }
+
+  const diagBase = buildDiagnostics(request, response);
+  const contentType = resolveContentType(response);
+
+  const bodyText = await response.text();
+  const currentDiag = bodyText ? { ...diagBase, bodySnippet: snippet(bodyText) } : diagBase;
+
+  if (!response.ok) {
+    logDebug('fetchJSON error response', currentDiag);
+    throw new FetchJSONError(
+      `Request failed with status ${response.status} ${response.statusText}`.trim(),
+      currentDiag,
+    );
+  }
+
+  if (contentType !== null && contentType !== 'application/json') {
+    logDebug('fetchJSON non-JSON content-type', currentDiag);
+    throw new FetchJSONError(
+      `Expected application/json but received ${contentType || 'unknown content-type'}`,
+      currentDiag,
+    );
+  }
+
+  try {
+    const parsed = JSON.parse(bodyText) as T;
+    logDebug('fetchJSON success', diagBase);
+    return parsed;
+  } catch (error) {
+    const parseDiag = { ...currentDiag };
+    logDebug('fetchJSON parse failure', parseDiag);
+    throw new FetchJSONError(
+      error instanceof Error ? `Unable to parse JSON: ${error.message}` : 'Unable to parse JSON payload',
+      parseDiag,
+    );
+  }
+}

--- a/site/src/lib/paths.ts
+++ b/site/src/lib/paths.ts
@@ -1,0 +1,3 @@
+export const base = import.meta.env.BASE_URL || '/';
+export const artifactsBase = `${base}artifacts/`;
+export const artifactUrl = (name: string) => `${artifactsBase}${name}`;

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react-swc';
 
-// Use env override; fall back to '/carbon-acx/' only when deploying under subpath
-const base = process.env.BUILD_BASE || '/';
+const rawBase = process.env.PUBLIC_BASE_PATH || '/carbon-acx/';
+const base = rawBase.startsWith('/') ? (rawBase.endsWith('/') ? rawBase : `${rawBase}/`) : `/${rawBase.replace(/^\/+/, '')}/`;
 
 export default defineConfig({
   base,


### PR DESCRIPTION
## Summary
- centralize artifact URL construction and add a diagnostic `fetchJSON` helper used by the layer catalog and compute artifact loaders【F:site/src/lib/paths.ts†L1-L3】【F:site/src/lib/fetchJSON.ts†L1-L103】【F:site/src/lib/useLayerCatalog.ts†L1-L188】【F:site/src/lib/api.ts†L1-L134】
- surface readable, copyable error diagnostics (with a mobile toggle) plus an empty-state in the Layer Browser when metadata fails to load【F:site/src/components/LayerBrowser.tsx†L1-L339】
- harden the Pages function so `/artifacts/*` never falls back to HTML and emits explicit content types and JSON errors, while syncing layers.json and emitting an artifact index during packaging with updated tooling/docs【F:functions/carbon-acx/[[path]].ts†L1-L219】【F:scripts/sync_layers_json.py†L1-L93】【F:scripts/prepare_pages_bundle.py†L1-L85】【F:Makefile†L37-L68】【F:site/vite.config.ts†L1-L18】【F:scripts/dev_diag.sh†L1-L17】【F:README.md†L262-L366】

## Testing
- npm run test【ecbeb9†L1-L12】
- make package【483e9f†L1-L23】【763439†L1-L9】【a13233†L1-L1】

------
https://chatgpt.com/codex/tasks/task_e_68dd7b17e044832ca0226c8930e64204