### PR TITLE
Handle missing HTML references

### DIFF
--- a/site/src/lib/__tests__/api.test.ts
+++ b/site/src/lib/__tests__/api.test.ts
@@ -35,8 +35,8 @@ describe('parseReferenceList', () => {
     ]);
   });
 
-  it('falls back to trimmed lines when HTML parsing fails', () => {
-    const text = '<!doctype html>\n<custom-element>'; // malformed for DOMParser
-    expect(parseReferenceList(text)).toEqual(['<!doctype html>', '<custom-element>']);
+  it('returns an empty list for HTML documents when DOMParser is unavailable', () => {
+    const text = '<!doctype html>\n<custom-element>'; // treated as a full HTML document
+    expect(parseReferenceList(text)).toEqual([]);
   });
 });

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -38,12 +38,16 @@ export function parseReferenceList(text: string): string[] {
     .filter((entry) => entry.length > 0);
 
   const htmlIndicator = /<(!doctype|html|head|body|ol|ul|li)\b/i;
+  const htmlDocumentIndicator = /^\s*<!doctype html\b/i;
+  const htmlRootIndicator = /^\s*<html\b/i;
+  const looksLikeHtmlDocument = htmlDocumentIndicator.test(trimmed) || htmlRootIndicator.test(trimmed);
+
   if (!htmlIndicator.test(trimmed)) {
     return fallback.map(normaliseWhitespace);
   }
 
   if (typeof DOMParser === 'undefined') {
-    return fallback.map(normaliseWhitespace);
+    return looksLikeHtmlDocument ? [] : fallback.map(normaliseWhitespace);
   }
 
   try {
@@ -59,6 +63,10 @@ export function parseReferenceList(text: string): string[] {
       return references;
     }
 
+    if (looksLikeHtmlDocument) {
+      return [];
+    }
+
     const bodyText = doc.body?.textContent ?? '';
     if (bodyText.trim().length === 0) {
       return fallback.map(normaliseWhitespace);
@@ -69,7 +77,7 @@ export function parseReferenceList(text: string): string[] {
       .map(normaliseWhitespace)
       .filter((entry) => entry.length > 0);
   } catch {
-    return fallback.map(normaliseWhitespace);
+    return looksLikeHtmlDocument ? [] : fallback.map(normaliseWhitespace);
   }
 }
 


### PR DESCRIPTION
## Summary
- treat HTML fallback documents as missing references when parsing static artifacts
- avoid emitting DOM fallback text when running without DOMParser support
- update unit test expectation for reference parsing behavior

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e341e03f4c832ca99d12618835e5ff