### PR TITLE
Add scenario manifest sidebar with copyable JSON

### DIFF
--- a/site/src/components/ReferencesDrawer.tsx
+++ b/site/src/components/ReferencesDrawer.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-window';
 
 import { useProfile } from '../state/profile';
+import { ScenarioManifest } from './ScenarioManifest';
 
 type ReferencesDrawerProps = {
   id?: string;
@@ -187,6 +188,7 @@ export function ReferencesDrawer({ id = 'references', open, onToggle }: Referenc
       <p className="text-compact text-slate-400">
         Primary sources supporting the figures. Press <kbd className="rounded bg-slate-800 px-1">Esc</kbd> to close.
       </p>
+      <ScenarioManifest />
       <div
         id={`${id}-content`}
         hidden={!open}

--- a/site/src/components/ScenarioManifest.tsx
+++ b/site/src/components/ScenarioManifest.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { hashManifest } from '../lib/hash';
+import { DEFAULT_CONTROLS, type DietOption, type ModeSplit, useProfile } from '../state/profile';
+
+const MODE_LABELS: Record<keyof ModeSplit, string> = {
+  car: 'Drive',
+  transit: 'Transit',
+  bike: 'Active'
+};
+
+const DIET_LABELS: Record<DietOption, string> = {
+  omnivore: 'Omnivore',
+  vegetarian: 'Vegetarian',
+  vegan: 'Vegan'
+};
+
+interface SelectedRowSummary {
+  activity_id: string;
+  quantity: number;
+}
+
+function formatCommuteDays(days: number): string {
+  return `${days} commute day${days === 1 ? '' : 's'}/week`;
+}
+
+function formatModeSplitSummary(split: ModeSplit, defaults: ModeSplit): string | null {
+  const changedModes = (Object.keys(split) as (keyof ModeSplit)[]).filter(
+    (mode) => Math.round(split[mode]) !== Math.round(defaults[mode])
+  );
+  if (changedModes.length === 0) {
+    return null;
+  }
+  const descriptors = changedModes.map((mode) => `${MODE_LABELS[mode]} ${Math.round(split[mode])}%`);
+  return `Commute mix ${descriptors.join(' / ')}`;
+}
+
+function formatStreamingSummary(hours: number): string {
+  if (hours <= 0) {
+    return 'No streaming';
+  }
+  if (hours < 1) {
+    return `${Math.round(hours * 60)} min/day streaming`;
+  }
+  if (Number.isInteger(hours)) {
+    return `${hours} hr/day streaming`;
+  }
+  return `${hours.toFixed(1)} hr/day streaming`;
+}
+
+function dedupeSourceIds(values: unknown): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  values.forEach((value) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+    if (seen.has(value)) {
+      return;
+    }
+    seen.add(value);
+    ordered.push(value);
+  });
+  return ordered;
+}
+
+export function ScenarioManifest(): JSX.Element {
+  const profile = useProfile();
+  const controls = (profile.controls ?? DEFAULT_CONTROLS) as typeof DEFAULT_CONTROLS;
+  const overrides = (profile.overrides ?? {}) as Record<string, number>;
+  const hasLifestyleOverrides = profile.hasLifestyleOverrides ?? false;
+  const manifest = profile.result?.manifest ?? null;
+
+  const overrideSource = manifest?.overrides ?? overrides;
+
+  const selectedRows = useMemo<SelectedRowSummary[]>(() => {
+    return Object.entries(overrideSource).reduce<SelectedRowSummary[]>((acc, [activityId, quantity]) => {
+      if (typeof quantity !== 'number' || !Number.isFinite(quantity) || quantity <= 0) {
+        return acc;
+      }
+      acc.push({ activity_id: activityId, quantity });
+      return acc;
+    }, []);
+  }, [overrideSource]);
+
+  const sourceIds = useMemo(() => dedupeSourceIds(manifest?.sources), [manifest]);
+
+  const scenarioHash = useMemo(() => (manifest ? hashManifest(manifest) : null), [manifest]);
+
+  const scenarioPayload = useMemo(
+    () => ({
+      selected_rows: selectedRows,
+      source_ids: sourceIds,
+      scenario_hash: scenarioHash,
+    }),
+    [selectedRows, sourceIds, scenarioHash],
+  );
+
+  const manifestJson = useMemo(() => JSON.stringify(scenarioPayload, null, 2), [scenarioPayload]);
+
+  const changeSummary = useMemo(() => {
+    const parts: string[] = [];
+    if (hasLifestyleOverrides && controls.commuteDaysPerWeek !== DEFAULT_CONTROLS.commuteDaysPerWeek) {
+      parts.push(formatCommuteDays(controls.commuteDaysPerWeek));
+    }
+    if (hasLifestyleOverrides) {
+      const modeSummary = formatModeSplitSummary(controls.modeSplit, DEFAULT_CONTROLS.modeSplit);
+      if (modeSummary) {
+        parts.push(modeSummary);
+      }
+    }
+    if (hasLifestyleOverrides && controls.diet !== DEFAULT_CONTROLS.diet) {
+      parts.push(`${DIET_LABELS[controls.diet]} diet`);
+    }
+    if (hasLifestyleOverrides && controls.streamingHoursPerDay !== DEFAULT_CONTROLS.streamingHoursPerDay) {
+      parts.push(formatStreamingSummary(controls.streamingHoursPerDay));
+    }
+    if (parts.length === 0) {
+      parts.push('Defaults retained');
+    }
+    parts.push(`${selectedRows.length} active row${selectedRows.length === 1 ? '' : 's'}`);
+    parts.push(`${sourceIds.length} source${sourceIds.length === 1 ? '' : 's'}`);
+    return parts.join(' • ');
+  }, [controls, hasLifestyleOverrides, selectedRows.length, sourceIds.length]);
+
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
+  const resetTimerRef = useRef<number | null>(null);
+
+  const scheduleReset = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = window.setTimeout(() => {
+      setCopyState('idle');
+      resetTimerRef.current = null;
+    }, 2000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    setCopyState('idle');
+    if (typeof window !== 'undefined' && resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
+  }, [manifestJson]);
+
+  const handleCopy = useCallback(async () => {
+    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+    if (!clipboard || typeof clipboard.writeText !== 'function') {
+      setCopyState('error');
+      scheduleReset();
+      return;
+    }
+    try {
+      await clipboard.writeText(manifestJson);
+      setCopyState('copied');
+    } catch (error) {
+      console.warn('Failed to copy scenario manifest', error);
+      setCopyState('error');
+    }
+    scheduleReset();
+  }, [manifestJson, scheduleReset]);
+
+  const copyLabel = copyState === 'copied' ? 'Copied' : copyState === 'error' ? 'Copy failed' : 'Copy JSON';
+
+  return (
+    <section className="rounded-xl border border-slate-800/70 bg-slate-950/50 p-[calc(var(--gap-1)*0.8)] shadow-inner shadow-slate-950/40">
+      <header className="flex items-center justify-between gap-[var(--gap-0)]">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300">Scenario manifest</p>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex items-center gap-2 rounded-md border border-sky-500/50 bg-sky-500/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.28em] text-sky-100 transition hover:bg-sky-500/15 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          data-testid="scenario-manifest-copy"
+        >
+          {copyLabel}
+        </button>
+      </header>
+      <p
+        className="mt-[calc(var(--gap-0)*0.6)] text-[11px] text-slate-400"
+        data-testid="scenario-manifest-summary"
+      >
+        <span className="font-semibold text-slate-200">What changed:</span> {changeSummary}
+      </p>
+      <div className="mt-[calc(var(--gap-0)*0.8)] rounded-lg border border-slate-800/60 bg-slate-950/70 p-[calc(var(--gap-0)*0.8)]">
+        <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-slate-200">
+          <code data-testid="scenario-manifest-json">{manifestJson}</code>
+        </pre>
+      </div>
+    </section>
+  );
+}

