### PR TITLE
Restore Netlify path block for COOP/COEP headers

### DIFF
--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,4 +1,6 @@
 /models/*
   Cache-Control: public, max-age=604800, immutable
-Cross-Origin-Opener-Policy: same-origin
-Cross-Origin-Embedder-Policy: require-corp
+
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp


### PR DESCRIPTION
## Summary
- reintroduce a catch-all route block in the Netlify `_headers` file
- ensure Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy are applied site-wide for WebGPU isolation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e59f98387c832c905675d8a2565ad4