### PR TITLE
feat(compare): add category aggregation utilities and UI

### DIFF
--- a/docs/compare.md
+++ b/docs/compare.md
@@ -1,0 +1,14 @@
+# Scenario comparison
+
+The scenario comparison view surfaces the difference between a baseline and comparison scenario at both the activity and category level.
+
+## Category aggregation
+
+Category summaries are produced by grouping each changed, added, or removed activity by a chosen basis key and summing the signed emission deltas.
+
+- **Basis keys** – Supported values are `activity.category` (default) and `layer_id`. Activity metadata from the catalog is used to resolve each key.
+- **Ordering** – Buckets are sorted by descending absolute delta, with lexical ordering as a tie-breaker to keep provenance deterministic.
+- **Rounding** – All totals and deltas are rounded to four decimal places before presentation. Percentage deltas are computed against the rounded baseline total. When the rounded baseline total is zero and the comparison total is non-zero, the percentage delta resolves to positive infinity.
+- **Null handling** – Baseline or comparison totals that are missing remain null-first and are not coerced to zero during aggregation.
+
+These rules ensure that category-level stacks mirror the underlying row-level scenario diff within a tolerance of `1e-6`.

--- a/site/src/components/ScenarioCompare.tsx
+++ b/site/src/components/ScenarioCompare.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type { Catalog } from '../lib/catalog';
+import {
+  aggregateByCategory,
+  listActivityDeltas,
+  type ActivityDelta,
+  type CategoryDelta,
+  type ScenarioDiff
+} from '../lib/scenarioCompare';
+import { compareDenseSpacing } from '../styles/dense';
+
+export interface ScenarioCompareProps {
+  diff: ScenarioDiff;
+  catalog: Catalog;
+  baseHash?: string;
+  compareHash?: string;
+}
+
+type CompareView = 'category' | 'activity';
+
+function round4(value: number): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  return Math.round(value * 10_000) / 10_000;
+}
+
+function formatDelta(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  const abs = Math.abs(value);
+  const formatted = abs.toLocaleString('en-US', {
+    maximumFractionDigits: 4,
+    minimumFractionDigits: abs < 1 ? 1 : 0
+  });
+  if (value > 0) {
+    return `+${formatted}`;
+  }
+  if (value < 0) {
+    return `−${formatted}`;
+  }
+  return '0';
+}
+
+function formatAbsolute(value: number | null | undefined): string {
+  if (value == null) {
+    return '—';
+  }
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  return value.toLocaleString('en-US', {
+    maximumFractionDigits: 4,
+    minimumFractionDigits: value < 1 && value > 0 ? 1 : 0
+  });
+}
+
+function formatPercent(value: number): string {
+  if (value === Number.POSITIVE_INFINITY) {
+    return '∞%';
+  }
+  if (value === Number.NEGATIVE_INFINITY) {
+    return '−∞%';
+  }
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  const percent = value * 100;
+  return `${percent.toLocaleString('en-US', {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: percent !== 0 ? 2 : 0
+  })}%`;
+}
+
+function SummaryCard({
+  title,
+  primary,
+  secondary,
+  testId
+}: {
+  title: string;
+  primary: string;
+  secondary?: string;
+  testId: string;
+}) {
+  return (
+    <div
+      className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-4"
+      data-testid={testId}
+      role="group"
+      aria-label={title}
+    >
+      <p className="text-xs uppercase tracking-[0.24em] text-slate-400">{title}</p>
+      <p className="mt-2 text-lg font-semibold text-slate-100">{primary}</p>
+      {secondary ? <p className="mt-1 text-sm text-slate-300">{secondary}</p> : null}
+    </div>
+  );
+}
+
+function CategoryDeltaChart({ data }: { data: CategoryDelta[] }) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return <p className="text-sm text-slate-400">No category deltas available.</p>;
+  }
+  const maxAbs = data.reduce((max, row) => Math.max(max, Math.abs(row.delta)), 0);
+  const widthScale = maxAbs > 0 ? 50 / maxAbs : 0;
+  return (
+    <div className="space-y-3" data-testid="scenario-compare-chart">
+      {data.map((row) => {
+        const width = Math.min(Math.abs(row.delta) * widthScale, 50);
+        const isPositive = row.delta >= 0;
+        return (
+          <div key={row.key} className="space-y-1">
+            <div className="flex items-center justify-between text-sm leading-tight text-slate-200">
+              <span className="font-medium text-slate-100">{row.label}</span>
+              <span>{formatDelta(row.delta)} kg CO₂e</span>
+            </div>
+            <div className="relative h-4 overflow-hidden rounded-full bg-slate-900/70">
+              <div className="absolute left-1/2 top-0 h-full w-px bg-slate-700/60" aria-hidden />
+              {isPositive ? (
+                <div
+                  className="absolute left-1/2 top-0 h-full rounded-r-full bg-emerald-500/80"
+                  style={{ width: `${width}%` }}
+                />
+              ) : (
+                <div
+                  className="absolute right-1/2 top-0 h-full rounded-l-full bg-rose-500/80"
+                  style={{ width: `${width}%` }}
+                />
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ActivityDeltaList({ data }: { data: ActivityDelta[] }) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return <p className="text-sm text-slate-400">No activity deltas available.</p>;
+  }
+  return (
+    <ol className="space-y-3" data-testid="scenario-compare-activity">
+      {data.map((row) => (
+        <li key={row.id} className="rounded-xl border border-slate-800/50 bg-slate-900/30 p-4">
+          <p className="text-sm font-semibold text-slate-100">{row.label}</p>
+          <p className="mt-1 text-sm text-slate-300">
+            {formatDelta(row.delta)} kg CO₂e · Base {formatAbsolute(row.total_base)} kg → Compare{' '}
+            {formatAbsolute(row.total_compare)} kg
+          </p>
+          <p className="mt-0.5 text-xs uppercase tracking-[0.22em] text-slate-500">
+            Change {formatPercent(row.delta_pct)}
+          </p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function useCompareView(): [CompareView, (view: CompareView) => void] {
+  const [view, setView] = useState<CompareView>(() => {
+    if (typeof window === 'undefined') {
+      return 'category';
+    }
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get('view');
+    return raw === 'activity' ? 'activity' : 'category';
+  });
+  return [view, setView];
+}
+
+function updateSearchParams(baseHash: string | undefined, compareHash: string | undefined, view: CompareView) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const params = new URLSearchParams(window.location.search);
+  if (baseHash && baseHash.trim()) {
+    params.set('base', baseHash.trim());
+  } else {
+    params.delete('base');
+  }
+  if (compareHash && compareHash.trim()) {
+    params.set('compare', compareHash.trim());
+  } else {
+    params.delete('compare');
+  }
+  params.set('view', view);
+  const next = `${window.location.pathname}?${params.toString()}`;
+  window.history.replaceState(null, '', next);
+}
+
+export function ScenarioCompare({ diff, catalog, baseHash, compareHash }: ScenarioCompareProps) {
+  const [view, setView] = useCompareView();
+  const categoryDeltas = useMemo(() => aggregateByCategory(diff, 'activity.category', catalog), [diff, catalog]);
+  const activityDeltas = useMemo(() => listActivityDeltas(diff, catalog), [diff, catalog]);
+
+  useEffect(() => {
+    updateSearchParams(baseHash, compareHash, view);
+  }, [baseHash, compareHash, view]);
+
+  const summary = useMemo(() => {
+    if (!Array.isArray(categoryDeltas) || categoryDeltas.length === 0) {
+      return {
+        netDelta: 0,
+        baseTotal: 0,
+        compareTotal: 0,
+        netPct: 0,
+        increase: null as CategoryDelta | null,
+        decrease: null as CategoryDelta | null
+      };
+    }
+    const netDelta = round4(categoryDeltas.reduce((sum, row) => sum + row.delta, 0));
+    const baseTotal = round4(categoryDeltas.reduce((sum, row) => sum + (row.total_base ?? 0), 0));
+    const compareTotal = round4(categoryDeltas.reduce((sum, row) => sum + (row.total_compare ?? 0), 0));
+    let netPct = 0;
+    if (baseTotal === 0) {
+      if (compareTotal !== 0) {
+        netPct = Number.POSITIVE_INFINITY;
+      }
+    } else {
+      netPct = round4(netDelta / baseTotal);
+    }
+    const increase = categoryDeltas
+      .filter((row) => row.delta > 0)
+      .sort((a, b) => b.delta - a.delta)[0] ?? null;
+    const decrease = categoryDeltas
+      .filter((row) => row.delta < 0)
+      .sort((a, b) => a.delta - b.delta)[0] ?? null;
+    return { netDelta, baseTotal, compareTotal, netPct, increase, decrease };
+  }, [categoryDeltas]);
+
+  return (
+    <section
+      className="rounded-2xl border border-slate-800/70 bg-slate-950/70 text-slate-100 shadow-inner shadow-slate-900/40"
+      style={{ padding: compareDenseSpacing.sectionPadding }}
+    >
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Scenario comparison</h2>
+          <p className="text-xs text-slate-400">Contrast baseline and alternative scenarios.</p>
+        </div>
+        <div className="flex items-center gap-2" role="group" aria-label="Comparison basis">
+          <button
+            type="button"
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
+              view === 'category'
+                ? 'bg-sky-500 text-slate-900 shadow-sm shadow-sky-900/40'
+                : 'bg-slate-900/50 text-slate-300 hover:bg-slate-900/70'
+            }`}
+            onClick={() => setView('category')}
+            data-testid="scenario-compare-toggle-category"
+          >
+            By category
+          </button>
+          <button
+            type="button"
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
+              view === 'activity'
+                ? 'bg-sky-500 text-slate-900 shadow-sm shadow-sky-900/40'
+                : 'bg-slate-900/50 text-slate-300 hover:bg-slate-900/70'
+            }`}
+            onClick={() => setView('activity')}
+            data-testid="scenario-compare-toggle-activity"
+          >
+            By activity
+          </button>
+        </div>
+      </header>
+      <div
+        className="mt-5 grid gap-5 sm:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]"
+        style={{ rowGap: compareDenseSpacing.cardGap, columnGap: compareDenseSpacing.cardGap }}
+      >
+        <div>
+          <CategoryDeltaChart data={categoryDeltas} />
+        </div>
+        <div className="grid gap-3" style={{ rowGap: compareDenseSpacing.cardGap }}>
+          <SummaryCard
+            title="Net change"
+            primary={`${formatDelta(summary.netDelta)} kg CO₂e`}
+            secondary={`Baseline ${formatAbsolute(summary.baseTotal)} kg → Compare ${formatAbsolute(
+              summary.compareTotal
+            )} kg (${formatPercent(summary.netPct)})`}
+            testId="scenario-compare-summary-net"
+          />
+          <SummaryCard
+            title="Top ↑ category"
+            primary={summary.increase ? summary.increase.label : 'No increase'}
+            secondary={summary.increase ? `${formatDelta(summary.increase.delta)} kg CO₂e` : undefined}
+            testId="scenario-compare-summary-up"
+          />
+          <SummaryCard
+            title="Top ↓ category"
+            primary={summary.decrease ? summary.decrease.label : 'No decrease'}
+            secondary={summary.decrease ? `${formatDelta(summary.decrease.delta)} kg CO₂e` : undefined}
+            testId="scenario-compare-summary-down"
+          />
+        </div>
+      </div>
+      <div className="mt-6" data-testid="scenario-compare-detail">
+        {view === 'category' ? <CategoryDeltaList data={categoryDeltas} /> : <ActivityDeltaList data={activityDeltas} />}
+      </div>
+    </section>
+  );
+}
+
+function CategoryDeltaList({ data }: { data: CategoryDelta[] }) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return <p className="text-sm text-slate-400">No category deltas available.</p>;
+  }
+  return (
+    <ol className="space-y-2" data-testid="scenario-compare-category">
+      {data.map((row) => (
+        <li key={row.key} className="flex items-baseline justify-between rounded-xl bg-slate-900/30 px-4 py-3">
+          <span className="text-sm font-medium text-slate-100">{row.label}</span>
+          <span className="text-sm text-slate-300">{formatDelta(row.delta)} kg CO₂e</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/site/src/components/tests/ScenarioCompare.view.test.tsx
+++ b/site/src/components/tests/ScenarioCompare.view.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { Catalog } from '../../lib/catalog';
+import { ScenarioCompare } from '../ScenarioCompare';
+
+const catalog: Catalog = {
+  activities: [
+    {
+      activity_id: 'ACT.ALPHA.ONE',
+      label: 'Alpha line retrofit',
+      category: 'alpha_ops',
+      layer_id: 'layer_main'
+    },
+    {
+      activity_id: 'ACT.BETA.TWO',
+      label: 'Beta workstation swap',
+      category: 'beta_ops',
+      layer_id: 'layer_main'
+    },
+    {
+      activity_id: 'ACT.ALPHA.THREE',
+      label: 'Alpha pilot program',
+      category: 'alpha_ops',
+      layer_id: 'layer_remote'
+    },
+    {
+      activity_id: 'ACT.GAMMA.FOUR',
+      label: 'Gamma furnace closure',
+      category: 'gamma_ops',
+      layer_id: 'layer_remote'
+    },
+    {
+      activity_id: 'ACT.GAMMA.FIVE',
+      label: 'Gamma service scope',
+      category: 'gamma_ops',
+      layer_id: 'layer_remote'
+    }
+  ],
+  profiles: []
+};
+
+const diff = {
+  changed: [
+    {
+      activity_id: 'ACT.ALPHA.ONE',
+      delta: 4.5678,
+      total_base: 20.1234,
+      total_compare: 24.6912
+    },
+    {
+      activity_id: 'ACT.BETA.TWO',
+      delta: -5.3,
+      total_base: 15.5,
+      total_compare: 10.2
+    },
+    {
+      activity_id: 'ACT.GAMMA.FIVE',
+      delta: 1.2,
+      total_base: 8.25,
+      total_compare: 9.45
+    }
+  ],
+  added: [
+    {
+      activity_id: 'ACT.ALPHA.THREE',
+      delta: 3.3333,
+      total_base: null,
+      total_compare: 3.3333
+    }
+  ],
+  removed: [
+    {
+      activity_id: 'ACT.GAMMA.FOUR',
+      delta: -5.75,
+      total_base: 5.75,
+      total_compare: null
+    }
+  ]
+};
+
+describe('ScenarioCompare', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/compare?base=baseline&compare=alt');
+  });
+
+  it('renders category deltas by default with summary cards', () => {
+    render(<ScenarioCompare diff={diff} catalog={catalog} baseHash="baseline" compareHash="alt" />);
+
+    expect(screen.getByTestId('scenario-compare-chart')).toBeInTheDocument();
+    const summaryNet = screen.getByTestId('scenario-compare-summary-net');
+    expect(summaryNet).toHaveTextContent('−1.9489 kg CO₂e');
+    expect(summaryNet).toHaveTextContent('Baseline 49.6234 kg → Compare 47.6745 kg');
+    expect(summaryNet).toHaveTextContent('(-3.93%)');
+
+    const summaryUp = screen.getByTestId('scenario-compare-summary-up');
+    expect(summaryUp).toHaveTextContent('Alpha Ops');
+    expect(summaryUp).toHaveTextContent('+7.9011 kg CO₂e');
+
+    const summaryDown = screen.getByTestId('scenario-compare-summary-down');
+    expect(summaryDown).toHaveTextContent('Beta Ops');
+    expect(summaryDown).toHaveTextContent('−5.3 kg CO₂e');
+
+    expect(screen.getByTestId('scenario-compare-category')).toBeInTheDocument();
+    expect(new URLSearchParams(window.location.search).get('view')).toBe('category');
+  });
+
+  it('switches to activity view and updates the URL parameter', () => {
+    render(<ScenarioCompare diff={diff} catalog={catalog} baseHash="baseline" compareHash="alt" />);
+
+    const activityButton = screen.getByTestId('scenario-compare-toggle-activity');
+    fireEvent.click(activityButton);
+
+    expect(screen.getByTestId('scenario-compare-activity')).toBeInTheDocument();
+    expect(screen.queryByTestId('scenario-compare-category')).not.toBeInTheDocument();
+    expect(new URLSearchParams(window.location.search).get('view')).toBe('activity');
+  });
+});

--- a/site/src/lib/scenarioCompare.ts
+++ b/site/src/lib/scenarioCompare.ts
@@ -1,0 +1,196 @@
+import { getActivityById, getCategoryLabel, getLayerLabel, type Catalog } from './catalog';
+
+export type CategoryKey = 'activity.category' | 'layer_id';
+
+export interface ScenarioActivityChange {
+  activity_id: string;
+  delta?: number | null;
+  total_base?: number | null;
+  total_compare?: number | null;
+}
+
+export interface ScenarioDiff {
+  changed?: ScenarioActivityChange[] | null;
+  added?: ScenarioActivityChange[] | null;
+  removed?: ScenarioActivityChange[] | null;
+}
+
+export interface CategoryDelta {
+  key: string;
+  label: string;
+  delta: number;
+  delta_pct: number;
+  total_base: number | null;
+  total_compare: number | null;
+}
+
+interface CategoryBucket {
+  key: string;
+  label: string;
+  delta: number;
+  totalBase: number;
+  hasBase: boolean;
+  totalCompare: number;
+  hasCompare: boolean;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  return value;
+}
+
+function round4(value: number): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  return Math.round(value * 10_000) / 10_000;
+}
+
+function resolveCategoryKey(
+  change: ScenarioActivityChange,
+  basis: CategoryKey,
+  catalog: Catalog
+): { key: string; label: string } {
+  const activity = getActivityById(catalog, change.activity_id);
+  if (basis === 'layer_id') {
+    const raw = typeof activity?.layer_id === 'string' ? activity.layer_id : '';
+    const key = raw || 'unassigned';
+    return { key, label: getLayerLabel(catalog, raw) };
+  }
+  const raw = typeof activity?.category === 'string' ? activity.category : '';
+  const key = raw || 'uncategorized';
+  return { key, label: getCategoryLabel(catalog, raw) };
+}
+
+export function aggregateByCategory(
+  diff: ScenarioDiff,
+  basis: CategoryKey,
+  catalog: Catalog
+): CategoryDelta[] {
+  const buckets = new Map<string, CategoryBucket>();
+  const rows = [diff.changed, diff.added, diff.removed]
+    .flat()
+    .filter((entry): entry is ScenarioActivityChange => Boolean(entry && entry.activity_id));
+
+  rows.forEach((entry) => {
+    const { key, label } = resolveCategoryKey(entry, basis, catalog);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        key,
+        label,
+        delta: 0,
+        totalBase: 0,
+        hasBase: false,
+        totalCompare: 0,
+        hasCompare: false
+      } satisfies CategoryBucket;
+      buckets.set(key, bucket);
+    }
+    const delta = toNumber(entry.delta);
+    if (delta !== null) {
+      bucket.delta += delta;
+    }
+    const base = toNumber(entry.total_base);
+    if (base !== null) {
+      bucket.totalBase += base;
+      bucket.hasBase = true;
+    }
+    const compare = toNumber(entry.total_compare);
+    if (compare !== null) {
+      bucket.totalCompare += compare;
+      bucket.hasCompare = true;
+    }
+  });
+
+  const deltas: CategoryDelta[] = Array.from(buckets.values()).map((bucket) => {
+    const totalBase = bucket.hasBase ? round4(bucket.totalBase) : null;
+    const totalCompare = bucket.hasCompare ? round4(bucket.totalCompare) : null;
+    const delta = round4(bucket.delta);
+    const denominator = totalBase ?? 0;
+    let pct = 0;
+    if (denominator === 0) {
+      if ((totalCompare ?? 0) !== 0) {
+        pct = Number.POSITIVE_INFINITY;
+      }
+    } else {
+      pct = round4(delta / denominator);
+    }
+    return {
+      key: bucket.key,
+      label: bucket.label,
+      delta,
+      delta_pct: pct,
+      total_base: totalBase,
+      total_compare: totalCompare
+    } satisfies CategoryDelta;
+  });
+
+  return deltas
+    .sort((a, b) => {
+      const magnitude = Math.abs(b.delta) - Math.abs(a.delta);
+      if (magnitude !== 0) {
+        return magnitude;
+      }
+      return a.key.localeCompare(b.key);
+    });
+}
+
+export interface ActivityDelta {
+  id: string;
+  label: string;
+  delta: number;
+  delta_pct: number;
+  total_base: number | null;
+  total_compare: number | null;
+}
+
+function resolveActivityLabel(change: ScenarioActivityChange, catalog: Catalog): string {
+  const activity = getActivityById(catalog, change.activity_id);
+  const labelCandidate =
+    typeof activity?.label === 'string' && activity.label.trim().length > 0
+      ? activity.label
+      : typeof activity?.name === 'string' && activity.name.trim().length > 0
+        ? activity.name
+        : change.activity_id;
+  return labelCandidate;
+}
+
+export function listActivityDeltas(diff: ScenarioDiff, catalog: Catalog): ActivityDelta[] {
+  const rows = [diff.changed, diff.added, diff.removed]
+    .flat()
+    .filter((entry): entry is ScenarioActivityChange => Boolean(entry && entry.activity_id));
+
+  const deltas = rows.map((entry) => {
+    const base = toNumber(entry.total_base);
+    const compare = toNumber(entry.total_compare);
+    const delta = toNumber(entry.delta) ?? round4((compare ?? 0) - (base ?? 0));
+    const denominator = base ?? 0;
+    let pct = 0;
+    if (denominator === 0) {
+      if ((compare ?? 0) !== 0) {
+        pct = Number.POSITIVE_INFINITY;
+      }
+    } else {
+      pct = round4(delta / denominator);
+    }
+    return {
+      id: entry.activity_id,
+      label: resolveActivityLabel(entry, catalog),
+      delta: round4(delta),
+      delta_pct: pct,
+      total_base: base == null ? null : round4(base),
+      total_compare: compare == null ? null : round4(compare)
+    } satisfies ActivityDelta;
+  });
+
+  return deltas.sort((a, b) => {
+    const magnitude = Math.abs(b.delta) - Math.abs(a.delta);
+    if (magnitude !== 0) {
+      return magnitude;
+    }
+    return a.label.localeCompare(b.label);
+  });
+}

--- a/site/src/lib/tests/scenarioCompare.aggregate.test.ts
+++ b/site/src/lib/tests/scenarioCompare.aggregate.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Catalog } from '../../lib/catalog';
+import {
+  aggregateByCategory,
+  listActivityDeltas,
+  type ScenarioDiff
+} from '../scenarioCompare';
+
+const catalog: Catalog = {
+  activities: [
+    {
+      activity_id: 'ACT.ALPHA.ONE',
+      label: 'Alpha line retrofit',
+      category: 'alpha_ops',
+      layer_id: 'layer_main'
+    },
+    {
+      activity_id: 'ACT.BETA.TWO',
+      label: 'Beta workstation swap',
+      category: 'beta_ops',
+      layer_id: 'layer_main'
+    },
+    {
+      activity_id: 'ACT.ALPHA.THREE',
+      label: 'Alpha pilot program',
+      category: 'alpha_ops',
+      layer_id: 'layer_remote'
+    },
+    {
+      activity_id: 'ACT.GAMMA.FOUR',
+      label: 'Gamma furnace closure',
+      category: 'gamma_ops',
+      layer_id: 'layer_remote'
+    },
+    {
+      activity_id: 'ACT.GAMMA.FIVE',
+      label: 'Gamma service scope',
+      category: 'gamma_ops',
+      layer_id: 'layer_remote'
+    }
+  ],
+  profiles: []
+};
+
+const diff: ScenarioDiff = {
+  changed: [
+    {
+      activity_id: 'ACT.ALPHA.ONE',
+      delta: 4.5678,
+      total_base: 20.1234,
+      total_compare: 24.6912
+    },
+    {
+      activity_id: 'ACT.BETA.TWO',
+      delta: -5.3,
+      total_base: 15.5,
+      total_compare: 10.2
+    },
+    {
+      activity_id: 'ACT.GAMMA.FIVE',
+      delta: 1.2,
+      total_base: 8.25,
+      total_compare: 9.45
+    }
+  ],
+  added: [
+    {
+      activity_id: 'ACT.ALPHA.THREE',
+      delta: 3.3333,
+      total_base: null,
+      total_compare: 3.3333
+    }
+  ],
+  removed: [
+    {
+      activity_id: 'ACT.GAMMA.FOUR',
+      delta: -5.75,
+      total_base: 5.75,
+      total_compare: null
+    }
+  ]
+};
+
+describe('aggregateByCategory', () => {
+  it('aggregates activity deltas by category with deterministic ordering and rounding', () => {
+    const result = aggregateByCategory(diff, 'activity.category', catalog);
+    expect(result.map((row) => row.key)).toEqual(['alpha_ops', 'beta_ops', 'gamma_ops']);
+    expect(result.map((row) => row.label)).toEqual(['Alpha Ops', 'Beta Ops', 'Gamma Ops']);
+
+    expect(result[0]).toMatchObject({
+      delta: 7.9011,
+      delta_pct: 0.3926,
+      total_base: 20.1234,
+      total_compare: 28.0245
+    });
+    expect(result[1]).toMatchObject({
+      delta: -5.3,
+      delta_pct: -0.3419,
+      total_base: 15.5,
+      total_compare: 10.2
+    });
+    expect(result[2]).toMatchObject({
+      delta: -4.55,
+      delta_pct: -0.325,
+      total_base: 14,
+      total_compare: 9.45
+    });
+
+    const aggregateTotal = result.reduce((sum, row) => sum + row.delta, 0);
+    const rowTotal = [diff.changed, diff.added, diff.removed]
+      .flat()
+      .reduce((sum, entry) => sum + (entry?.delta ?? 0), 0);
+    expect(Math.abs(aggregateTotal - rowTotal)).toBeLessThan(1e-6);
+  });
+
+  it('uses layer grouping when requested', () => {
+    const result = aggregateByCategory(diff, 'layer_id', catalog);
+    expect(result.map((row) => row.key)).toEqual(['layer_remote', 'layer_main']);
+    expect(result.map((row) => row.label)).toEqual(['Layer Remote', 'Layer Main']);
+    expect(result[0].delta).toBeCloseTo(-1.2167, 4);
+    expect(result[1].delta).toBeCloseTo(-0.7322, 4);
+  });
+});
+
+describe('listActivityDeltas', () => {
+  it('orders activities by absolute delta and includes rounded totals', () => {
+    const result = listActivityDeltas(diff, catalog);
+    expect(result.map((row) => row.id)).toEqual([
+      'ACT.GAMMA.FOUR',
+      'ACT.BETA.TWO',
+      'ACT.ALPHA.ONE',
+      'ACT.ALPHA.THREE',
+      'ACT.GAMMA.FIVE'
+    ]);
+    expect(result[0]).toMatchObject({
+      label: 'Gamma furnace closure',
+      delta: -5.75,
+      total_base: 5.75,
+      total_compare: null
+    });
+    expect(result[2]).toMatchObject({
+      label: 'Alpha line retrofit',
+      delta: 4.5678,
+      total_base: 20.1234,
+      total_compare: 24.6912
+    });
+    expect(result[3]).toMatchObject({
+      label: 'Alpha pilot program',
+      delta: 3.3333,
+      total_base: null,
+      total_compare: 3.3333,
+      delta_pct: Number.POSITIVE_INFINITY
+    });
+  });
+});

--- a/site/src/styles/dense.ts
+++ b/site/src/styles/dense.ts
@@ -1,0 +1,11 @@
+export interface DenseSpacingConfig {
+  sectionPadding: string;
+  cardGap: string;
+  chartHeight: number;
+}
+
+export const compareDenseSpacing: DenseSpacingConfig = {
+  sectionPadding: '1.25rem',
+  cardGap: '0.75rem',
+  chartHeight: 280
+};


### PR DESCRIPTION
## Summary
- add scenario diff aggregation helpers for category/layer groupings and activity-level listings
- expose catalog lookups and shared spacing tokens required by the new scenario comparison surface
- implement scenario comparison component with URL-persisted toggle, stacked delta view, summary cards, and accompanying tests/docs

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e5bb68e474832cb22bd874791a01b5