--- a/site/src/components/__tests__/ReferencesDrawer.test.tsx
+++ b/site/src/components/__tests__/ReferencesDrawer.test.tsx
@@ -5,7 +5,16 @@ import { ReferencesDrawer } from '../ReferencesDrawer';
 
 vi.mock('../../state/profile', () => ({
   useProfile: () => ({
-    activeReferences: ['First reference.', 'Second reference.']
+    activeReferences: ['First reference.', 'Second reference.'],
+    controls: {
+      commuteDaysPerWeek: 3,
+      modeSplit: { car: 60, transit: 30, bike: 10 },
+      diet: 'omnivore',
+      streamingHoursPerDay: 1.5,
+    },
+    overrides: {},
+    hasLifestyleOverrides: false,
+    result: { manifest: { sources: [] } },
   })
 }));
 

--- a/site/src/components/__tests__/ScenarioManifest.test.tsx
+++ b/site/src/components/__tests__/ScenarioManifest.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../state/profile', async () => {
+  const actual = await vi.importActual<typeof import('../../state/profile')>('../../state/profile');
+  return {
+    ...actual,
+    useProfile: vi.fn(),
+  };
+});
+
+import { ScenarioManifest } from '../ScenarioManifest';
+import { hashManifest } from '../../lib/hash';
+import { useProfile } from '../../state/profile';
+
+const mockUseProfile = useProfile as unknown as vi.Mock;
+
+describe('ScenarioManifest', () => {
+  const manifest = {
+    overrides: {
+      'ACTIVITY.ONE': 5,
+      'ACTIVITY.ZERO': 0,
+      'ACTIVITY.TWO': 2.5,
+    },
+    sources: ['SRC.ONE', 'SRC.TWO', 'SRC.ONE'],
+  } as const;
+
+  beforeEach(() => {
+    mockUseProfile.mockReturnValue({
+      controls: {
+        commuteDaysPerWeek: 4,
+        modeSplit: { car: 50, transit: 30, bike: 20 },
+        diet: 'vegetarian',
+        streamingHoursPerDay: 2,
+      },
+      overrides: manifest.overrides,
+      hasLifestyleOverrides: true,
+      result: { manifest },
+    });
+  });
+
+  afterEach(() => {
+    mockUseProfile.mockReset();
+    if ('clipboard' in navigator) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (navigator as any).clipboard;
+    }
+  });
+
+  it('renders scenario payload with selected rows and ordered sources', () => {
+    render(<ScenarioManifest />);
+
+    const jsonBlock = screen.getByTestId('scenario-manifest-json');
+    const payload = JSON.parse(jsonBlock.textContent ?? '{}');
+
+    expect(payload.selected_rows).toEqual([
+      { activity_id: 'ACTIVITY.ONE', quantity: 5 },
+      { activity_id: 'ACTIVITY.TWO', quantity: 2.5 },
+    ]);
+    expect(payload.source_ids).toEqual(['SRC.ONE', 'SRC.TWO']);
+    expect(payload.scenario_hash).toBe(hashManifest(manifest));
+
+    const summary = screen.getByTestId('scenario-manifest-summary');
+    expect(summary.textContent).toContain('4 commute days/week');
+    expect(summary.textContent).toContain('Commute mix Drive 50% / Active 20%');
+    expect(summary.textContent).toContain('Vegetarian diet');
+    expect(summary.textContent).toContain('2 hr/day streaming');
+    expect(summary.textContent).toContain('2 active rows');
+    expect(summary.textContent).toContain('2 sources');
+  });
+
+  it('copies the manifest json to the clipboard', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<ScenarioManifest />);
+
+    const copyButton = screen.getByTestId('scenario-manifest-copy');
+    await user.click(copyButton);
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('selected_rows'));
+    expect(copyButton).toHaveTextContent(/copied/i);
+  });
+});

