### PR TITLE
Document manifest-first workflows and add icon helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Carbon ACX is an open reference stack for trustworthy carbon accounting. It turn
 
 ---
 
+## Manifest-first
+
+Every chart, layer catalogue, and disclosure ships from a manifest that records byte hashes, schema versions, and provenance so downstream clients can trust figure lineage before rendering. The primary manifest schema lives at [`site/public/schemas/figure-manifest.schema.json`](site/public/schemas/figure-manifest.schema.json) and is enforced by the derivation pipeline so browser experiences, Dash, and Workers all consume the same contract.【F:site/public/schemas/figure-manifest.schema.json†L1-L140】【F:calc/derive.py†L52-L92】
+
+---
+
 ## Product vision
 
 Carbon ACX is designed as a product-quality example of carbon accounting operations:
@@ -28,6 +34,25 @@ Together these pieces model how organisations can move from raw operational acti
 | **Static React site** | `site/` contains a Vite + Tailwind build that mirrors the Dash workflow for marketing or investor portals while reading the same manifest catalogue.【F:site/src/App.tsx†L1-L160】 |
 | **Edge delivery surfaces** | `functions/` provides the Cloudflare Pages function that hardens artefact serving, and `workers/` exposes a JSON API for compute scenarios and health checks.【F:functions/carbon-acx/[[path]].ts†L1-L160】【F:workers/compute/index.ts†L1-L123】 |
 | **Packaging automation** | Make targets and helper scripts assemble reproducible releases, sync layer catalogues, and prepare static bundles with deployment metadata.【F:Makefile†L1-L120】【F:scripts/prepare_pages_bundle.py†L1-L100】 |
+
+## At-a-glance layers
+
+| Layer | Type | Example activities |
+| --- | --- | --- |
+| Professional services | Civilian | Coffee—12 oz hot; Toronto subway—per passenger-kilometre |
+| Online services | Civilian | Video conferencing hour; SaaS productivity suite seat |
+| Industrial (Light) | Industry | Lab bench operation; Prototyping print run |
+| Industrial (Heavy) | Industry | Steel batch furnace; Heavy equipment runtime |
+| Military operations | Industry | Military aviation (pkm); Armoured convoy patrol |
+| Weapons manufacturing | Industry | Fighter aircraft production; Armoured vehicle build |
+| Defence installations | Industry | Military base (m²-year); Munitions depot (m²-year) |
+| Scenario simulations | Crosscut | Armed conflict (month); Wildfire burned area—per hectare |
+| Defence supply chain | Industry | TNT explosive production; RDX explosive production |
+| Private security | Industry | Private security convoy (km); Security helicopter (hour) |
+| Earth system feedbacks | Crosscut | Ocean CO₂ uptake; Cryosphere albedo loss |
+| Industrial externalities | Crosscut | Tailings pond footprint; Acid mine drainage |
+
+Layer descriptions, types, and activities are sourced directly from `data/layers.csv` so the table stays aligned with the seeded catalogue.【F:data/layers.csv†L1-L16】
 
 ---
 
@@ -85,6 +110,17 @@ make build
 - **Static site:** `npm run dev -- --host 0.0.0.0` inside `site/` starts the Vite dev server mirroring the same catalogue for UX validation.【F:site/package.json†L1-L20】【F:site/src/App.tsx†L1-L160】
 - **Worker API:** Use `wrangler dev` to exercise `/api/compute` and `/api/health`, verifying payload validation before deploying to Cloudflare.【F:workers/compute/index.ts†L1-L123】【F:wrangler.toml†L1-L12】
 
+### Local Chat (WebGPU)
+
+1. Use a Chromium-based browser with WebGPU enabled (Chrome 123+ or Edge) so the local worker can initialise GPU execution.
+2. Download a compact model into `site/public/models/`—for example:
+
+   ```bash
+   pnpm dlx @mlc-ai/web-llm download qwen2.5-1.5b-instruct-q4f16_1 -o site/public/models/
+   ```
+
+3. Run `npm run dev -- --host 0.0.0.0` inside `site/` and open `/chat` to warm the model via `@mlc-ai/web-llm`; all prompts stay in-browser because inference executes through the local worker bridge.【F:site/public/models/README.md†L1-L4】【F:site/src/lib/chat/LocalLLMWorker.ts†L1-L120】【F:site/src/lib/chat/LocalLLMAdapter.ts†L1-L360】
+
 ---
 
 ## Data & modelling workflows
