### PR TITLE
Add CI artifact for packaged static site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,17 @@ jobs:
           PYTHONPATH: "."
         run: make build-static
 
-      - name: Upload artifacts
+      - name: Upload data artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist-artifacts
           path: dist/artifacts
+
+      - name: Upload static site bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-site
+          path: dist/site
 
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update the CI workflow to upload the compiled site bundle from `dist/site`
- make the workflow label the data and site artifacts distinctly for deployment tooling

## Testing
- npm run build
- make package

------
https://chatgpt.com/codex/tasks/task_e_68df3cf31cc0832c8196fa4dff1ea8d4