### PR TITLE
Fix default base path for Cloudflare deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Additional configuration:
 2. **Continuous integration** — The CI workflow (replicated by `make ci_build_pages`) runs install, lint, test, and packages the static site (`make package`), publishing two artefacts: `dist-artifacts` (data bundle) and `dist-site` (static client).
 3. **Release** — `make release` is a placeholder for future automated releases; production deploys currently upload `dist/site/` to Cloudflare Pages manually or via upstream automation described in `docs/deploy.md`.
 4. **Routing** — `functions/carbon-acx/[[path]].ts` sits alongside the static bundle to proxy or serve `/carbon-acx/*` traffic with opinionated caching headers (see `docs/routes.md`).
-5. **Base path overrides** — Set `PUBLIC_BASE_PATH` when building the site to align with the deployment prefix (defaults to `/carbon-acx/`). The same value flows through Vite’s `base` config and the runtime fetch helpers.
+5. **Base path overrides** — Set `PUBLIC_BASE_PATH` when building the site to align with the deployment prefix (defaults to `/`). The same value flows through Vite’s `base` config and the runtime fetch helpers.
 
 For reproducible deployments, treat `dist/artifacts/latest-build.json` as the pointer to the most recent build hash and package that directory verbatim.
 

--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -20,7 +20,7 @@ interface BasePathInfo {
 }
 
 function normaliseBasePath(raw: string | undefined): BasePathInfo {
-  let base = (raw && raw.trim()) || "/carbon-acx/";
+  let base = (raw && raw.trim()) || "/";
   if (!base.startsWith("/")) {
     base = `/${base}`;
   }

--- a/scripts/dev_diag.sh
+++ b/scripts/dev_diag.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE="${PUBLIC_BASE_PATH:-/carbon-acx/}"
+BASE="${PUBLIC_BASE_PATH:-/}"
 if [[ "${BASE}" != */ ]]; then
   BASE="${BASE}/"
 fi

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react-swc';
 
-const rawBase = process.env.PUBLIC_BASE_PATH || '/carbon-acx/';
+const rawBase = process.env.PUBLIC_BASE_PATH || '/';
 const base = rawBase.startsWith('/') ? (rawBase.endsWith('/') ? rawBase : `${rawBase}/`) : `/${rawBase.replace(/^\/+/, '')}/`;
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- default the static site's base path to "/" so Cloudflare Pages serves scripts and styles with the correct MIME type
- align the Pages function and diagnostic tooling with the new default and document the change

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df4fd64330832ca844f4cf47b2becf