@@ -92,6 +128,7 @@ make build
 - Update activity, factor, schedule, and grid CSVs in `data/` as the primary source of truth; keep provenance in sync with references and commit history.【F:data/activities.csv†L1-L10】
 - Extend the schema or validation behaviour through the `calc` package so new data inherits manifest integrity and figure generation without bespoke glue code.【F:calc/derive.py†L52-L92】
 - When you need intensity tables or exports for downstream models, run `python -m calc.derive intensity --fu all` or use the Make targets that wrap it for consistency.【F:Makefile†L1-L54】【F:calc/derive.py†L1080-L1151】
+- Keep UI icon assignments in sync via `data/icons.csv` so layer and activity surfaces stay backed by committed assets.【F:data/icons.csv†L1-L12】
 
 ---
 

--- a/data/icons.csv
+++ b/data/icons.csv
@@ -1,0 +1,13 @@
+icon_id,slug,layer_id,activity_id,description
+professional,professional.svg,professional,,Professional services baseline icon anchoring hybrid office activity sets.
+online,online.svg,online,,Online services workloads for remote-first teams and biosphere feedback pathways.
+industrial_light,industrial_light.svg,industrial_light,,Light industrial lab, prototyping, and fabrication iconography.
+industrial_heavy,industrial_heavy.svg,industrial_heavy,,Heavy industrial and externalities coverage icon.
+military_ops,military_ops.svg,industrial_heavy_military,,Military operations emissions icon used for defence missions.
+defense_embodied,defense_embodied.svg,industrial_heavy_embodied,,Weapons manufacturing and embodied defence asset icon.
+defense_building,defense_building.svg,buildings_defense,,Defence installation operations iconography.
+conflict_modeled,conflict_modeled.svg,modeled_events,,Scenario simulation icon used for conflict and hazard modelling.
+chemicals_defense,chemicals_defense.svg,materials_chemicals,,Defence supply chain energetic materials icon.
+personal_security,personal_security.svg,personal_security_layer,,Private security convoy and aerial patrol icon.
+biosphere_feedbacks,online.svg,biosphere_feedbacks,,Earth system feedback pathways sharing the online services iconography.
+industrial_externalities,industrial_heavy.svg,industrial_externalities,,Industrial externalities icon reused from heavy industry.

--- a/site/src/components/Icon.tsx
+++ b/site/src/components/Icon.tsx
@@ -1,0 +1,80 @@
+import { memo } from 'react';
+import type { ImgHTMLAttributes } from 'react';
+
+import { ASSETS } from '../basePath';
+
+type IconDescriptor = {
+  id: string;
+  slug: string;
+  layerId?: string;
+  activityId?: string;
+};
+
+const ICON_REGISTRY: IconDescriptor[] = [
+  { id: 'professional', slug: 'professional.svg', layerId: 'professional' },
+  { id: 'online', slug: 'online.svg', layerId: 'online' },
+  { id: 'industrial_light', slug: 'industrial_light.svg', layerId: 'industrial_light' },
+  { id: 'industrial_heavy', slug: 'industrial_heavy.svg', layerId: 'industrial_heavy' },
+  { id: 'military_ops', slug: 'military_ops.svg', layerId: 'industrial_heavy_military' },
+  { id: 'defense_embodied', slug: 'defense_embodied.svg', layerId: 'industrial_heavy_embodied' },
+  { id: 'defense_building', slug: 'defense_building.svg', layerId: 'buildings_defense' },
+  { id: 'conflict_modeled', slug: 'conflict_modeled.svg', layerId: 'modeled_events' },
+  { id: 'chemicals_defense', slug: 'chemicals_defense.svg', layerId: 'materials_chemicals' },
+  { id: 'personal_security', slug: 'personal_security.svg', layerId: 'personal_security_layer' },
+  { id: 'biosphere_feedbacks', slug: 'online.svg', layerId: 'biosphere_feedbacks' },
+  { id: 'industrial_externalities', slug: 'industrial_heavy.svg', layerId: 'industrial_externalities' }
+];
+
+const ICON_BY_ID = new Map<string, IconDescriptor>();
+const ICON_BY_LAYER = new Map<string, IconDescriptor>();
+const ICON_BY_ACTIVITY = new Map<string, IconDescriptor>();
+
+for (const entry of ICON_REGISTRY) {
+  ICON_BY_ID.set(entry.id, entry);
+  if (entry.layerId) {
+    ICON_BY_LAYER.set(entry.layerId, entry);
+  }
+  if (entry.activityId) {
+    ICON_BY_ACTIVITY.set(entry.activityId, entry);
+  }
+}
+
+export interface IconProps extends ImgHTMLAttributes<HTMLImageElement> {
+  id?: string | null;
+  layerId?: string | null;
+  activityId?: string | null;
+}
+
+function resolveIconSlug(props: IconProps): string | null {
+  const id = props.id?.trim();
+  if (id) {
+    const descriptor = ICON_BY_ID.get(id) ?? { slug: id };
+    return descriptor.slug;
+  }
+  const layerId = props.layerId?.trim();
+  if (layerId) {
+    const descriptor = ICON_BY_LAYER.get(layerId);
+    if (descriptor) {
+      return descriptor.slug;
+    }
+  }
+  const activityId = props.activityId?.trim();
+  if (activityId) {
+    const descriptor = ICON_BY_ACTIVITY.get(activityId);
+    if (descriptor) {
+      return descriptor.slug;
+    }
+  }
+  return null;
+}
+
+function IconComponent({ id, layerId, activityId, alt = '', ...rest }: IconProps): JSX.Element | null {
+  const slug = resolveIconSlug({ id, layerId, activityId });
+  if (!slug) {
+    return null;
+  }
+  const src = `${ASSETS()}/layers/${slug}`;
+  return <img src={src} alt={alt} {...rest} />;
+}
+
+export const Icon = memo(IconComponent);

