### PR TITLE
feat(ui): surface upstream operations and drill

### DIFF
--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -825,6 +825,66 @@ p {
   display: none;
 }
 
+.upstream-chips {
+  margin-top: clamp(0.5rem, 2vw, 1rem);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.upstream-chips:empty {
+  display: none;
+}
+
+.upstream-chips__label {
+  font-weight: 600;
+}
+
+.upstream-chips__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.upstream-chip {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-muted);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: 0.9rem;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+.upstream-chip:hover,
+.upstream-chip:focus-visible {
+  background: var(--color-accent-subtle);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  outline: none;
+}
+
+.upstream-chip:focus-visible {
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+}
+
+.upstream-chip__name {
+  font-weight: 600;
+}
+
+.upstream-chip__brand {
+  color: var(--color-text-muted);
+}
+
 .layer-panels--grid {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }

--- a/artifacts/dependency_map.json
+++ b/artifacts/dependency_map.json
@@ -6,7 +6,13 @@
       "notes": "Fuel supply",
       "operation_activity_id": "ENERGY.GASOLINE.LITRE",
       "operation_asset_id": "ASSET.SHELL.REF.AB",
-      "operation_functional_unit_id": "FU.L_GASOLINE"
+      "operation_functional_unit_id": "FU.L_GASOLINE",
+      "operation_activity_name": "Gasoline refined & delivered (L)",
+      "operation_activity_label": "Gasoline refined & delivered",
+      "operation_activity_category": "energy",
+      "operation_entity_name": "Shell Canada",
+      "operation_asset_name": "Edmonton refinery",
+      "operation_functional_unit_name": "Refined motor gasoline delivered"
     }
   ],
   "TRAN.TTC.SUBWAY.KM": [
@@ -16,7 +22,13 @@
       "notes": "Traction electricity",
       "operation_activity_id": "ENERGY.KWH.DELIVERED",
       "operation_asset_id": "ASSET.HYDROONE.GRID.CAON",
-      "operation_functional_unit_id": "FU.KWH"
+      "operation_functional_unit_id": "FU.KWH",
+      "operation_activity_name": "Electricity delivered (kWh)",
+      "operation_activity_label": "Electricity delivered",
+      "operation_activity_category": "energy",
+      "operation_entity_name": "Hydro One",
+      "operation_asset_name": "CA-ON grid",
+      "operation_functional_unit_name": "Electrical energy delivered"
     }
   ],
   "MEDIA.STREAM.HD.HOUR": [
@@ -25,7 +37,12 @@
       "share": 1.0,
       "notes": "Platform infra",
       "operation_activity_id": "MEDIA.STREAM.HD.HOUR",
-      "operation_asset_id": "ASSET.GOOGLE.YOUTUBE.GLOBAL"
+      "operation_asset_id": "ASSET.GOOGLE.YOUTUBE.GLOBAL",
+      "operation_activity_name": "HD video streaming—per hour",
+      "operation_activity_label": "HD video streaming",
+      "operation_activity_category": "media",
+      "operation_entity_name": "Google LLC",
+      "operation_asset_name": "YouTube content delivery infrastructure"
     }
   ]
 }

--- a/calc/upstream.py
+++ b/calc/upstream.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Helper utilities for enriching upstream dependency metadata."""
+
+from typing import Mapping
+
+from .schema import Activity, Asset, Entity, FunctionalUnit, Operation, Site
+
+__all__ = ["dependency_metadata"]
+
+
+def _coerce_text(value: object | None) -> str | None:
+    if value in (None, ""):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _short_activity_label(name: str | None) -> str | None:
+    if not name:
+        return None
+    text = name.strip()
+    for separator in ("—", "–", "-", ":"):
+        if separator in text:
+            text = text.split(separator, 1)[0].strip()
+            break
+    if "(" in text:
+        text = text.split("(", 1)[0].strip()
+    return text or name.strip()
+
+
+def dependency_metadata(
+    operation: Operation,
+    *,
+    activities: Mapping[str, Activity] | None = None,
+    assets: Mapping[str, Asset] | None = None,
+    sites: Mapping[str, Site] | None = None,
+    entities: Mapping[str, Entity] | None = None,
+    functional_units: Mapping[str, FunctionalUnit] | None = None,
+) -> dict[str, object]:
+    """Return optional metadata fields for an upstream dependency entry."""
+
+    metadata: dict[str, object] = {}
+
+    activity = activities.get(operation.activity_id) if activities else None
+    if activity is not None:
+        activity_name = _coerce_text(activity.name)
+        if activity_name:
+            metadata["operation_activity_name"] = activity_name
+            short_label = _short_activity_label(activity_name)
+            if short_label:
+                metadata["operation_activity_label"] = short_label
+        category = _coerce_text(activity.category)
+        if category:
+            metadata["operation_activity_category"] = category
+
+    asset = assets.get(operation.asset_id) if assets else None
+    site = sites.get(asset.site_id) if asset and sites else None
+    entity = entities.get(site.entity_id) if site and entities else None
+
+    asset_name = _coerce_text(getattr(asset, "name", None))
+    if asset_name:
+        metadata["operation_asset_name"] = asset_name
+    site_name = _coerce_text(getattr(site, "name", None))
+    if site_name:
+        metadata["operation_site_name"] = site_name
+
+    entity_name = _coerce_text(getattr(entity, "name", None))
+    if entity_name:
+        metadata["operation_entity_name"] = entity_name
+    entity_id = _coerce_text(getattr(entity, "entity_id", None))
+    if entity_id:
+        metadata["operation_entity_id"] = entity_id
+
+    if operation.functional_unit_id and functional_units:
+        functional_unit = functional_units.get(operation.functional_unit_id)
+        if functional_unit is not None:
+            fu_name = _coerce_text(functional_unit.name)
+            if fu_name:
+                metadata["operation_functional_unit_name"] = fu_name
+
+    return metadata
+


### PR DESCRIPTION
## Summary
- enrich derived payloads with upstream operation metadata and include it in dependency artifacts
- render upstream operation chips on civilian bubble charts with drill-through into the intensity view
- style the upstream chips and update the dev dependency map fixture with richer metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd7fe562fc832c9587ae51bc7924d6