### PR TITLE
feat(app): add agency agency breakdown KPI strip

### DIFF
--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -815,6 +815,49 @@ p {
   gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
+.agency-strip-container {
+  margin-top: clamp(0.25rem, 1.5vw, 0.75rem);
+}
+
+.agency-strip {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-xs);
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.agency-strip--empty {
+  color: var(--color-text-muted);
+}
+
+.agency-strip__segment {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-xxs);
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.agency-strip__segment-label {
+  color: var(--color-text-muted);
+}
+
+.agency-strip__segment-value {
+  font-weight: 600;
+}
+
+.agency-strip__separator {
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.agency-strip__separator + .agency-strip__segment,
+.agency-strip__segment + .agency-strip__separator {
+  margin-left: 0;
+}
+
 .chart-narrative {
   margin-top: clamp(1rem, 2.5vw, 1.75rem);
   color: var(--color-text-muted);

--- a/app/components/agency_strip.py
+++ b/app/components/agency_strip.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+from dash import html
+
+__all__ = ["render"]
+
+
+def _build_segment_contents(segment: Mapping[str, object]) -> list[html.Span]:
+    label = str(segment.get("label", "")).strip() or "Agency"
+    percent = str(segment.get("percent", "")).strip() or "0%"
+    return [
+        html.Span(label, className="agency-strip__segment-label"),
+        html.Span(percent, className="agency-strip__segment-value"),
+    ]
+
+
+def _tooltip_text(segment: Mapping[str, object]) -> str | None:
+    tooltip_lines = segment.get("tooltip_lines")
+    if isinstance(tooltip_lines, Iterable):
+        lines = [str(line) for line in tooltip_lines if str(line).strip()]
+        if lines:
+            return "\n".join(lines)
+    return None
+
+
+def _segment(segment: Mapping[str, object]) -> html.Span:
+    tooltip = _tooltip_text(segment)
+    attrs: dict[str, object] = {
+        "className": "agency-strip__segment",
+        "children": _build_segment_contents(segment),
+    }
+    if tooltip:
+        attrs["title"] = tooltip
+        attrs["aria-label"] = f"{segment.get('label', '')}: {segment.get('percent', '')}. {tooltip.replace('\n', '; ')}"
+    else:
+        attrs["aria-label"] = f"{segment.get('label', '')}: {segment.get('percent', '')}"
+    return html.Span(**attrs)
+
+
+def _separator() -> html.Span:
+    return html.Span("•", className="agency-strip__separator", **{"aria-hidden": "true"})
+
+
+def render(segments: Iterable[Mapping[str, object]] | None, *, empty_message: str | None = None):
+    valid_segments = [segment for segment in segments or []]
+    if not valid_segments:
+        message = empty_message or "Select an activity to view agency contributions."
+        return html.Div(message, className="agency-strip agency-strip--empty")
+
+    children: list[html.Span] = []
+    for idx, segment in enumerate(valid_segments):
+        if idx > 0:
+            children.append(_separator())
+        children.append(_segment(segment))
+
+    return html.Div(children, className="agency-strip", role="list")

--- a/app/components/agency_strip.py
+++ b/app/components/agency_strip.py
@@ -33,7 +33,8 @@ def _segment(segment: Mapping[str, object]) -> html.Span:
     }
     if tooltip:
         attrs["title"] = tooltip
-        attrs["aria-label"] = f"{segment.get('label', '')}: {segment.get('percent', '')}. {tooltip.replace('\n', '; ')}"
+        safe_tooltip = tooltip.replace("\n", "; ")
+        attrs["aria-label"] = f"{segment.get('label', '')}: {segment.get('percent', '')}. {safe_tooltip}"
     else:
         attrs["aria-label"] = f"{segment.get('label', '')}: {segment.get('percent', '')}"
     return html.Span(**attrs)

--- a/app/lib/agency.py
+++ b/app/lib/agency.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+__all__ = ["breakdown_for_activity"]
+
+AGENCY_KEY_ORDER = ["sovereign", "corporate", "institutional", "individual"]
+
+ENTITY_TYPE_TO_AGENCY = {
+    "corporate": "corporate",
+    "company": "corporate",
+    "enterprise": "corporate",
+    "municipal": "institutional",
+    "ngo": "institutional",
+    "nonprofit": "institutional",
+    "university": "institutional",
+    "college": "institutional",
+    "cooperative": "institutional",
+    "public": "institutional",
+    "crown": "sovereign",
+    "federal": "sovereign",
+    "national": "sovereign",
+    "provincial": "sovereign",
+    "state": "sovereign",
+    "territorial": "sovereign",
+    "sovereign": "sovereign",
+}
+
+AGENCY_LABELS = {
+    "corporate": "Corporate",
+    "institutional": "Institutional",
+    "sovereign": "Sovereign",
+    "individual": "Individual",
+}
+
+
+def _coerce_share(value: object) -> float:
+    try:
+        share = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return 0.0
+    if not (share > 0.0):
+        return 0.0
+    return share
+
+
+def _normalise_text(value: object | None) -> str:
+    if value in (None, ""):
+        return ""
+    return str(value).strip()
+
+
+def _operation_label(entry: Mapping[str, object]) -> str:
+    for key in (
+        "operation_activity_label",
+        "operation_activity_name",
+        "operation_activity_id",
+        "operation_id",
+    ):
+        label = _normalise_text(entry.get(key))
+        if label:
+            return label
+    return "Operation"
+
+
+def _entity_label(entry: Mapping[str, object]) -> str:
+    for key in ("operation_entity_name", "operation_entity_id"):
+        value = _normalise_text(entry.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _normalise_entity_type(value: object | None) -> str:
+    text = _normalise_text(value)
+    return text.lower()
+
+
+def _format_percentage(value: float) -> str:
+    percent = value * 100
+    if percent >= 99.5:
+        return "100%"
+    if percent >= 10:
+        return f"{percent:.0f}%"
+    if percent >= 1:
+        text = f"{percent:.1f}"
+        if text.endswith(".0"):
+            text = text[:-2]
+        return f"{text}%"
+    if percent > 0:
+        return "<1%"
+    return "0%"
+
+
+def _agency_rank(agency: str) -> int:
+    try:
+        return AGENCY_KEY_ORDER.index(agency)
+    except ValueError:
+        return len(AGENCY_KEY_ORDER)
+
+
+def _build_tooltip_lines(entries: Iterable[Mapping[str, object]]) -> list[str]:
+    items = []
+    for entry in entries:
+        share = _coerce_share(entry.get("share"))
+        if share <= 0:
+            continue
+        percent = _format_percentage(share)
+        label = _operation_label(entry)
+        entity = _entity_label(entry)
+        if entity:
+            label = f"{label} — {entity}"
+        items.append((share, f"{percent} — {label}"))
+    items.sort(key=lambda item: item[0], reverse=True)
+    return [text for _, text in items]
+
+
+def breakdown_for_activity(
+    activity_id: str | None,
+    dependency_map: Mapping[str, Iterable[Mapping[str, object]]] | None,
+) -> list[dict[str, object]]:
+    if not activity_id or not isinstance(dependency_map, Mapping):
+        return []
+
+    entries = dependency_map.get(activity_id)
+    if not isinstance(entries, Iterable):  # pragma: no cover - defensive
+        return []
+
+    groups: dict[str, dict[str, object]] = {}
+    total_share = 0.0
+
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        share = _coerce_share(entry.get("share"))
+        if share <= 0:
+            continue
+        total_share += share
+        entity_type = _normalise_entity_type(entry.get("operation_entity_type"))
+        agency = ENTITY_TYPE_TO_AGENCY.get(entity_type, "institutional")
+        bucket = groups.setdefault(agency, {"share": 0.0, "entries": []})
+        bucket["share"] = float(bucket.get("share", 0.0)) + share
+        bucket_entries = bucket.setdefault("entries", [])
+        if isinstance(bucket_entries, list):
+            bucket_entries.append(entry)
+
+    if not groups:
+        return []
+
+    total_share = max(0.0, min(total_share, 1.0))
+    individual_share = max(0.0, 1.0 - total_share)
+
+    segments: list[dict[str, object]] = []
+    for agency, payload in groups.items():
+        share = float(payload.get("share", 0.0))
+        if share <= 0:
+            continue
+        entries_for_tooltip = payload.get("entries")
+        tooltip_lines: list[str] = []
+        if isinstance(entries_for_tooltip, Iterable):
+            tooltip_lines = _build_tooltip_lines(entries_for_tooltip)
+        segments.append(
+            {
+                "agency": agency,
+                "label": AGENCY_LABELS.get(agency, agency.title()),
+                "share": share,
+                "percent": _format_percentage(share),
+                "tooltip_lines": tooltip_lines,
+            }
+        )
+
+    if individual_share > 0.0005:
+        segments.append(
+            {
+                "agency": "individual",
+                "label": AGENCY_LABELS["individual"],
+                "share": individual_share,
+                "percent": _format_percentage(individual_share),
+                "tooltip_lines": [],
+            }
+        )
+
+    segments.sort(key=lambda item: (-float(item.get("share", 0.0)), _agency_rank(str(item.get("agency")))))
+    return segments

--- a/artifacts/dependency_map.json
+++ b/artifacts/dependency_map.json
@@ -1,48 +1,54 @@
 {
+  "MEDIA.STREAM.HD.HOUR": [
+    {
+      "notes": "Platform infra",
+      "operation_activity_category": "media",
+      "operation_activity_id": "MEDIA.STREAM.HD.HOUR",
+      "operation_activity_label": "HD video streaming",
+      "operation_activity_name": "HD video streaming\u2014per hour",
+      "operation_asset_id": "ASSET.GOOGLE.YOUTUBE.GLOBAL",
+      "operation_asset_name": "YouTube content delivery infrastructure",
+      "operation_entity_id": "ENTITY.GOOGLE.US",
+      "operation_entity_name": "Google LLC",
+      "operation_entity_type": "corporate",
+      "operation_id": "OP.YOUTUBE.HD.HOUR2025",
+      "share": 1.0
+    }
+  ],
   "TRAN.SCHOOLRUN.CAR.KM": [
     {
-      "operation_id": "OP.SHELL.GASOLINE2024",
-      "share": 1.0,
       "notes": "Fuel supply",
-      "operation_activity_id": "ENERGY.GASOLINE.LITRE",
-      "operation_asset_id": "ASSET.SHELL.REF.AB",
-      "operation_functional_unit_id": "FU.L_GASOLINE",
-      "operation_activity_name": "Gasoline refined & delivered (L)",
-      "operation_activity_label": "Gasoline refined & delivered",
       "operation_activity_category": "energy",
-      "operation_entity_name": "Shell Canada",
+      "operation_activity_id": "ENERGY.GASOLINE.LITRE",
+      "operation_activity_label": "Gasoline refined & delivered",
+      "operation_activity_name": "Gasoline refined & delivered (L)",
+      "operation_asset_id": "ASSET.SHELL.REF.AB",
       "operation_asset_name": "Edmonton refinery",
-      "operation_functional_unit_name": "Refined motor gasoline delivered"
+      "operation_entity_id": "ENTITY.SHELL.CA",
+      "operation_entity_name": "Shell Canada",
+      "operation_entity_type": "corporate",
+      "operation_functional_unit_id": "FU.L_GASOLINE",
+      "operation_functional_unit_name": "Refined motor gasoline delivered",
+      "operation_id": "OP.SHELL.GASOLINE2024",
+      "share": 1.0
     }
   ],
   "TRAN.TTC.SUBWAY.KM": [
     {
-      "operation_id": "OP.HYDROONE.KWH2024",
-      "share": 1.0,
       "notes": "Traction electricity",
-      "operation_activity_id": "ENERGY.KWH.DELIVERED",
-      "operation_asset_id": "ASSET.HYDROONE.GRID.CAON",
-      "operation_functional_unit_id": "FU.KWH",
-      "operation_activity_name": "Electricity delivered (kWh)",
-      "operation_activity_label": "Electricity delivered",
       "operation_activity_category": "energy",
-      "operation_entity_name": "Hydro One",
+      "operation_activity_id": "ENERGY.KWH.DELIVERED",
+      "operation_activity_label": "Electricity delivered",
+      "operation_activity_name": "Electricity delivered (kWh)",
+      "operation_asset_id": "ASSET.HYDROONE.GRID.CAON",
       "operation_asset_name": "CA-ON grid",
-      "operation_functional_unit_name": "Electrical energy delivered"
-    }
-  ],
-  "MEDIA.STREAM.HD.HOUR": [
-    {
-      "operation_id": "OP.YOUTUBE.HD.HOUR2025",
-      "share": 1.0,
-      "notes": "Platform infra",
-      "operation_activity_id": "MEDIA.STREAM.HD.HOUR",
-      "operation_asset_id": "ASSET.GOOGLE.YOUTUBE.GLOBAL",
-      "operation_activity_name": "HD video streaming—per hour",
-      "operation_activity_label": "HD video streaming",
-      "operation_activity_category": "media",
-      "operation_entity_name": "Google LLC",
-      "operation_asset_name": "YouTube content delivery infrastructure"
+      "operation_entity_id": "ENTITY.HYDROONE.CA",
+      "operation_entity_name": "Hydro One",
+      "operation_entity_type": "corporate",
+      "operation_functional_unit_id": "FU.KWH",
+      "operation_functional_unit_name": "Electrical energy delivered",
+      "operation_id": "OP.HYDROONE.KWH2024",
+      "share": 1.0
     }
   ]
 }

--- a/calc/upstream.py
+++ b/calc/upstream.py
@@ -71,6 +71,11 @@ def dependency_metadata(
     entity_id = _coerce_text(getattr(entity, "entity_id", None))
     if entity_id:
         metadata["operation_entity_id"] = entity_id
+    entity_type = getattr(entity, "type", None)
+    if entity_type:
+        metadata["operation_entity_type"] = (
+            entity_type.value if hasattr(entity_type, "value") else str(entity_type)
+        )
 
     if operation.functional_unit_id and functional_units:
         functional_unit = functional_units.get(operation.functional_unit_id)

--- a/tests/test_agency_breakdown.py
+++ b/tests/test_agency_breakdown.py
@@ -1,0 +1,51 @@
+from app.lib.agency import breakdown_for_activity
+
+
+def test_breakdown_returns_segments_with_individual_share():
+    dependency_map = {
+        "ACT.TRANSPORT": [
+            {
+                "share": 0.72,
+                "operation_activity_label": "Gasoline refining",
+                "operation_entity_name": "Shell Canada",
+                "operation_entity_type": "corporate",
+            },
+            {
+                "share": 0.18,
+                "operation_activity_label": "Transit electricity",
+                "operation_entity_name": "Toronto Hydro",
+                "operation_entity_type": "municipal",
+            },
+        ]
+    }
+
+    segments = breakdown_for_activity("ACT.TRANSPORT", dependency_map)
+
+    labels = [segment["label"] for segment in segments]
+    assert labels == ["Corporate", "Institutional", "Individual"]
+    assert segments[0]["percent"] == "72%"
+    assert segments[1]["percent"] == "18%"
+    assert segments[2]["percent"] == "10%"
+    tooltip_lines = segments[0]["tooltip_lines"]
+    assert tooltip_lines and "Shell Canada" in tooltip_lines[0]
+
+
+def test_breakdown_handles_unknown_types_as_institutional():
+    dependency_map = {
+        "ACT.UNKNOWN": [
+            {"share": 0.5, "operation_activity_label": "Service", "operation_entity_type": "cooperative"}
+        ]
+    }
+
+    segments = breakdown_for_activity("ACT.UNKNOWN", dependency_map)
+
+    assert len(segments) == 2
+    assert segments[0]["label"] == "Institutional"
+    assert segments[0]["percent"] == "50%"
+    assert segments[1]["label"] == "Individual"
+    assert segments[1]["percent"] == "50%"
+
+
+def test_breakdown_empty_for_missing_activity():
+    dependency_map = {}
+    assert breakdown_for_activity("ACT.NONE", dependency_map) == []


### PR DESCRIPTION
## Summary
- load the upstream dependency map into the Dash app and render a new agency KPI strip for the selected activity
- add aggregation logic that maps operation entity types to agency classes and formats tooltip content
- style the strip, propagate entity types in dependency metadata, and cover the breakdown logic with unit tests

## Testing
- pytest tests/test_agency_breakdown.py
- pytest tests/test_app_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68e1483534dc832cb4ce0b9e758a6c18