--- a/site/src/components/LayerBrowser.tsx
+++ b/site/src/components/LayerBrowser.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { ASSETS } from '../basePath';
 import { useLayerCatalog, LayerAuditActivity } from '../lib/useLayerCatalog';
 import { FetchJSONDiagnostics, FetchJSONError } from '../lib/fetchJSON';
 import { PRIMARY_LAYER_ID, useProfile } from '../state/profile';
+import { Icon } from './Icon';
 
 interface StatusMeta {
   label: string;
@@ -57,13 +57,6 @@ function resolveStatus(
     return 'seeded_hidden';
   }
   return 'seeded_hidden';
-}
-
-function resolveIconPath(icon: string | undefined): string | null {
-  if (!icon) {
-    return null;
-  }
-  return `${ASSETS()}/layers/${icon}`;
 }
 
 function resolveTargetView(activity: LayerAuditActivity | undefined): ViewTarget {
@@ -336,7 +329,6 @@ export function SectorBrowser(): JSX.Element {
             seededHidden: seededHidden.has(layer.id)
           });
           const statusMeta = STATUS_META[status];
-          const iconPath = resolveIconPath(layer.icon ?? undefined);
           const activities = activityBucket.activities ?? [];
           const coverageLabel =
             coverage && typeof coverage.with_emission_factors === 'number' && typeof coverage.activities === 'number'
@@ -346,13 +338,12 @@ export function SectorBrowser(): JSX.Element {
             <details key={layer.id} className="group rounded-xl border border-slate-800/70 bg-slate-950/40" open={isActive}>
               <summary className="flex cursor-pointer flex-col gap-[calc(var(--gap-0)*0.75)] px-[var(--gap-1)] py-[6px] text-left outline-none transition hover:bg-slate-900/50">
                 <div className="flex items-start gap-[calc(var(--gap-0)*0.8)]">
-                  {iconPath ? (
-                    <img
-                      src={iconPath}
-                      alt=""
-                      className="h-9 w-9 flex-shrink-0 rounded-lg border border-slate-800/70 bg-slate-950/80 object-contain"
-                    />
-                  ) : null}
+                  <Icon
+                    id={layer.icon ?? undefined}
+                    layerId={layer.id}
+                    alt=""
+                    className="h-9 w-9 flex-shrink-0 rounded-lg border border-slate-800/70 bg-slate-950/80 object-contain"
+                  />
                   <div className="flex-1">
                     <div className="flex flex-wrap items-start gap-[calc(var(--gap-0)*0.6)]">
                       <div className="min-w-0 flex-1 space-y-[calc(var(--gap-0)*0.4)]">


### PR DESCRIPTION
## Summary
- document the manifest-first contract, expanded layer overview, and WebGPU chat quickstart in the README
- capture icon-to-layer mappings in data/icons.csv for UI asset provenance
- add a reusable <Icon> component and update the layer browser to consume the registry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a07975f8832cadf6872ced9fe074