### PR TITLE
Schema v1.2 sector canonical migration and UI density updates

### DIFF
--- a/CHANGELOG_ACX041.md
+++ b/CHANGELOG_ACX041.md
@@ -2,6 +2,9 @@
 
 This changelog tracks local progress toward implementing the ACX041 View Provenance module.
 
+## 2025-10-06
+- Documented schema v1.2 migration replacing segment terminology with sector, retaining manifest compatibility and alias reads.
+
 ## 2024-05-20
 - Initialized changelog with placeholder entry outlining pending workstreams for ACX041 manifest implementation.
 - Documented outstanding tasks spanning manifest generation, CI enforcement, frontend verification, governance updates, and QA artifact collection.

--- a/calc/dal/aliases.py
+++ b/calc/dal/aliases.py
@@ -1,0 +1,110 @@
+"""Term alias helpers for datastore hydration and schema normalisation."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+import pandas as pd
+
+
+def _is_missing(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    try:
+        return bool(pd.isna(value))
+    except Exception:  # pragma: no cover - defensive fallback
+        return False
+
+TERM_ALIASES: dict[str, str] = {
+    "segment": "sector",
+    "segment_id": "sector_id",
+    "segment_name": "sector_name",
+    "segment_label": "sector_label",
+    "Segment": "Sector",
+    "Segments": "Sectors",
+}
+
+_PREFIX_ALIASES: tuple[tuple[str, str], ...] = (
+    ("segment_", "sector_"),
+    ("Segment ", "Sector "),
+    ("segment", "sector"),
+)
+
+_SUFFIX_ALIASES: tuple[tuple[str, str], ...] = (
+    ("_segment", "_sector"),
+    ("Segment", "Sector"),
+)
+
+
+def canonical_term(key: str) -> str:
+    """Return the canonical representation for ``key`` using term aliases."""
+
+    replacement = TERM_ALIASES.get(key)
+    if replacement is not None:
+        return replacement
+
+    for prefix, canonical in _PREFIX_ALIASES:
+        if key.startswith(prefix):
+            return canonical + key[len(prefix) :]
+
+    for suffix, canonical in _SUFFIX_ALIASES:
+        if key.endswith(suffix):
+            return key[: -len(suffix)] + canonical
+
+    return key
+
+
+def remap_record(record: Mapping[str, object]) -> dict[str, object]:
+    """Return a copy of ``record`` with legacy segment keys normalised."""
+
+    remapped: dict[str, object] = {}
+    for raw_key, value in record.items():
+        if isinstance(raw_key, str):
+            key = canonical_term(raw_key)
+        else:  # pragma: no cover - defensive branch for non-string keys
+            key = raw_key
+        existing = remapped.get(key)
+        if _is_missing(existing) and not _is_missing(value):
+            remapped[key] = value
+        elif key not in remapped:
+            remapped[key] = value
+    return remapped
+
+
+def remap_columns(columns: Iterable[str]) -> dict[str, str]:
+    """Return a rename mapping suitable for :meth:`pandas.DataFrame.rename`."""
+
+    mapping: dict[str, str] = {}
+    for column in columns:
+        canonical = canonical_term(column)
+        if canonical != column:
+            mapping[column] = canonical
+    return mapping
+
+
+def coalesce_alias_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    """Return ``frame`` with alias columns folded into their canonical names."""
+
+    for alias, canonical in list(TERM_ALIASES.items()):
+        if alias not in frame.columns:
+            continue
+        if canonical in frame.columns:
+            frame[canonical] = frame[canonical].where(
+                ~frame[canonical].map(_is_missing), frame[alias]
+            )
+        else:
+            frame[canonical] = frame[alias]
+        frame = frame.drop(columns=[alias])
+    return frame
+
+
+__all__ = [
+    "TERM_ALIASES",
+    "canonical_term",
+    "coalesce_alias_columns",
+    "remap_columns",
+    "remap_record",
+]
+

--- a/calc/dal/aliases.py
+++ b/calc/dal/aliases.py
@@ -17,6 +17,7 @@ def _is_missing(value: object) -> bool:
     except Exception:  # pragma: no cover - defensive fallback
         return False
 
+
 TERM_ALIASES: dict[str, str] = {
     "segment": "sector",
     "segment_id": "sector_id",
@@ -107,4 +108,3 @@ __all__ = [
     "remap_columns",
     "remap_record",
 ]
-

--- a/calc/dal/csv.py
+++ b/calc/dal/csv.py
@@ -18,6 +18,7 @@ from ..schema import (
     Profile,
     Site,
 )
+from .aliases import remap_record
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 
@@ -25,7 +26,7 @@ DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 def _load_csv(path: Path) -> List[dict]:
     df = pd.read_csv(path, dtype=object)
     df = df.where(pd.notnull(df), None)
-    return df.to_dict(orient="records")
+    return [remap_record(row) for row in df.to_dict(orient="records")]
 
 
 class CsvStore:

--- a/calc/figures.py
+++ b/calc/figures.py
@@ -198,9 +198,7 @@ def slice_stacked(
     if has_sector:
         group_keys.insert(1, "sector")
     aggregated = (
-        frame.groupby(group_keys, dropna=False)[value_columns]
-        .sum(min_count=1)
-        .reset_index()
+        frame.groupby(group_keys, dropna=False)[value_columns].sum(min_count=1).reset_index()
     )
     aggregated["_layer_rank"] = aggregated["layer_id"].map(_layer_rank)
     sort_keys = ["_layer_rank", "layer_id"]
@@ -286,9 +284,7 @@ def slice_bubble(
     if has_sector:
         group_keys.insert(3, "sector")
     aggregated = (
-        frame.groupby(group_keys, dropna=False)[value_columns]
-        .sum(min_count=1)
-        .reset_index()
+        frame.groupby(group_keys, dropna=False)[value_columns].sum(min_count=1).reset_index()
     )
     aggregated["_layer_rank"] = aggregated["layer_id"].map(_layer_rank)
     sort_keys = ["_layer_rank", "layer_id", "activity_id", "activity_name"]

--- a/calc/figures.py
+++ b/calc/figures.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pandas as pd
 import yaml
 
+from .dal.aliases import coalesce_alias_columns, remap_columns
 from .schema import Activity, FeedbackLoop, LayerId
 
 CONFIG_PATH = Path(__file__).parent / "config.yaml"
@@ -143,6 +144,13 @@ def _normalise_layer(value: Any) -> str | None:
     return str(value)
 
 
+def _normalise_sector(value: Any) -> str | None:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _layer_rank(value: str | None) -> int:
     if value in LAYER_ORDER:
         return LAYER_ORDER.index(value)
@@ -178,19 +186,31 @@ def slice_stacked(
             "layer_id",
         ],
     ).copy()
+    frame = coalesce_alias_columns(frame)
+    frame = frame.rename(columns=remap_columns(frame.columns))
+    has_sector = "sector" in frame.columns
     frame["activity_category"] = frame["activity_category"].map(_normalise_category)
     frame["layer_id"] = frame["layer_id"].map(_normalise_layer)
+    if has_sector:
+        frame["sector"] = frame["sector"].map(_normalise_sector)
     value_columns = _value_columns(frame)
+    group_keys = ["layer_id", "activity_category"]
+    if has_sector:
+        group_keys.insert(1, "sector")
     aggregated = (
-        frame.groupby(["layer_id", "activity_category"], dropna=False)[value_columns]
+        frame.groupby(group_keys, dropna=False)[value_columns]
         .sum(min_count=1)
         .reset_index()
     )
     aggregated["_layer_rank"] = aggregated["layer_id"].map(_layer_rank)
-    aggregated = aggregated.sort_values(
-        ["_layer_rank", "layer_id", "activity_category", "annual_emissions_g"],
-        ascending=[True, True, True, False],
-    )
+    sort_keys = ["_layer_rank", "layer_id"]
+    if has_sector:
+        sort_keys.append("sector")
+    sort_keys.extend(["activity_category", "annual_emissions_g"])
+    ascending = [True] * len(sort_keys)
+    if ascending:
+        ascending[-1] = False
+    aggregated = aggregated.sort_values(sort_keys, ascending=ascending)
 
     results: list[dict] = []
     for _, row in aggregated.iterrows():
@@ -199,14 +219,17 @@ def slice_stacked(
             continue
         layer = _normalise_layer(row.get("layer_id"))
         category = row["activity_category"]
+        sector = row.get("sector") if has_sector else None
+        category_key = sector if sector is not None else category
         entry = {
             "layer_id": layer,
             "category": category,
+            "sector": sector,
             "values": values,
             "units": dict(ANNUAL_EMISSIONS_UNITS),
         }
         if reference_map is not None:
-            payload = reference_map.get((layer, category))
+            payload = reference_map.get((layer, category_key))
             if payload:
                 keys, indices = payload
                 if keys:
@@ -222,6 +245,7 @@ class BubblePoint:
     activity_id: str
     activity_name: str
     category: str | None
+    sector: str | None
     layer_id: str | None
     values: dict
     units: dict[str, str]
@@ -245,33 +269,36 @@ def slice_bubble(
             "layer_id",
         ],
     ).copy()
+    frame = coalesce_alias_columns(frame)
+    frame = frame.rename(columns=remap_columns(frame.columns))
+    has_sector = "sector" in frame.columns
     frame["activity_name"] = frame.apply(
         lambda row: row["activity_name"] if row["activity_name"] else row["activity_id"],
         axis=1,
     )
     frame["activity_category"] = frame["activity_category"].map(_normalise_category)
     frame["layer_id"] = frame["layer_id"].map(_normalise_layer)
+    if has_sector:
+        frame["sector"] = frame["sector"].map(_normalise_sector)
 
     value_columns = _value_columns(frame)
+    group_keys = ["layer_id", "activity_id", "activity_name", "activity_category"]
+    if has_sector:
+        group_keys.insert(3, "sector")
     aggregated = (
-        frame.groupby(
-            ["layer_id", "activity_id", "activity_name", "activity_category"],
-            dropna=False,
-        )[value_columns]
+        frame.groupby(group_keys, dropna=False)[value_columns]
         .sum(min_count=1)
         .reset_index()
     )
     aggregated["_layer_rank"] = aggregated["layer_id"].map(_layer_rank)
-    aggregated = aggregated.sort_values(
-        [
-            "_layer_rank",
-            "layer_id",
-            "activity_id",
-            "activity_name",
-            "annual_emissions_g",
-        ],
-        ascending=[True, True, True, True, False],
-    )
+    sort_keys = ["_layer_rank", "layer_id", "activity_id", "activity_name"]
+    if has_sector:
+        sort_keys.append("sector")
+    sort_keys.append("annual_emissions_g")
+    ascending = [True] * len(sort_keys)
+    if ascending:
+        ascending[-1] = False
+    aggregated = aggregated.sort_values(sort_keys, ascending=ascending)
 
     results: list[BubblePoint] = []
     for _, row in aggregated.iterrows():
@@ -279,6 +306,7 @@ def slice_bubble(
         if values is None:
             continue
         layer = _normalise_layer(row.get("layer_id"))
+        sector = row.get("sector") if has_sector else None
         ref_keys: list[str] | None = None
         ref_indices: list[int] | None = None
         if reference_map is not None:
@@ -291,6 +319,7 @@ def slice_bubble(
                 activity_id=str(row["activity_id"]),
                 activity_name=str(row["activity_name"]),
                 category=row["activity_category"],
+                sector=sector,
                 layer_id=layer,
                 values=values,
                 units=dict(ANNUAL_EMISSIONS_UNITS),
@@ -348,33 +377,40 @@ def slice_sankey(
             "layer_id",
         ],
     ).copy()
+    frame = coalesce_alias_columns(frame)
+    frame = frame.rename(columns=remap_columns(frame.columns))
+    has_sector = "sector" in frame.columns
     frame["activity_name"] = frame.apply(
         lambda row: row["activity_name"] if row["activity_name"] else row["activity_id"],
         axis=1,
     )
     frame["activity_category"] = frame["activity_category"].map(_normalise_category)
     frame["layer_id"] = frame["layer_id"].map(_normalise_layer)
+    if has_sector:
+        frame["sector"] = frame["sector"].map(_normalise_sector)
 
     value_columns = _value_columns(frame)
     aggregated = (
         frame.groupby(
-            ["layer_id", "activity_category", "activity_id", "activity_name"], dropna=False
+            (
+                ["layer_id", "activity_category", "activity_id", "activity_name"]
+                if not has_sector
+                else ["layer_id", "sector", "activity_category", "activity_id", "activity_name"]
+            ),
+            dropna=False,
         )[value_columns]
         .sum(min_count=1)
         .reset_index()
     )
     aggregated["_layer_rank"] = aggregated["layer_id"].map(_layer_rank)
-    aggregated = aggregated.sort_values(
-        [
-            "_layer_rank",
-            "layer_id",
-            "activity_category",
-            "activity_id",
-            "activity_name",
-            "annual_emissions_g",
-        ],
-        ascending=[True, True, True, True, True, False],
-    )
+    sort_keys = ["_layer_rank", "layer_id"]
+    if has_sector:
+        sort_keys.append("sector")
+    sort_keys.extend(["activity_category", "activity_id", "activity_name", "annual_emissions_g"])
+    ascending = [True] * len(sort_keys)
+    if ascending:
+        ascending[-1] = False
+    aggregated = aggregated.sort_values(sort_keys, ascending=ascending)
 
     nodes: dict[tuple[str, str], dict] = {}
     two_stage_nodes: dict[str, dict] = {}
@@ -427,7 +463,9 @@ def slice_sankey(
         if values is None:
             continue
         layer = _normalise_layer(row.get("layer_id"))
-        category_label = str(row["activity_category"])
+        raw_category = row["activity_category"]
+        sector = row.get("sector") if has_sector else None
+        category_label = str(sector) if sector is not None else str(raw_category)
         activity_label = str(row["activity_name"])
         activity_id = str(row["activity_id"])
         source = _ensure_node("category", category_label)
@@ -436,7 +474,8 @@ def slice_sankey(
             "source": source["id"],
             "target": target["id"],
             "activity_id": activity_id,
-            "category": category_label,
+            "category": raw_category,
+            "sector": sector,
             "layer_id": layer,
             "values": values,
             "units": dict(ANNUAL_EMISSIONS_UNITS),
@@ -482,7 +521,8 @@ def slice_sankey(
                 "source": operation_node_id,
                 "target": activity_node_id,
                 "activity_id": activity_id,
-                "category": category_label,
+                "category": raw_category,
+                "sector": sector,
                 "layer_id": layer,
                 "values": link_values,
                 "units": dict(ANNUAL_EMISSIONS_UNITS),

--- a/calc/outputs/governance_log.txt
+++ b/calc/outputs/governance_log.txt
@@ -4,3 +4,4 @@ number_of_rows_changed: 0
 tests_passed: True
 citation_count: 55
 ambiguity_flag_count: 78
+notes: Schema v1.2 — segment → sector (dual-read, write-sector)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- _No changes yet._
+- Schema v1.2 — 'segment' → 'sector' (dual-read, write-sector).
 
 ## v1.2 - 2025-10-06
 

--- a/site/src/components/ActivityPlanner.tsx
+++ b/site/src/components/ActivityPlanner.tsx
@@ -30,7 +30,7 @@ function formatStreaming(hours: number): string {
 export function ActivityPlanner(): JSX.Element {
   const { controls, activeLayers, primaryLayer } = useProfile();
 
-  const workingSegments = useMemo(() => {
+  const workingSectors = useMemo(() => {
     if (activeLayers.length > 0) {
       return activeLayers;
     }
@@ -52,18 +52,18 @@ export function ActivityPlanner(): JSX.Element {
   return (
     <div className="space-y-[calc(var(--gap-1)*0.9)]">
       <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-[calc(var(--gap-1)*0.85)] shadow-inner shadow-slate-950/60">
-        <h3 className="text-[12px] font-semibold uppercase tracking-[0.3em] text-slate-300">Active segments</h3>
+        <h3 className="text-[12px] font-semibold uppercase tracking-[0.3em] text-slate-300">Active sectors</h3>
         <p className="mt-[8px] text-[12px] text-slate-400">
-          Start with the segments below, then layer in additional detail as questions surface.
+          Start with the sectors below, then layer in additional detail as questions surface.
         </p>
         <ul className="mt-[calc(var(--gap-0)*0.9)] flex flex-wrap gap-[calc(var(--gap-0)*0.75)]">
-          {workingSegments.map((segment) => (
+          {workingSectors.map((sector) => (
             <li
-              key={segment}
+              key={sector}
               className="inline-flex items-center gap-[6px] rounded-full border border-sky-500/40 bg-sky-500/10 px-[var(--gap-0)] py-[4px] text-[11px] font-medium uppercase tracking-[0.18em] text-sky-100"
             >
               <span className="h-[6px] w-[6px] rounded-full bg-sky-400" aria-hidden="true" />
-              {segment}
+              {sector}
             </li>
           ))}
         </ul>

--- a/site/src/components/Bubble.tsx
+++ b/site/src/components/Bubble.tsx
@@ -13,6 +13,7 @@ export interface BubbleDatum extends ReferenceCarrier {
   activity_id?: string | null;
   activity_name?: string | null;
   category?: string | null;
+  sector?: string | null;
   values?: {
     mean?: number | null;
   } | null;

--- a/site/src/components/Bubble.tsx
+++ b/site/src/components/Bubble.tsx
@@ -42,18 +42,6 @@ const PADDING_Y = 50;
 const MAX_RADIUS = 42;
 const AXIS_FONT_SIZE = 11;
 const AXIS_TICK_FONT_SIZE = 10;
-const MIN_LABEL_FONT_SIZE = 10;
-const MAX_LABEL_FONT_SIZE = 16;
-
-function resolveLabelFontSize(radius: number): number {
-  if (!Number.isFinite(radius) || radius <= 0) {
-    return MIN_LABEL_FONT_SIZE;
-  }
-  const computed = radius * 0.45;
-  const bounded = Math.max(MIN_LABEL_FONT_SIZE, Math.min(MAX_LABEL_FONT_SIZE, computed));
-  return Math.round(bounded);
-}
-
 function toCategory(value: string | null | undefined): string {
   if (!value) {
     return 'Other';
@@ -157,8 +145,6 @@ export function Bubble({
             const relative = point.kilograms / maxKg;
             const cy = PADDING_Y + chartHeight - relative * chartHeight;
             const radius = Math.max(8, Math.sqrt(relative) * MAX_RADIUS);
-            const labelFontSize = resolveLabelFontSize(radius);
-            const labelOffset = radius + labelFontSize + 4;
             return (
               <g
                 key={point.key}
@@ -174,14 +160,6 @@ export function Bubble({
                 >
                   <title>{point.hint}</title>
                 </circle>
-                <text
-                  y={labelOffset}
-                  textAnchor="middle"
-                  className="fill-slate-200 font-medium"
-                  style={{ fontSize: `${labelFontSize}px` }}
-                >
-                  {point.label}
-                </text>
               </g>
             );
           })}

--- a/site/src/components/LayerBrowser.tsx
+++ b/site/src/components/LayerBrowser.tsx
@@ -92,7 +92,7 @@ function focusVisualization(target: ViewTarget): void {
   });
 }
 
-export function LayerBrowser(): JSX.Element {
+export function SectorBrowser(): JSX.Element {
   const { layers, audit, loading, error } = useLayerCatalog();
   const { availableLayers, activeLayers, setActiveLayers } = useProfile();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -208,7 +208,7 @@ export function LayerBrowser(): JSX.Element {
     return (
       <section className="acx-card bg-slate-950/60">
         <header className="flex items-center justify-between gap-[var(--gap-0)]">
-          <h2 className="text-[13px] font-semibold">Segment Browser</h2>
+          <h2 className="text-[13px] font-semibold">Sector Browser</h2>
           <span className="text-[10px] uppercase tracking-[0.3em] text-slate-400">Loading…</span>
         </header>
         <div className="mt-[var(--gap-1)] space-y-[var(--gap-0)]">
@@ -227,12 +227,12 @@ export function LayerBrowser(): JSX.Element {
   if (error) {
     const isNotFound = errorDiag?.status === 404;
     const message = isNotFound
-      ? 'Segment catalog not found. Confirm site/public/artifacts/layers.json is present.'
-      : 'Unable to load segment metadata.';
+      ? 'Sector catalog not found. Confirm site/public/artifacts/layers.json is present.'
+      : 'Unable to load sector metadata.';
     return (
       <section className="acx-card bg-slate-950/60">
         <header className="flex items-center justify-between gap-[var(--gap-0)]">
-          <h2 className="text-[13px] font-semibold">Segment Browser</h2>
+          <h2 className="text-[13px] font-semibold">Sector Browser</h2>
         </header>
         <div className="mt-[var(--gap-1)] space-y-[var(--gap-1)]">
           <p className="text-sm text-rose-300">
@@ -293,10 +293,10 @@ export function LayerBrowser(): JSX.Element {
     return (
       <section className="acx-card bg-slate-950/60">
         <header className="flex items-center justify-between gap-[var(--gap-0)]">
-          <h2 className="text-[13px] font-semibold">Segment Browser</h2>
+          <h2 className="text-[13px] font-semibold">Sector Browser</h2>
         </header>
         <div className="mt-[var(--gap-1)] space-y-[var(--gap-0)] text-sm text-slate-300">
-          <p>No segments are currently configured.</p>
+          <p>No sectors are currently configured.</p>
           <p>
             Update <code className="rounded bg-slate-900/80 px-1 py-0.5 text-xs">data/layers.csv</code> and run
             {' '}<code className="rounded bg-slate-900/80 px-1 py-0.5 text-xs">python scripts/audit_layers.py</code> to refresh
@@ -309,16 +309,16 @@ export function LayerBrowser(): JSX.Element {
 
   const content = (
     <section
-      aria-labelledby="segment-browser-heading"
+      aria-labelledby="sector-browser-heading"
       className="acx-card flex flex-col gap-[var(--gap-1)] bg-slate-950/60"
     >
       <header className="flex items-center justify-between gap-[var(--gap-0)]">
         <div>
-          <h2 id="segment-browser-heading" className="text-[13px] font-semibold">
-            Segment Browser
+          <h2 id="sector-browser-heading" className="text-[13px] font-semibold">
+            Sector Browser
           </h2>
           <p className="mt-[2px] text-[11px] uppercase tracking-[0.3em] text-slate-400">
-            Browse seeded segments & activity coverage
+            Browse seeded sectors & activity coverage
           </p>
         </div>
       </header>
@@ -344,53 +344,51 @@ export function LayerBrowser(): JSX.Element {
               : null;
           return (
             <details key={layer.id} className="group rounded-xl border border-slate-800/70 bg-slate-950/40" open={isActive}>
-              <summary className="flex cursor-pointer flex-col gap-[var(--gap-0)] px-[var(--gap-1)] py-[var(--gap-1)] text-left outline-none transition hover:bg-slate-900/50">
-                <div className="flex items-start gap-[var(--gap-1)]">
+              <summary className="flex cursor-pointer flex-col gap-[calc(var(--gap-0)*0.75)] px-[var(--gap-1)] py-[6px] text-left outline-none transition hover:bg-slate-900/50">
+                <div className="flex items-start gap-[calc(var(--gap-0)*0.8)]">
                   {iconPath ? (
                     <img
                       src={iconPath}
                       alt=""
-                      className="h-10 w-10 flex-shrink-0 rounded-lg border border-slate-800/70 bg-slate-950/80 object-contain"
+                      className="h-9 w-9 flex-shrink-0 rounded-lg border border-slate-800/70 bg-slate-950/80 object-contain"
                     />
                   ) : null}
                   <div className="flex-1">
-                    <div className="flex items-start justify-between gap-[var(--gap-0)]">
-                      <div>
+                    <div className="flex flex-wrap items-start gap-[calc(var(--gap-0)*0.6)]">
+                      <div className="min-w-0 flex-1 space-y-[calc(var(--gap-0)*0.4)]">
                         <p className="text-sm font-semibold text-slate-100">{layer.title}</p>
                         {layer.summary ? (
-                          <p className="mt-[2px] text-xs text-slate-400">{layer.summary}</p>
+                          <p className="max-w-[300px] text-[11px] leading-snug text-slate-400">{layer.summary}</p>
                         ) : null}
+                        <div className="flex flex-wrap items-center gap-[8px] text-[10px] uppercase tracking-[0.25em] text-slate-400">
+                          <span
+                            className={`inline-flex items-center gap-[4px] rounded-full border px-2 py-[2px] text-[10px] font-semibold tracking-[0.18em] ${statusMeta.tone}`}
+                          >
+                            <span aria-hidden="true">{statusMeta.badge}</span>
+                            {statusMeta.label}
+                          </span>
+                          <span>{activityBucket.count ?? 0} activities</span>
+                          <span>{operations} ops</span>
+                          {coverageLabel ? <span>{coverageLabel}</span> : null}
+                        </div>
                       </div>
-                      <span
-                        className={`inline-flex items-center gap-[4px] rounded-full border px-2 py-[2px] text-[11px] font-semibold ${statusMeta.tone}`}
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          handleToggleLayer(layer.id);
+                        }}
+                        className={`inline-flex items-center gap-1 rounded-md border px-2 py-[6px] text-[10px] font-semibold uppercase tracking-[0.2em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
+                          isActive
+                            ? 'border-sky-400/60 bg-sky-500/10 text-sky-200 hover:border-sky-300'
+                            : 'border-slate-700 bg-slate-900/70 text-slate-200 hover:border-slate-500'
+                        }`}
                       >
-                        <span aria-hidden="true">{statusMeta.badge}</span>
-                        {statusMeta.label}
-                      </span>
-                    </div>
-                    <div className="mt-[var(--gap-0)] flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.25em] text-slate-400">
-                      <span>{activityBucket.count ?? 0} activities</span>
-                      <span>{operations} ops</span>
-                      {coverageLabel ? <span>{coverageLabel}</span> : null}
+                        {isActive ? 'Active' : 'Include'}
+                      </button>
                     </div>
                   </div>
-                </div>
-                <div className="flex items-center justify-end gap-[var(--gap-0)]">
-                  <button
-                    type="button"
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      handleToggleLayer(layer.id);
-                    }}
-                    className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
-                      isActive
-                        ? 'border-sky-400/60 bg-sky-500/10 text-sky-200 hover:border-sky-300'
-                        : 'border-slate-700 bg-slate-900/70 text-slate-200 hover:border-slate-500'
-                    }`}
-                  >
-                    {isActive ? 'Active' : 'Include'}
-                  </button>
                 </div>
               </summary>
               <div className="border-t border-slate-800/60 bg-slate-950/70 px-[var(--gap-1)] py-[var(--gap-1)]">
@@ -436,7 +434,7 @@ export function LayerBrowser(): JSX.Element {
           aria-expanded={mobileOpen}
           onClick={() => setMobileOpen((open) => !open)}
         >
-          <span>Browse layers</span>
+          <span>Browse sectors</span>
           <svg
             className={`h-4 w-4 transition-transform ${mobileOpen ? 'rotate-180 text-sky-300' : 'text-slate-400'}`}
             viewBox="0 0 12 12"
@@ -451,3 +449,6 @@ export function LayerBrowser(): JSX.Element {
     </div>
   );
 }
+
+export const LayerBrowser = SectorBrowser;
+export const SegmentBrowser = SectorBrowser;

--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, ReactNode, useCallback, useId } from 'react';
 
-export type StageId = 'segment' | 'profile' | 'activity';
+export type StageId = 'sector' | 'profile' | 'activity';
 
 export interface StageStateMeta {
   unlocked: boolean;
@@ -37,18 +37,18 @@ interface StageMeta {
 
 const STAGES: StageMeta[] = [
   {
-    id: 'segment',
-    label: 'Segments',
-    summary: 'Anchor the analysis to the segments you want to compare.',
+    id: 'sector',
+    label: 'Sectors',
+    summary: 'Anchor the analysis to the sectors you want to compare.',
     advanceLabel: 'Continue to profiles',
-    advanceHelper: 'Lock in the segments that matter, then deepen the persona.',
+    advanceHelper: 'Lock in the sectors that matter, then deepen the persona.',
     nextStage: 'profile'
   },
   {
     id: 'profile',
     label: 'Profiles',
-    summary: 'Shape the representative lifestyle for the active segments.',
-    lockedSummary: 'Choose your segments above to unlock profile refinement.',
+    summary: 'Shape the representative lifestyle for the active sectors.',
+    lockedSummary: 'Choose your sectors above to unlock profile refinement.',
     advanceLabel: 'Drill into activities',
     advanceHelper: 'Dial commute, diet, and media habits to expose activities.',
     nextStage: 'activity'
@@ -63,7 +63,7 @@ const STAGES: StageMeta[] = [
 
 function renderStagePanel(stage: StageId, slots: Pick<LayoutProps, 'layerBrowser' | 'controls' | 'activity'>) {
   switch (stage) {
-    case 'segment':
+    case 'sector':
       return slots.layerBrowser;
     case 'profile':
       return slots.controls;
@@ -93,7 +93,7 @@ export function Layout({
   const activeIndex = stageIds.indexOf(stage);
 
   const isStageUnlocked = useCallback(
-    (stageId: StageId) => stageId === 'segment' || Boolean(stageStates[stageId]?.unlocked),
+    (stageId: StageId) => stageId === 'sector' || Boolean(stageStates[stageId]?.unlocked),
     [stageStates]
   );
 
@@ -174,7 +174,7 @@ export function Layout({
             Context depth
           </p>
           <p className="mt-[6px] text-[12px] text-slate-400">
-            Feed the console more context to unlock deeper, segment-aware visualizations.
+            Feed the console more context to unlock deeper, sector-aware visualizations.
           </p>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto pt-[calc(var(--gap-0)*0.9)]">
@@ -184,7 +184,7 @@ export function Layout({
             className="flex flex-col gap-[calc(var(--gap-0)*0.75)]"
           >
             {STAGES.map((meta) => {
-              const state = stageStates[meta.id] ?? { unlocked: meta.id === 'segment', ready: false };
+              const state = stageStates[meta.id] ?? { unlocked: meta.id === 'sector', ready: false };
               const unlocked = isStageUnlocked(meta.id);
               const isActive = unlocked && stage === meta.id;
               const stageIndex = stageIds.indexOf(meta.id);

--- a/site/src/components/ProfileControls.tsx
+++ b/site/src/components/ProfileControls.tsx
@@ -139,7 +139,7 @@ export function ProfileControls(): JSX.Element {
     [commitStreamingHours]
   );
 
-  const modeSegments = useMemo(() => {
+  const modeShares = useMemo(() => {
     const entries = Object.entries(modeSplit) as [keyof ModeSplit, number][];
     return entries.map(([key, value]) => {
       const metadata = MODE_METADATA[key];
@@ -149,8 +149,8 @@ export function ProfileControls(): JSX.Element {
   }, [modeSplit.car, modeSplit.transit, modeSplit.bike, commuteDays]);
 
   const allocatedDays = useMemo(
-    () => modeSegments.reduce((sum, segment) => sum + segment.days, 0),
-    [modeSegments]
+    () => modeShares.reduce((sum, share) => sum + share.days, 0),
+    [modeShares]
   );
 
   const handleModeSplitDayChange = useCallback(
@@ -223,7 +223,7 @@ export function ProfileControls(): JSX.Element {
                 </span>
               </div>
               <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
-                {modeSegments.map(({ key, value, metadata }) => (
+                {modeShares.map(({ key, value, metadata }) => (
                   <div
                     key={key}
                     className={`${metadata.color} h-full`}
@@ -233,7 +233,7 @@ export function ProfileControls(): JSX.Element {
                 ))}
               </div>
               <div className="grid gap-[var(--gap-1)] sm:grid-cols-2">
-                {modeSegments.map(({ key, value, metadata, days }) => (
+                {modeShares.map(({ key, value, metadata, days }) => (
                   <div key={key} className="space-y-[var(--gap-0)] rounded-lg border border-slate-800/70 bg-slate-900/60 pad-compact">
                     <div className="flex items-center justify-between gap-[var(--gap-0)]">
                       <div>
@@ -335,7 +335,7 @@ export function ProfileControls(): JSX.Element {
           <div className="col-span-2 space-y-[var(--gap-1)] rounded-xl border border-slate-800/70 bg-slate-950/30 p-[var(--gap-1)] text-compact text-slate-400">
             <p className="text-[13px] font-semibold text-slate-200">Live overrides</p>
             <dl className="grid gap-[var(--gap-0)] md:grid-cols-2">
-              {modeSegments.map(({ key, value, metadata }) => (
+              {modeShares.map(({ key, value, metadata }) => (
                 <Fragment key={`override-${key}`}>
                   <dt className="text-[10px] uppercase tracking-[0.3em] text-slate-300">{metadata.label} days/wk</dt>
                   <dd className="text-[13px] font-semibold text-slate-200">

--- a/site/src/components/ScopeBar.tsx
+++ b/site/src/components/ScopeBar.tsx
@@ -1,17 +1,19 @@
 import type { StageId, StageSummaries } from './Layout';
 
-const STAGE_SEQUENCE: StageId[] = ['segment', 'profile', 'activity'];
+const STAGE_SEQUENCE: StageId[] = ['sector', 'profile', 'activity'];
 
 const STAGE_LABEL: Record<StageId, string> = {
-  segment: 'Segment',
+  sector: 'Sector',
   profile: 'Profile',
   activity: 'Activity'
 };
 
-export interface ScopeSegmentDescriptor {
+export interface ScopeSectorDescriptor {
   id: string;
   label: string;
 }
+
+export type ScopeSegmentDescriptor = ScopeSectorDescriptor;
 
 export interface ScopePin {
   id: string;
@@ -24,7 +26,7 @@ export interface ScopePin {
 interface ScopeBarProps {
   stage: StageId;
   stageSummaries?: StageSummaries;
-  segments: ScopeSegmentDescriptor[];
+  sectors: ScopeSectorDescriptor[];
   profileDetail?: string;
   activityDetail?: string;
   pinnedScopes: ScopePin[];
@@ -35,7 +37,7 @@ interface ScopeBarProps {
 export function ScopeBar({
   stage,
   stageSummaries = {},
-  segments,
+  sectors,
   profileDetail,
   activityDetail,
   pinnedScopes,
@@ -87,17 +89,17 @@ export function ScopeBar({
           </button>
         </div>
         <div className="flex flex-wrap items-center gap-[calc(var(--gap-0)*0.6)] text-[12px] text-slate-200">
-          {segments.length > 0 ? (
-            segments.map((segment) => (
+          {sectors.length > 0 ? (
+            sectors.map((sector) => (
               <span
-                key={segment.id}
+                key={sector.id}
                 className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/40 px-3 py-[0.2rem] text-[12px] text-slate-100"
               >
-                {segment.label}
+                {sector.label}
               </span>
             ))
           ) : (
-            <span className="text-[12px] text-slate-500">No segments selected</span>
+            <span className="text-[12px] text-slate-500">No sectors selected</span>
           )}
         </div>
         <div className="flex flex-wrap items-center gap-[calc(var(--gap-0)*0.6)] text-[11px] text-slate-400">

--- a/site/src/components/Stacked.tsx
+++ b/site/src/components/Stacked.tsx
@@ -11,6 +11,7 @@ import {
 export interface StackedDatum extends ReferenceCarrier {
   layer_id?: string | null;
   category?: string | null;
+  sector?: string | null;
   values?: {
     mean?: number | null;
     low?: number | null;
@@ -59,7 +60,7 @@ export function Stacked({
         if (mean == null || !Number.isFinite(mean) || mean <= 0) {
           return null;
         }
-        const label = normaliseCategory(row?.category ?? null);
+        const label = normaliseCategory((row?.sector as string | null) ?? row?.category ?? null);
         const indices = resolveReferenceIndices(row, referenceLookup);
         return {
           key: `${label}-${index}`,

--- a/site/src/components/VizCanvas.tsx
+++ b/site/src/components/VizCanvas.tsx
@@ -342,9 +342,11 @@ function aggregateBubbleByCategory(data: readonly BubbleDatum[]): BubbleDatum[] 
     if (mean == null || !Number.isFinite(mean) || mean <= 0) {
       return;
     }
-    const category =
+    const baseCategory =
       typeof row?.category === 'string' && row.category ? row.category : 'Other';
-    let bucket = buckets.get(category);
+    const sectorLabel =
+      typeof row?.sector === 'string' && row.sector ? row.sector : baseCategory;
+    let bucket = buckets.get(sectorLabel);
     if (!bucket) {
       bucket = {
         total: 0,
@@ -352,7 +354,7 @@ function aggregateBubbleByCategory(data: readonly BubbleDatum[]): BubbleDatum[] 
         hoverIndices: new Set<number>(),
         units: row?.units ?? null
       };
-      buckets.set(category, bucket);
+      buckets.set(sectorLabel, bucket);
     }
     bucket.total += mean;
     if (!bucket.units && row?.units) {
@@ -373,7 +375,7 @@ function aggregateBubbleByCategory(data: readonly BubbleDatum[]): BubbleDatum[] 
   });
   const entries = Array.from(buckets.entries());
   entries.sort((a, b) => b[1].total - a[1].total);
-  return entries.map(([category, bucket], index) => {
+  return entries.map(([sectorLabel, bucket], index) => {
     const citation_keys =
       bucket.citationKeys.size > 0 ? Array.from(bucket.citationKeys) : undefined;
     const hover_reference_indices =
@@ -382,9 +384,10 @@ function aggregateBubbleByCategory(data: readonly BubbleDatum[]): BubbleDatum[] 
         : undefined;
     return {
       layer_id: null,
-      activity_id: `category:${category}:${index}`,
-      activity_name: category,
-      category,
+      activity_id: `category:${sectorLabel}:${index}`,
+      activity_name: sectorLabel,
+      category: sectorLabel,
+      sector: sectorLabel,
       values: { mean: bucket.total },
       units: bucket.units ?? undefined,
       citation_keys,
@@ -741,7 +744,7 @@ export function VizCanvas({ stage }: VizCanvasProps): JSX.Element {
 
   const stageStackedData = useMemo(
     () =>
-      stage === 'segment'
+      stage === 'sector'
         ? aggregateStackedByLayer(rawStacked, activeLayerSet, layerTitleLookup)
         : stackedData,
     [stage, rawStacked, activeLayerSet, layerTitleLookup, stackedData]
@@ -762,7 +765,7 @@ export function VizCanvas({ stage }: VizCanvasProps): JSX.Element {
 
   const stageSankeyData = useMemo(
     () =>
-      stage === 'segment'
+      stage === 'sector'
         ? buildLayerSankey(rawSankey, activeLayerSet, layerTitleLookup)
         : sankeyData,
     [stage, rawSankey, activeLayerSet, layerTitleLookup, sankeyData]
@@ -799,29 +802,29 @@ export function VizCanvas({ stage }: VizCanvasProps): JSX.Element {
   const resolvedTotal = totals.total ?? stackedTotal ?? bubbleTotal ?? sankeyTotal ?? null;
 
   const focusLabel =
-    stage === 'segment' ? 'Segments tracked' : stage === 'profile' ? 'Categories tracked' : 'Activities tracked';
-  const stackedShareLabel = stage === 'segment' ? 'segment portfolio' : 'tracked categories';
+    stage === 'sector' ? 'Sectors tracked' : stage === 'profile' ? 'Categories tracked' : 'Activities tracked';
+  const stackedShareLabel = stage === 'sector' ? 'sector portfolio' : 'tracked categories';
   const bubbleShareLabel =
-    stage === 'segment' ? 'segment emissions' : stage === 'profile' ? 'category emissions' : 'activity emissions';
-  const sankeyShareLabel = stage === 'segment' ? 'segment flow' : 'mapped flow';
+    stage === 'sector' ? 'sector emissions' : stage === 'profile' ? 'category emissions' : 'activity emissions';
+  const sankeyShareLabel = stage === 'sector' ? 'sector flow' : 'mapped flow';
   const feedbackShareLabel = 'feedback intensity';
-  const stackedPanelTitle = stage === 'segment' ? 'Annual emissions by segment' : 'Annual emissions by category';
+  const stackedPanelTitle = stage === 'sector' ? 'Annual emissions by sector' : 'Annual emissions by category';
   const bubblePanelTitle =
-    stage === 'segment'
-      ? 'Segment emissions bubble chart'
+    stage === 'sector'
+      ? 'Sector emissions bubble chart'
       : stage === 'profile'
         ? 'Category emissions bubble chart'
         : 'Activity emissions bubble chart';
-  const sankeyPanelTitle = stage === 'segment' ? 'Segment emission pathways' : 'Emission pathways';
+  const sankeyPanelTitle = stage === 'sector' ? 'Sector emission pathways' : 'Emission pathways';
   const feedbackPanelTitle = 'Feedback loops';
-  const stackedEmptyMessage = stage === 'segment' ? 'No segment data available.' : 'No category data available.';
+  const stackedEmptyMessage = stage === 'sector' ? 'No sector data available.' : 'No category data available.';
   const bubbleEmptyMessage =
-    stage === 'segment'
-      ? 'No segment data available.'
+    stage === 'sector'
+      ? 'No sector data available.'
       : stage === 'profile'
         ? 'No category data available.'
         : 'No activity data available.';
-  const sankeyEmptyMessage = stage === 'segment' ? 'No segment flow data available.' : 'No sankey data available.';
+  const sankeyEmptyMessage = stage === 'sector' ? 'No sector flow data available.' : 'No sankey data available.';
   const feedbackEmptyMessage = 'No feedback loop data available.';
 
   const stackedSummary = useMemo(() => {
@@ -833,8 +836,10 @@ export function VizCanvas({ stage }: VizCanvasProps): JSX.Element {
             if (mean == null || !Number.isFinite(mean) || mean <= 0) {
               return null;
             }
+            const sectorLabel = typeof row?.sector === 'string' && row.sector ? row.sector : null;
             const category = typeof row?.category === 'string' && row.category ? row.category : 'Uncategorized';
-            return { id: `${category}-${index}`, label: category, value: mean };
+            const label = sectorLabel ?? category;
+            return { id: `${label}-${index}`, label, value: mean };
           })
           .filter((entry): entry is { id: string; label: string; value: number } => entry !== null)
       : [];

--- a/site/src/components/__tests__/__snapshots__/Bubble.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/Bubble.test.tsx.snap
@@ -52,14 +52,6 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
         Cooling — 2.50 kg CO₂e [1]
       </title>
     </circle>
-    <text
-      class="fill-slate-200 font-medium"
-      style="font-size: 16px;"
-      text-anchor="middle"
-      y="62"
-    >
-      Cooling
-    </text>
   </g>
   <g
     class="group"
@@ -76,14 +68,6 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
         Lighting — 1.20 kg CO₂e [2]
       </title>
     </circle>
-    <text
-      class="fill-slate-200 font-medium"
-      style="font-size: 13px;"
-      text-anchor="middle"
-      y="46.09845356715714"
-    >
-      Lighting
-    </text>
   </g>
   <text
     class="fill-slate-400"

--- a/site/src/components/__tests__/__snapshots__/Sankey.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/Sankey.test.tsx.snap
@@ -64,14 +64,16 @@ exports[`Sankey > renders gradient links with reference hints 1`] = `
       </title>
     </rect>
     <text
-      alignment-baseline="middle"
-      class="fill-slate-950 font-semibold"
+      class="sankey-node-label fill-slate-950 font-semibold"
       style="font-size: 16px;"
       text-anchor="middle"
-      x="70"
-      y="18"
     >
-      Cooling
+      <tspan
+        x="70"
+        y="18"
+      >
+        Cooling
+      </tspan>
     </text>
     <text
       class="fill-slate-400"
@@ -103,14 +105,16 @@ exports[`Sankey > renders gradient links with reference hints 1`] = `
       </title>
     </rect>
     <text
-      alignment-baseline="middle"
-      class="fill-slate-950 font-semibold"
+      class="sankey-node-label fill-slate-950 font-semibold"
       style="font-size: 16px;"
       text-anchor="middle"
-      x="70"
-      y="18"
     >
-      Chiller
+      <tspan
+        x="70"
+        y="18"
+      >
+        Chiller
+      </tspan>
     </text>
     <text
       class="fill-slate-400"

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { artifactUrl } from './paths';
-import { fetchJSON } from './fetchJSON';
+import { FetchJSONError, fetchJSON } from './fetchJSON';
 import type { ComputeResult } from '../state/profile';
 
 export type ComputeRequest = Record<string, unknown>;
@@ -22,36 +22,234 @@ const jsonArtifactCache = new Map<string, unknown>();
 const textArtifactCache = new Map<string, string>();
 const referenceListCache = new Map<string, string[]>();
 
+interface ArtifactIndexEntry {
+  path?: string;
+}
+
+interface ArtifactIndexPayload {
+  files?: ArtifactIndexEntry[];
+}
+
+interface LatestBuildPointer {
+  build_hash?: string;
+  artifact_dir?: string;
+}
+
+type ArtifactOverrideMap = Map<string, string>;
+
+let artifactOverrides: ArtifactOverrideMap | null = null;
+let artifactOverridesPromise: Promise<ArtifactOverrideMap> | null = null;
+
+function canonicalKeyFromPath(path: string): string | null {
+  const normalised = normalisePath(path);
+  const marker = '/calc/outputs/';
+  const markerIndex = normalised.indexOf(marker);
+  if (markerIndex >= 0) {
+    return normalised.slice(markerIndex + marker.length);
+  }
+  if (!normalised.includes('/')) {
+    return normalised;
+  }
+  return null;
+}
+
+function extractRootHash(path: string): string | null {
+  const segments = normalisePath(path)
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  if (segments.length === 0) {
+    return null;
+  }
+  return segments[0];
+}
+
+function scoreArtifactPath(path: string, preferredHash: string | null): number {
+  let score = 0;
+  const normalised = normalisePath(path);
+  if (preferredHash && extractRootHash(normalised) === preferredHash) {
+    score += 100;
+  }
+  if (normalised.includes('/calc/outputs/')) {
+    score += 10;
+  }
+  if (!normalised.includes('/')) {
+    score -= 5;
+  }
+  return score;
+}
+
+function extractHashFromPointer(pointer: LatestBuildPointer | null): string | null {
+  if (!pointer) {
+    return null;
+  }
+  if (typeof pointer.build_hash === 'string' && pointer.build_hash.trim().length > 0) {
+    return pointer.build_hash.trim();
+  }
+  if (typeof pointer.artifact_dir === 'string' && pointer.artifact_dir.trim().length > 0) {
+    const fromDir = extractRootHash(pointer.artifact_dir);
+    if (fromDir) {
+      return fromDir;
+    }
+  }
+  return null;
+}
+
+async function loadArtifactOverrides(signal?: AbortSignal): Promise<ArtifactOverrideMap> {
+  if (artifactOverrides) {
+    return artifactOverrides;
+  }
+
+  if (!artifactOverridesPromise) {
+    artifactOverridesPromise = (async (): Promise<ArtifactOverrideMap> => {
+      const candidates = new Map<string, { path: string; score: number }>();
+      try {
+        const [indexPayload, pointerPayload] = await Promise.all([
+          fetchJSON<ArtifactIndexPayload>(resolveArtifactUrl('index.json'), {
+            signal,
+            headers: { Accept: 'application/json' },
+            cache: 'no-store',
+          }).catch((error: unknown) => {
+            if (error instanceof FetchJSONError) {
+              return null;
+            }
+            throw error;
+          }),
+          fetchJSON<LatestBuildPointer>(resolveArtifactUrl('latest-build.json'), {
+            signal,
+            headers: { Accept: 'application/json' },
+            cache: 'no-store',
+          }).catch((error: unknown) => {
+            if (error instanceof FetchJSONError) {
+              return null;
+            }
+            throw error;
+          }),
+        ]);
+
+        const preferredHash = extractHashFromPointer(pointerPayload ?? null);
+        if (indexPayload && Array.isArray(indexPayload.files)) {
+          for (const entry of indexPayload.files) {
+            if (!entry || typeof entry.path !== 'string') {
+              continue;
+            }
+            const canonicalKey = canonicalKeyFromPath(entry.path);
+            if (!canonicalKey) {
+              continue;
+            }
+            const score = scoreArtifactPath(entry.path, preferredHash);
+            const existing = candidates.get(canonicalKey);
+            if (!existing || score > existing.score) {
+              candidates.set(canonicalKey, {
+                path: normalisePath(entry.path),
+                score,
+              });
+            }
+          }
+        }
+      } catch {
+        // ignore failures and fall back to direct paths
+      }
+
+      artifactOverrides = new Map<string, string>();
+      for (const [key, value] of candidates.entries()) {
+        artifactOverrides.set(key, value.path);
+      }
+      return artifactOverrides;
+    })();
+  }
+
+  try {
+    return await artifactOverridesPromise;
+  } finally {
+    artifactOverridesPromise = null;
+    if (!artifactOverrides) {
+      artifactOverrides = new Map<string, string>();
+    }
+  }
+}
+
+async function resolveOverridePath(path: string, signal?: AbortSignal): Promise<string | null> {
+  const overrides = await loadArtifactOverrides(signal);
+  const normalised = normalisePath(path);
+  const override = overrides.get(normalised);
+  if (override && override !== normalised) {
+    return override;
+  }
+  return null;
+}
+
 async function fetchArtifact(
   path: string,
   init: RequestInit = {}
 ): Promise<Response> {
-  const response = await fetch(resolveArtifactUrl(path), {
+  const normalised = normalisePath(path);
+  const requestInit: RequestInit = {
     method: 'GET',
     cache: 'no-store',
     credentials: 'same-origin',
     ...init
-  });
+  };
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Artifact request failed with status ${response.status}`);
+  const performFetch = async (targetPath: string): Promise<Response> => {
+    return fetch(resolveArtifactUrl(targetPath), requestInit);
+  };
+
+  let response = await performFetch(normalised);
+  if (response.ok) {
+    return response;
   }
 
-  return response;
+  const fallbackPath = await resolveOverridePath(normalised, requestInit.signal);
+  if (fallbackPath && fallbackPath !== normalised) {
+    response = await performFetch(fallbackPath);
+    if (response.ok) {
+      return response;
+    }
+  }
+
+  let message = '';
+  try {
+    message = await response.text();
+  } catch {
+    // ignore read failures and fall back to status text
+  }
+  throw new Error(message || `Artifact request failed with status ${response.status}`);
 }
 
 async function loadArtifactJson(path: string, signal?: AbortSignal): Promise<unknown> {
   if (jsonArtifactCache.has(path)) {
     return jsonArtifactCache.get(path)!;
   }
-  const data = await fetchJSON<unknown>(resolveArtifactUrl(path), {
-    signal,
-    headers: { Accept: 'application/json' },
-    cache: 'no-store',
-  });
-  jsonArtifactCache.set(path, data);
-  return data;
+
+  const normalised = normalisePath(path);
+  try {
+    const data = await fetchJSON<unknown>(resolveArtifactUrl(normalised), {
+      signal,
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+    jsonArtifactCache.set(path, data);
+    return data;
+  } catch (error) {
+    const shouldRetry =
+      error instanceof FetchJSONError ||
+      (error instanceof Error && /Unable to parse JSON/.test(error.message));
+    if (!shouldRetry) {
+      throw error;
+    }
+    const fallbackPath = await resolveOverridePath(normalised, signal);
+    if (!fallbackPath || fallbackPath === normalised) {
+      throw error;
+    }
+    const data = await fetchJSON<unknown>(resolveArtifactUrl(fallbackPath), {
+      signal,
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+    jsonArtifactCache.set(path, data);
+    return data;
+  }
 }
 
 async function loadArtifactText(path: string, signal?: AbortSignal): Promise<string> {

--- a/site/src/styles/density.css
+++ b/site/src/styles/density.css
@@ -58,6 +58,12 @@ body {
   text-overflow: ellipsis;
 }
 
+.sankey-node-label {
+  font-size: clamp(11px, 0.9vw, 16px);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+}
+
 .acx-condensed .stack-gap {
   display: flex;
   flex-direction: column;

--- a/tests/test_alias_segment_sector.py
+++ b/tests/test_alias_segment_sector.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+import pandas as pd
+
+from calc import figures
+
+
+def _serialise_payload(df: pd.DataFrame) -> dict[str, object]:
+    stacked = figures.slice_stacked(df)
+    bubble = [asdict(point) for point in figures.slice_bubble(df)]
+    sankey = figures.slice_sankey(df)
+    return {
+        "stacked": json.loads(json.dumps(stacked, sort_keys=True)),
+        "bubble": json.loads(json.dumps(bubble, sort_keys=True)),
+        "sankey": json.loads(json.dumps(sankey, sort_keys=True)),
+    }
+
+
+def _build_rows(column_name: str) -> list[dict[str, object]]:
+    return [
+        {
+            "activity_id": "A1",
+            "activity_name": "Alpha",
+            "activity_category": "Mobility",
+            "annual_emissions_g": 1_000.0,
+            "layer_id": "professional",
+            column_name: "Transport",
+        },
+        {
+            "activity_id": "A2",
+            "activity_name": "Bravo",
+            "activity_category": "Energy",
+            "annual_emissions_g": 500.0,
+            "layer_id": "professional",
+            column_name: "Transport",
+        },
+    ]
+
+
+def test_alias_reads_match_for_segment_and_sector() -> None:
+    segment_only = pd.DataFrame(_build_rows("segment"))
+    sector_only = pd.DataFrame(_build_rows("sector"))
+    mixed_rows = _build_rows("segment")
+    for index, row in enumerate(mixed_rows):
+        if index % 2 == 1:
+            row["sector"] = row.pop("segment")
+    mixed = pd.DataFrame(mixed_rows)
+
+    canonical_segment = _serialise_payload(segment_only)
+    canonical_sector = _serialise_payload(sector_only)
+    canonical_mixed = _serialise_payload(mixed)
+
+    assert canonical_segment == canonical_sector == canonical_mixed
+
+    # Forward outputs should only emit sector terminology.
+    stacked_entry = canonical_segment["stacked"][0]
+    assert "sector" in stacked_entry
+    assert stacked_entry.get("sector") == "Transport"
+    assert "segment" not in json.dumps(canonical_segment)
+
+    bubble_entry = canonical_segment["bubble"][0]
+    assert bubble_entry.get("sector") == "Transport"
+
+    sankey_nodes = canonical_segment["sankey"]["nodes"]
+    assert all("segment" not in json.dumps(node) for node in sankey_nodes)
+

--- a/tests/test_alias_segment_sector.py
+++ b/tests/test_alias_segment_sector.py
@@ -66,4 +66,3 @@ def test_alias_reads_match_for_segment_and_sector() -> None:
 
     sankey_nodes = canonical_segment["sankey"]["nodes"]
     assert all("segment" not in json.dumps(node) for node in sankey_nodes)
-


### PR DESCRIPTION
## Summary
- add alias-aware datastore helpers and update schema/models to normalise legacy `segment*` fields into the new sector vocabulary
- ensure figure pipelines coalesce sector data and emit sector-only outputs while keeping manifests/version metadata current
- tighten UI density with sector-first wording, wrapped Sankey labels, bubble chart label removal, and compact sector browser cards

## Testing
- `poetry run pytest`
- `npm test`
- `poetry run ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68e320ebdbf0832c9aa89de8382eca40