### PR TITLE
Ensure seeded layers appear in layer browser

### DIFF
--- a/calc/dal/__init__.py
+++ b/calc/dal/__init__.py
@@ -2,22 +2,23 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Protocol, Sequence
+from typing import Any, Protocol, Sequence, TYPE_CHECKING
 
-from ..schema import (
-    Activity,
-    ActivityDependency,
-    ActivitySchedule,
-    Asset,
-    FeedbackLoop,
-    EmissionFactor,
-    Entity,
-    GridIntensity,
-    Layer,
-    Operation,
-    Profile,
-    Site,
-)
+if TYPE_CHECKING:  # pragma: no cover - imported for static type checking
+    from ..schema import (
+        Activity,
+        ActivityDependency,
+        ActivitySchedule,
+        Asset,
+        EmissionFactor,
+        Entity,
+        FeedbackLoop,
+        GridIntensity,
+        Layer,
+        Operation,
+        Profile,
+        Site,
+    )
 from .csv import CsvStore
 from .duckdb import DuckDbStore
 from ..dal_sql import SqlStore
@@ -41,6 +42,21 @@ __all__ = [
     "SqlStore",
     "choose_backend",
 ]
+
+_SCHEMA_EXPORTS = {
+    "Activity",
+    "ActivityDependency",
+    "ActivitySchedule",
+    "Asset",
+    "EmissionFactor",
+    "Entity",
+    "FeedbackLoop",
+    "GridIntensity",
+    "Layer",
+    "Operation",
+    "Profile",
+    "Site",
+}
 
 
 class DataStore(Protocol):
@@ -67,6 +83,42 @@ class DataStore(Protocol):
     def load_activity_dependencies(self) -> Sequence[ActivityDependency]: ...
 
     def load_feedback_loops(self) -> Sequence[FeedbackLoop]: ...
+
+
+def __getattr__(name: str) -> Any:
+    if name in _SCHEMA_EXPORTS:
+        from ..schema import (
+            Activity,
+            ActivityDependency,
+            ActivitySchedule,
+            Asset,
+            EmissionFactor,
+            Entity,
+            FeedbackLoop,
+            GridIntensity,
+            Layer,
+            Operation,
+            Profile,
+            Site,
+        )
+
+        namespace = {
+            "Activity": Activity,
+            "ActivityDependency": ActivityDependency,
+            "ActivitySchedule": ActivitySchedule,
+            "Asset": Asset,
+            "EmissionFactor": EmissionFactor,
+            "Entity": Entity,
+            "FeedbackLoop": FeedbackLoop,
+            "GridIntensity": GridIntensity,
+            "Layer": Layer,
+            "Operation": Operation,
+            "Profile": Profile,
+            "Site": Site,
+        }
+        globals().update(namespace)
+        return namespace[name]
+    raise AttributeError(f"module 'calc.dal' has no attribute {name!r}")
 
 
 def _resolve_db_path(candidate: str | os.PathLike[str] | None) -> Path:

--- a/tests/test_app_layout.py
+++ b/tests/test_app_layout.py
@@ -38,7 +38,9 @@ def test_layout_contains_expected_sections(monkeypatch) -> None:
     figures_store = {
         name: app_module._load_figure_payload(fixture_dir, name) for name in app_module.FIGURE_NAMES
     }
-    available_layers = app_module._collect_layers(figures_store)
+    available_layers = app_module._collect_layers(
+        figures_store, fallback=app_module.LAYER_ORDER
+    )
     selected_layers = (
         available_layers[:1] if available_layers else [app_module.LayerId.PROFESSIONAL.value]
     )
@@ -47,7 +49,14 @@ def test_layout_contains_expected_sections(monkeypatch) -> None:
         info for key, info in dash_app.callback_map.items() if "layer-panels.children" in key
     )
     callback = panel_callback_info["callback"].__wrapped__
-    panels_children, _ = callback(selected_layers, "single", figures_store)
+    panels_children, _ = callback(
+        selected_layers,
+        "single",
+        None,
+        None,
+        figures_store,
+        available_layers,
+    )
 
     panel_ids: set[str] = set()
     for child in panels_children:

--- a/tests/test_app_layout.py
+++ b/tests/test_app_layout.py
@@ -38,9 +38,7 @@ def test_layout_contains_expected_sections(monkeypatch) -> None:
     figures_store = {
         name: app_module._load_figure_payload(fixture_dir, name) for name in app_module.FIGURE_NAMES
     }
-    available_layers = app_module._collect_layers(
-        figures_store, fallback=app_module.LAYER_ORDER
-    )
+    available_layers = app_module._collect_layers(figures_store, fallback=app_module.LAYER_ORDER)
     selected_layers = (
         available_layers[:1] if available_layers else [app_module.LayerId.PROFESSIONAL.value]
     )


### PR DESCRIPTION
## Summary
- ensure the layer browser always includes the full seeded layer list when building options and panels
- lazily expose schema types from `calc.dal` and `calc.schema` to prevent circular imports during app initialisation
- update the layout test to exercise the new callback signature and layer collection behaviour

## Testing
- poetry run pytest tests/test_app_layout.py

------
https://chatgpt.com/codex/tasks/task_e_68e590520878832cb26bd9f9cdd199a8