### PR TITLE
Match left and right pane heights

### DIFF
--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -168,7 +168,9 @@ export function Layout({
 
   return (
     <div className="grid min-h-0 flex-1 grid-cols-1 gap-[var(--gap-1)] lg:grid-cols-[minmax(0,0.34fr)_minmax(0,0.66fr)]">
-      <div className="order-2 flex min-h-0 flex-col lg:order-1 lg:max-h-[calc(100vh-128px)] lg:pr-[calc(var(--gap-0)*0.75)]">
+      <div
+        className="order-2 flex min-h-0 flex-col lg:order-1 lg:h-[calc(100vh-128px)] lg:overflow-y-auto lg:pr-[calc(var(--gap-0)*0.75)]"
+      >
         <div className="sticky top-0 z-20 bg-slate-950/85 pb-[calc(var(--gap-0)*0.5)] pt-[var(--gap-0)] backdrop-blur">
           <p id={workflowLabelId} className="text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-500">
             Context depth
@@ -177,7 +179,7 @@ export function Layout({
             Feed the console more context to unlock deeper, sector-aware visualizations.
           </p>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto pt-[calc(var(--gap-0)*0.9)]">
+        <div className="min-h-0 flex-1 pt-[calc(var(--gap-0)*0.9)]">
           <ol
             role="list"
             aria-labelledby={workflowLabelId}
@@ -288,7 +290,7 @@ export function Layout({
           </ol>
         </div>
       </div>
-      <div className="order-1 flex min-h-0 flex-col gap-[var(--gap-1)] lg:order-2 lg:min-h-[calc(100vh-128px)]">
+      <div className="order-1 flex min-h-0 flex-col gap-[var(--gap-1)] lg:order-2 lg:h-[calc(100vh-128px)]">
         {scopeIndicator ? (
           <div className="lg:flex-none">{scopeIndicator}</div>
         ) : null}


### PR DESCRIPTION
## Summary
- set the workflow column to a fixed large-screen height so it always matches the canvas pane
- give the canvas column the same explicit height to keep both panes aligned

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5bfd0d600832cb82f21e0fb364b3a