--- a/site/src/components/__tests__/ScenarioManifest.test.tsx
+++ b/site/src/components/__tests__/ScenarioManifest.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
 
 vi.mock('../../state/profile', async () => {
   const actual = await vi.importActual<typeof import('../../state/profile')>('../../state/profile');
@@ -14,7 +15,7 @@ import { ScenarioManifest } from '../ScenarioManifest';
 import { hashManifest } from '../../lib/hash';
 import { useProfile } from '../../state/profile';
 
-const mockUseProfile = useProfile as unknown as vi.Mock;
+const mockUseProfile = useProfile as unknown as Mock;
 
 describe('ScenarioManifest', () => {
   const manifest = {

--- a/site/src/components/__tests__/__snapshots__/ReferencesDrawer.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/ReferencesDrawer.test.tsx.snap
@@ -51,6 +51,54 @@ exports[`ReferencesDrawer > renders references and closes on escape 1`] = `
       </kbd>
        to close.
     </p>
+    <section
+      class="rounded-xl border border-slate-800/70 bg-slate-950/50 p-[calc(var(--gap-1)*0.8)] shadow-inner shadow-slate-950/40"
+    >
+      <header
+        class="flex items-center justify-between gap-[var(--gap-0)]"
+      >
+        <p
+          class="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300"
+        >
+          Scenario manifest
+        </p>
+        <button
+          class="inline-flex items-center gap-2 rounded-md border border-sky-500/50 bg-sky-500/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.28em] text-sky-100 transition hover:bg-sky-500/15 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          data-testid="scenario-manifest-copy"
+          type="button"
+        >
+          Copy JSON
+        </button>
+      </header>
+      <p
+        class="mt-[calc(var(--gap-0)*0.6)] text-[11px] text-slate-400"
+        data-testid="scenario-manifest-summary"
+      >
+        <span
+          class="font-semibold text-slate-200"
+        >
+          What changed:
+        </span>
+         Defaults retained • 0 active rows • 0 sources
+      </p>
+      <div
+        class="mt-[calc(var(--gap-0)*0.8)] rounded-lg border border-slate-800/60 bg-slate-950/70 p-[calc(var(--gap-0)*0.8)]"
+      >
+        <pre
+          class="max-h-48 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-slate-200"
+        >
+          <code
+            data-testid="scenario-manifest-json"
+          >
+            {
+  "selected_rows": [],
+  "source_ids": [],
+  "scenario_hash": "e0fadea9"
+}
+          </code>
+        </pre>
+      </div>
+    </section>
     <div
       class="flex-1 overflow-y-auto rounded-xl border border-slate-800/60 bg-slate-950/30 p-[var(--gap-1)] text-compact text-slate-300"
       id="references-content"

--- a/site/src/lib/hash.ts
+++ b/site/src/lib/hash.ts
@@ -1,0 +1,9 @@
+export function hashManifest(payload: unknown): string {
+  const serialised = JSON.stringify(payload ?? {});
+  let hash = 2166136261;
+  for (let index = 0; index < serialised.length; index += 1) {
+    hash ^= serialised.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
+}

--- a/site/src/state/chat.tsx
+++ b/site/src/state/chat.tsx
@@ -5,6 +5,7 @@ import type { ComputeResult } from './profile';
 import { compute } from '../lib/api';
 import { applyIntent } from '../lib/intent';
 import type { IntentResolution } from '../lib/intent';
+import { hashManifest } from '../lib/hash';
 
 export type ChatRole = 'user' | 'assistant' | 'system';
 
@@ -64,16 +65,6 @@ function normaliseSources(manifest: ComputeResult['manifest'] | null): string[] 
   }
   const ids = Array.isArray(manifest.sources) ? manifest.sources : [];
   return ids.filter((value, index) => typeof value === 'string' && ids.indexOf(value) === index);
-}
-
-function hashManifest(manifest: ComputeResult['manifest'] | null): string {
-  const payload = JSON.stringify(manifest ?? {});
-  let hash = 2166136261;
-  for (let index = 0; index < payload.length; index += 1) {
-    hash ^= payload.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return (hash >>> 0).toString(16);
 }
 
 function snapshotManifest(manifest: ComputeResult['manifest'] | null): ChatManifestSnapshot | null {

--- a/site/src/state/profile.tsx
+++ b/site/src/state/profile.tsx
@@ -117,7 +117,7 @@ const DIET_ACTIVITY_IDS: Record<DietOption, string> = {
 
 const STREAMING_ACTIVITY_ID = 'MEDIA.STREAM.HD.HOUR.TV';
 
-const DEFAULT_CONTROLS: ProfileControlsState = {
+export const DEFAULT_CONTROLS: ProfileControlsState = {
   commuteDaysPerWeek: 3,
   modeSplit: {
     car: 60,


### PR DESCRIPTION
## Summary
- add a scenario manifest sidebar that surfaces the active selections, sources, and hash with a copy action
- integrate the manifest panel into the references drawer while sharing the manifest hashing helper
- cover the new manifest UI with unit tests and refresh the references drawer snapshot

## Testing
- npm run test -- -u

------
https://chatgpt.com/codex/tasks/task_e_68e5a75a9810832cb7a949663d7d3a34