### PR TITLE
Ensure references text artifact is served correctly

### DIFF
--- a/functions/carbon-acx/[[path]].ts
+++ b/functions/carbon-acx/[[path]].ts
@@ -124,6 +124,11 @@ async function handleArtifactRequest(
   const staticResponse = await ctx.next();
   if (staticResponse && staticResponse.status !== 404) {
     const contentType = staticResponse.headers.get("content-type")?.toLowerCase() ?? "";
+    const isReferenceText =
+      sanitizedKey.toLowerCase().startsWith("references/") && sanitizedKey.toLowerCase().endsWith(".txt");
+    if (isReferenceText && !contentType.includes("text/html")) {
+      return applyArtifactHeaders(staticResponse, artifactKey, { includeDiagHeader }, "text/plain");
+    }
     if (!contentType.includes("text/html")) {
       return applyArtifactHeaders(staticResponse, artifactKey, { includeDiagHeader }, desiredContentType);
     }

--- a/site/public/artifacts/references/export_view_refs.txt
+++ b/site/public/artifacts/references/export_view_refs.txt
@@ -1,0 +1,5 @@
+IPCC Sixth Assessment Report — WG III
+IEA World Energy Outlook 2024
+UN Emissions Gap Report 2023
+Nationally Determined Contributions Synthesis Report 2023
+Climate Policy Radar Dataset 2024

--- a/site/src/lib/api.ts
+++ b/site/src/lib/api.ts
@@ -32,6 +32,11 @@ export function parseReferenceList(text: string): string[] {
     return [];
   }
 
+  const lowerCasedStart = trimmed.slice(0, 32).toLowerCase();
+  if (lowerCasedStart.startsWith('<!doctype html') || lowerCasedStart.startsWith('<html')) {
+    return [];
+  }
+
   const fallback = trimmed
     .split('\n')
     .map((entry) => entry.trim())


### PR DESCRIPTION
## Summary
- add placeholder reference export text file under public artifacts
- ensure worker serves reference .txt artifacts from static storage with text/plain
- guard reference parsing against HTML responses on the client

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3a641b7f0832ca3acbf6ad0c42aec