### PR TITLE
Adjust keyboard navigation for stage controls

### DIFF
--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -124,25 +124,29 @@ export function Layout({
 
   const handleStageKeyDown = (meta: StageMeta) => (event: KeyboardEvent<HTMLButtonElement>) => {
     const key = event.key.toLowerCase();
-    const currentIndex = stageIds.indexOf(stage);
+    const currentIndex = stageIds.indexOf(meta.id);
+    const changeStage = (nextStageId: StageId | undefined) => {
+      if (!nextStageId || nextStageId === stage || !isStageUnlocked(nextStageId)) {
+        return;
+      }
+      onStageChange(nextStageId);
+    };
     if (key === 'arrowright' || key === 'arrowdown') {
       event.preventDefault();
       const nextIndex = findNextUnlockedIndex(currentIndex, 1);
-      onStageChange(stageIds[nextIndex] ?? meta.id);
+      changeStage(stageIds[nextIndex] ?? meta.id);
       return;
     }
     if (key === 'arrowleft' || key === 'arrowup') {
       event.preventDefault();
       const nextIndex = findNextUnlockedIndex(currentIndex, -1);
-      onStageChange(stageIds[nextIndex] ?? meta.id);
+      changeStage(stageIds[nextIndex] ?? meta.id);
       return;
     }
     if (key === 'home') {
       event.preventDefault();
       const firstUnlocked = stageIds.find((candidate) => isStageUnlocked(candidate));
-      if (firstUnlocked) {
-        onStageChange(firstUnlocked);
-      }
+      changeStage(firstUnlocked);
       return;
     }
     if (key === 'end') {
@@ -150,7 +154,7 @@ export function Layout({
       for (let index = stageIds.length - 1; index >= 0; index -= 1) {
         const candidate = stageIds[index];
         if (isStageUnlocked(candidate)) {
-          onStageChange(candidate);
+          changeStage(candidate);
           break;
         }
       }

--- a/site/src/components/VizCanvas.tsx
+++ b/site/src/components/VizCanvas.tsx
@@ -1122,7 +1122,9 @@ interface VisualizerPanelProps {
 function VisualizerPanel({ id, title, summary, children, expanded, onToggle }: VisualizerPanelProps) {
   return (
     <section
+      id={id}
       aria-labelledby={`${id}-heading`}
+      tabIndex={-1}
       className="rounded-2xl border border-slate-800/80 bg-slate-950/60 p-[var(--gap-1)] shadow-inner shadow-slate-900/40 sm:p-[var(--gap-2)]"
     >
       <div className="flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
## Summary
- derive stage navigation indices from the focused control while preventing redundant updates
- keep Home/End behavior and selection shortcuts intact for stage buttons
- make visualization panels programmatically focusable via id and tabIndex

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1a0dbd880832c82be9bdce961ce5b