### PR TITLE
feat: merge upstream references into habit view

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -474,6 +474,80 @@ def create_app() -> Dash:
 
         return best_layer, best_entries
 
+    def _activity_reference_keys(
+        activity_id: str | None,
+        figures_store_value,
+    ) -> tuple[list[str], str | None]:
+        if not activity_id or not isinstance(figures_store_value, Mapping):
+            return [], None
+
+        bubble_payload = figures_store_value.get("bubble")
+        if not isinstance(bubble_payload, Mapping):
+            return [], None
+
+        data = bubble_payload.get("data")
+        if not isinstance(data, list):
+            return [], None
+
+        for entry in data:
+            if not isinstance(entry, Mapping):
+                continue
+            raw_id = entry.get("activity_id")
+            if raw_id in (None, ""):
+                continue
+            if str(raw_id) != activity_id:
+                continue
+            raw_keys = entry.get("citation_keys")
+            keys = [str(key) for key in raw_keys if isinstance(key, str)] if isinstance(raw_keys, list) else []
+            ordered = _order_reference_keys(keys, reference_lookup)
+            layer_value = entry.get("layer_id")
+            layer_id = str(layer_value) if layer_value not in (None, "") else None
+            return ordered, layer_id
+
+        return [], None
+
+    def _resolve_upstream_reference_keys(
+        activity_id: str | None,
+        figures_store_value,
+        *,
+        layer_hint: str | None = None,
+    ) -> tuple[list[str], str | None]:
+        if not activity_id:
+            return [], layer_hint
+
+        layer_id, upstream_entries = _resolve_upstream_chain(
+            activity_id,
+            figures_store_value,
+            layer_hint=layer_hint,
+        )
+
+        effective_layer = layer_id or layer_hint
+        if effective_layer not in CIVILIAN_LAYERS:
+            return [], layer_id
+
+        upstream_keys: list[str] = []
+        for entry in upstream_entries:
+            if not isinstance(entry, Mapping):
+                continue
+            for field in ("citation_keys", "sources", "source_ids"):
+                raw_values = entry.get(field)
+                if isinstance(raw_values, list):
+                    extend_unique(
+                        [str(item) for item in raw_values if isinstance(item, str)],
+                        upstream_keys,
+                    )
+                elif isinstance(raw_values, str):
+                    extend_unique([raw_values], upstream_keys)
+
+            operation_activity_id = entry.get("operation_activity_id")
+            if operation_activity_id in (None, ""):
+                continue
+            op_keys, _ = _activity_reference_keys(str(operation_activity_id), figures_store_value)
+            extend_unique(op_keys, upstream_keys)
+
+        ordered = _order_reference_keys(upstream_keys, reference_lookup)
+        return ordered, layer_id
+
     def _summarise_layers(
         layers: list[str], metadata_store_value: Mapping | None
     ) -> dict[str, list[str]]:
@@ -1514,9 +1588,11 @@ def create_app() -> Dash:
     @app.callback(
         Output("references", "children"),
         Input("layer-selector", "value"),
+        Input("acx-active-activity", "data"),
         State("layer-citation-keys", "data"),
+        State("figures-store", "data"),
     )
-    def _update_references(selected_layers, layer_map):
+    def _update_references(selected_layers, active_activity, layer_map, figures_store_value):
         layers = selected_layers or []
         if isinstance(layers, str):
             layers = [layers]
@@ -1532,9 +1608,25 @@ def create_app() -> Dash:
             }
 
         reference_keys_for_layers = _resolve_reference_keys(ordered_layers, mapping)
+
+        upstream_keys: list[str] = []
+        if isinstance(active_activity, str) and active_activity:
+            activity_keys, activity_layer = _activity_reference_keys(
+                active_activity,
+                figures_store_value,
+            )
+            if activity_keys:
+                reference_keys_for_layers = activity_keys
+            upstream_keys, _ = _resolve_upstream_reference_keys(
+                active_activity,
+                figures_store_value,
+                layer_hint=activity_layer,
+            )
+
         return references.render_children(
             reference_keys_for_layers,
             include_heading=False,
+            upstream_keys=upstream_keys,
         )
 
     @app.callback(

--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -950,6 +950,24 @@ p {
   color: var(--color-text);
 }
 
+.references-panel__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.references-panel__section + .references-panel__section {
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--color-border);
+}
+
+.references-panel__section h3 {
+  margin: 0;
+  font-size: clamp(1rem, 1.8vw, 1.25rem);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
 .references-list {
   margin: 0;
   padding-left: clamp(1.5rem, 2.5vw, 2.5rem);

--- a/app/components/references.py
+++ b/app/components/references.py
@@ -1,39 +1,125 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Iterable, Sequence
 
 from dash import html
 
 from calc import citations
 
 
-def _reference_texts(reference_keys: Sequence[str] | None) -> list[str]:
-    references = [
-        citations.format_ieee(ref.numbered(idx))
-        for idx, ref in enumerate(citations.references_for(reference_keys or []), start=1)
-    ]
-    if not references:
-        references = ["No references available."]
-    return references
+def _reference_entries(reference_keys: Sequence[str] | None) -> list[tuple[str, int, str]]:
+    entries: list[tuple[str, int, str]] = []
+    for idx, ref in enumerate(citations.references_for(reference_keys or []), start=1):
+        entries.append((ref.key, idx, citations.format_ieee(ref.numbered(idx))))
+    return entries
+
+
+def _combine_keys(
+    primary: Sequence[str] | None, secondary: Sequence[str] | None
+) -> list[str]:
+    keys: list[str] = []
+    for value in (primary or []):
+        if value not in keys:
+            keys.append(value)
+    for value in (secondary or []):
+        if value not in keys:
+            keys.append(value)
+    return keys
+
+
+def _build_items(
+    keys: Iterable[str],
+    lookup: dict[str, tuple[int, str]],
+) -> list[html.Li]:
+    items: list[html.Li] = []
+    for key in keys:
+        payload = lookup.get(key)
+        if not payload:
+            continue
+        index, text = payload
+        attrs = {"children": text}
+        if index is not None:
+            attrs["data-reference-index"] = str(index)
+        items.append(html.Li(**attrs))
+    return items
 
 
 def render_children(
     reference_keys: Sequence[str] | None,
     *,
     include_heading: bool = True,
+    upstream_keys: Sequence[str] | None = None,
 ) -> list[html.Component]:
-    references = _reference_texts(reference_keys)
-    has_indices = bool(reference_keys)
-    items = []
-    for idx, text in enumerate(references, start=1):
-        attrs = {"children": text}
-        if has_indices:
-            attrs["data-reference-index"] = str(idx)
-        items.append(html.Li(**attrs))
+    combined_keys = _combine_keys(reference_keys, upstream_keys)
+    entries = _reference_entries(combined_keys)
+    if not entries:
+        children = [
+            html.H2("References") if include_heading else None,
+            html.P("No references available."),
+        ]
+        return [child for child in children if child is not None]
+
+    entry_lookup = {key: (idx, text) for key, idx, text in entries}
+
+    def _section(
+        title: str,
+        keys: Sequence[str] | None,
+        class_name: str,
+    ) -> html.Div | None:
+        items = _build_items(keys or [], entry_lookup)
+        if not items:
+            return None
+        start_index = None
+        for key in keys or []:
+            payload = entry_lookup.get(key)
+            if payload:
+                start_index = payload[0]
+                break
+        if start_index is None:
+            start_index = entry_lookup[combined_keys[0]][0]
+        return html.Div(
+            [
+                html.H3(title),
+                html.Ol(items, className="references-list", start=start_index),
+            ],
+            className=class_name,
+        )
+
     children: list[html.Component] = []
     if include_heading:
         children.append(html.H2("References"))
-    children.append(html.Ol(items, className="references-list"))
+
+    sections: list[html.Component] = []
+    direct_section = _section(
+        "Direct factors",
+        reference_keys,
+        "references-panel__section references-panel__section--direct",
+    )
+    upstream_section = _section(
+        "Upstream industrial factors",
+        upstream_keys,
+        "references-panel__section references-panel__section--upstream",
+    )
+
+    if direct_section:
+        sections.append(direct_section)
+    if upstream_section:
+        sections.append(upstream_section)
+
+    if not sections:
+        sections.append(
+            html.Div(
+                [
+                    html.Ol(
+                        _build_items(combined_keys, entry_lookup),
+                        className="references-list",
+                    )
+                ],
+                className="references-panel__section",
+            )
+        )
+
+    children.extend(sections)
     return children
 
 


### PR DESCRIPTION
## Summary
- collect activity-level and upstream operation citation keys when a civilian habit is active
- split the references panel into direct and upstream industrial sections with shared numbering
- add styling to the references panel sections for clearer separation

## Testing
- pytest tests/test_app_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68dd89bc6090832c82d819f08ea6f952