### PR TITLE
feat: add deterministic scenario diff export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@9
 
       - uses: actions/setup-python@v5
         with:

--- a/docs/share-diff.md
+++ b/docs/share-diff.md
@@ -1,0 +1,13 @@
+# Sharing scenario diffs
+
+The scenario comparison view can export the current diff as a deterministic JSON payload. The export happens entirely in the browser:
+
+- The payload is constructed with sorted keys and numbers rounded to four decimal places, then serialised with a trailing newline.
+- Downloads use a `Blob` and a temporary anchor element—no filesystem access and no Node.js APIs are required on the client.
+
+By default exports are unsigned. To add a signature locally, use the optional helper:
+
+1. Set `DIFF_SIGN_KEY_BASE64` (and optionally `DIFF_SIGN_KEY_ID`) in your shell to an Ed25519 secret key encoded in base64.
+2. Run `tsx tools/sign-diff.ts <path-to-diff.json>` to produce a `*.signed.json` alongside the source file.
+
+Keep signing keys out of the repository. CI remains unsigned and does not require any secrets to build or test.

--- a/site/package.json
+++ b/site/package.json
@@ -17,6 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-window": "^1.8.11",
+    "tweetnacl": "^1.0.3",
     "zustand": "^4.5.4",
     "zod": "^3.23.8"
   },

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@mlc-ai/web-llm':
+        specifier: ^0.2.79
+        version: 0.2.79
+      dompurify:
+        specifier: ^3.1.6
+        version: 3.2.7
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
@@ -20,6 +26,15 @@ importers:
       react-window:
         specifier: ^1.8.11
         version: 1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+      zustand:
+        specifier: ^4.5.4
+        version: 4.5.7(@types/react@18.3.25)(react@18.3.1)
     devDependencies:
       '@testing-library/dom':
         specifier: ^9.3.4
@@ -51,6 +66,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.21(postcss@8.5.6)
+      fastest-levenshtein:
+        specifier: ^1.0.16
+        version: 1.0.16
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
@@ -280,6 +298,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mlc-ai/web-llm@0.2.79':
+    resolution: {integrity: sha512-Hy1ZHQ0o2bZGZoVnGK48+fts/ZSKwLe96xjvqL/6C59Mem9HoHTcFE07NC2E23mRmhd01tL655N6CPeYmwWgwQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -532,6 +553,9 @@ packages:
   '@types/react@18.3.25':
     resolution: {integrity: sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@vitejs/plugin-react-swc@3.11.0':
     resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
     peerDependencies:
@@ -773,6 +797,9 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -831,6 +858,10 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1079,6 +1110,10 @@ packages:
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
     engines: {node: '>=14'}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1534,6 +1569,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
@@ -1561,6 +1599,11 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1698,6 +1741,24 @@ packages:
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -1838,6 +1899,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mlc-ai/web-llm@0.2.79':
+    dependencies:
+      loglevel: 1.9.2
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2032,6 +2097,9 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@vitejs/plugin-react-swc@3.11.0(vite@5.4.20(@types/node@24.6.2))':
     dependencies:
@@ -2295,6 +2363,10 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2389,6 +2461,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fastest-levenshtein@1.0.16: {}
 
   fastq@1.19.1:
     dependencies:
@@ -2656,6 +2730,8 @@ snapshots:
     dependencies:
       mlly: 1.8.0
       pkg-types: 1.3.1
+
+  loglevel@1.9.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -3136,6 +3212,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tweetnacl@1.0.3: {}
+
   type-detect@4.1.0: {}
 
   typescript@5.9.3: {}
@@ -3156,6 +3234,10 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 
@@ -3291,3 +3373,12 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yocto-queue@1.2.1: {}
+
+  zod@3.25.76: {}
+
+  zustand@4.5.7(@types/react@18.3.25)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      react: 18.3.1

--- a/site/src/components/tests/ScenarioCompare.view.test.tsx
+++ b/site/src/components/tests/ScenarioCompare.view.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import type { Catalog } from '../../lib/catalog';
+import type { ScenarioManifest } from '../../lib/exportDiff';
 import { ScenarioCompare } from '../ScenarioCompare';
 
 const catalog: Catalog = {
@@ -79,13 +80,32 @@ const diff = {
   ]
 };
 
+const baseManifest: ScenarioManifest = {
+  profile_id: 'baseline',
+  sources: ['SRC.BASE.ONE', 'SRC.BASE.TWO']
+};
+
+const compareManifest: ScenarioManifest = {
+  profile_id: 'compare',
+  sources: ['SRC.COMPARE.ONE']
+};
+
 describe('ScenarioCompare', () => {
   beforeEach(() => {
     window.history.replaceState(null, '', '/compare?base=baseline&compare=alt');
   });
 
   it('renders category deltas by default with summary cards', () => {
-    render(<ScenarioCompare diff={diff} catalog={catalog} baseHash="baseline" compareHash="alt" />);
+    render(
+      <ScenarioCompare
+        diff={diff}
+        catalog={catalog}
+        baseManifest={baseManifest}
+        compareManifest={compareManifest}
+        baseHash="baseline"
+        compareHash="alt"
+      />
+    );
 
     expect(screen.getByTestId('scenario-compare-chart')).toBeInTheDocument();
     const summaryNet = screen.getByTestId('scenario-compare-summary-net');
@@ -106,7 +126,16 @@ describe('ScenarioCompare', () => {
   });
 
   it('switches to activity view and updates the URL parameter', () => {
-    render(<ScenarioCompare diff={diff} catalog={catalog} baseHash="baseline" compareHash="alt" />);
+    render(
+      <ScenarioCompare
+        diff={diff}
+        catalog={catalog}
+        baseManifest={baseManifest}
+        compareManifest={compareManifest}
+        baseHash="baseline"
+        compareHash="alt"
+      />
+    );
 
     const activityButton = screen.getByTestId('scenario-compare-toggle-activity');
     fireEvent.click(activityButton);

--- a/site/src/lib/__tests__/exportDiff.test.ts
+++ b/site/src/lib/__tests__/exportDiff.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+import nacl from 'tweetnacl';
+
+import {
+  buildSignedDiff,
+  downloadExport,
+  stableStringify,
+  type ScenarioManifest,
+} from '../exportDiff';
+
+const baseManifest: ScenarioManifest = {
+  profile_id: 'baseline-profile',
+  dataset_version: '2024.01',
+  sources: ['SRC.ALPHA', 'SRC.BETA'],
+  overrides: { 'ACT.ONE': 1 },
+};
+
+const compareManifest: ScenarioManifest = {
+  profile_id: 'compare-profile',
+  dataset_version: '2024.01',
+  sources: ['SRC.BETA', 'SRC.GAMMA'],
+  overrides: { 'ACT.TWO': 2 },
+};
+
+describe('stableStringify', () => {
+  it('produces deterministic JSON regardless of object key order', () => {
+    const variantA = {
+      zeta: 1,
+      alpha: {
+        beta: 1.234567,
+        gamma: [
+          { delta: 3.33333, epsilon: 2 },
+          { kappa: Number.POSITIVE_INFINITY },
+        ],
+        eta: null,
+      },
+      theta: 'value',
+    };
+    const variantB = {
+      theta: 'value',
+      alpha: {
+        eta: null,
+        gamma: [
+          { epsilon: 2, delta: 3.33333 },
+          { kappa: Number.POSITIVE_INFINITY },
+        ],
+        beta: 1.234567,
+      },
+      zeta: 1,
+    };
+
+    const outputA = stableStringify(variantA);
+    const outputB = stableStringify(variantB);
+
+    expect(outputA).toBe(outputB);
+    expect(outputA.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(outputA) as { alpha: { beta: number } };
+    expect(parsed.alpha.beta).toBeCloseTo(1.2346, 4);
+  });
+});
+
+describe('buildSignedDiff', () => {
+  const diff = { changed: null, added: null, removed: null };
+
+  it('returns unsigned payload when no key provided', () => {
+    const payload = buildSignedDiff(diff, { baseManifest, compareManifest });
+
+    expect(payload.signature).toBeUndefined();
+    expect(payload.signer).toBeUndefined();
+    expect(payload.sources_union).toEqual(['SRC.ALPHA', 'SRC.BETA', 'SRC.GAMMA']);
+  });
+
+  it('adds signature information when key provided', () => {
+    const keyPair = nacl.sign.keyPair();
+    const payload = buildSignedDiff(diff, {
+      baseManifest,
+      compareManifest,
+      key: keyPair.secretKey,
+      keyId: 'test-key',
+    });
+
+    expect(payload.signer).toEqual({ algo: 'ed25519', key_id: 'test-key' });
+    expect(typeof payload.signature).toBe('string');
+    expect(payload.signature?.length).toBeGreaterThan(0);
+
+    const unsignedPayload = { ...payload };
+    delete unsignedPayload.signature;
+    delete unsignedPayload.signer;
+    const canonical = stableStringify(unsignedPayload);
+    const message = Uint8Array.from(new TextEncoder().encode(canonical));
+    const signatureBytes = Uint8Array.from(Buffer.from(payload.signature ?? '', 'base64'));
+    const publicKey = Uint8Array.from(keyPair.publicKey);
+    expect(
+      nacl.sign.detached.verify(message, signatureBytes, publicKey),
+    ).toBe(true);
+  });
+});
+
+describe('downloadExport', () => {
+  it('rejects unsafe filenames', async () => {
+    await expect(downloadExport('../diff.json', '{}')).rejects.toThrow('Unsafe filename');
+  });
+
+  it('triggers a download for safe filenames', async () => {
+    const urlMock = URL as unknown as { [key: string]: any };
+    const originalCreate = urlMock.createObjectURL;
+    const originalRevoke = urlMock.revokeObjectURL;
+    urlMock.createObjectURL = vi.fn(() => 'blob:example');
+    urlMock.revokeObjectURL = vi.fn();
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    const removeSpy = vi.spyOn(document.body, 'removeChild');
+    const anchor = document.createElement('a');
+    const clickSpy = vi.spyOn(anchor, 'click');
+    clickSpy.mockImplementation(() => undefined);
+    const originalCreateElement = document.createElement.bind(document);
+    const createSpy = vi.spyOn(document, 'createElement');
+    createSpy.mockImplementation(((tagName: string) => {
+      if (tagName.toLowerCase() === 'a') {
+        return anchor;
+      }
+      return originalCreateElement(tagName);
+    }) as typeof document.createElement);
+
+    await downloadExport('valid.json', '{}');
+
+    expect(urlMock.createObjectURL).toHaveBeenCalled();
+    expect(urlMock.revokeObjectURL).toHaveBeenCalledWith('blob:example');
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    createSpy.mockRestore();
+    urlMock.createObjectURL = originalCreate;
+    urlMock.revokeObjectURL = originalRevoke;
+  });
+});

--- a/site/src/lib/exportDiff.ts
+++ b/site/src/lib/exportDiff.ts
@@ -1,0 +1,143 @@
+import nacl from 'tweetnacl';
+
+import { hashManifest } from './hash';
+import type { ScenarioDiff } from './scenarioCompare';
+import type { ComputeResult } from '../state/profile';
+
+export type ScenarioManifest = NonNullable<ComputeResult['manifest']>;
+
+function roundNumber(value: number): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  const rounded = Math.round(value * 10_000) / 10_000;
+  return Object.is(rounded, -0) ? 0 : rounded;
+}
+
+function canonicalise(value: unknown): unknown {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === 'number') {
+    return roundNumber(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalise(entry));
+  }
+  if (typeof value === 'object') {
+    const record = value as { [key: string]: unknown };
+    if (typeof (record as { toJSON?: unknown }).toJSON === 'function') {
+      return canonicalise((record as { toJSON: () => unknown }).toJSON());
+    }
+    const next: { [key: string]: unknown } = {};
+    Object.keys(record)
+      .sort()
+      .forEach((key) => {
+        next[key] = canonicalise(record[key]);
+      });
+    return next;
+  }
+  return value;
+}
+
+export function stableStringify(obj: unknown): string {
+  const canonical = canonicalise(obj);
+  return `${JSON.stringify(canonical, null, 2)}\n`;
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+  let binary = '';
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]!);
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  throw new Error('Base64 encoding is not available in this environment.');
+}
+
+export interface SignedDiff {
+  spec_version: '1.0';
+  created_at: string;
+  base_hash: string;
+  compare_hash: string;
+  scenario_diff: ScenarioDiff;
+  sources_union: string[];
+  manifest_hashes: { base: string; compare: string };
+  signer?: { algo: 'ed25519'; key_id: string };
+  signature?: string;
+}
+
+interface BuildSignedDiffOptions {
+  baseManifest: ScenarioManifest;
+  compareManifest: ScenarioManifest;
+  key?: Uint8Array;
+  keyId?: string;
+}
+
+export function buildSignedDiff(diff: ScenarioDiff, opts: BuildSignedDiffOptions): SignedDiff {
+  const baseHash = hashManifest(opts.baseManifest);
+  const compareHash = hashManifest(opts.compareManifest);
+  const sourceSet = new Set<string>();
+  const addSources = (manifest: ScenarioManifest) => {
+    const sources = Array.isArray(manifest.sources) ? manifest.sources : [];
+    sources.forEach((source) => {
+      if (typeof source === 'string' && source.trim().length > 0) {
+        sourceSet.add(source);
+      }
+    });
+  };
+  addSources(opts.baseManifest);
+  addSources(opts.compareManifest);
+  const payload: SignedDiff = {
+    spec_version: '1.0',
+    created_at: new Date().toISOString(),
+    base_hash: baseHash,
+    compare_hash: compareHash,
+    scenario_diff: diff,
+    sources_union: Array.from(sourceSet).sort(),
+    manifest_hashes: {
+      base: baseHash,
+      compare: compareHash,
+    },
+  };
+
+  if (opts.key) {
+    const unsigned = { ...payload } as SignedDiff;
+    delete unsigned.signature;
+    delete unsigned.signer;
+    const serialised = stableStringify(unsigned);
+    const message = Uint8Array.from(new TextEncoder().encode(serialised));
+    const secretKey = Uint8Array.from(opts.key);
+    const signature = nacl.sign.detached(message, secretKey);
+    payload.signer = { algo: 'ed25519', key_id: opts.keyId ?? 'local' };
+    payload.signature = encodeBase64(signature);
+  }
+
+  return payload;
+}
+
+const SAFE_FILENAME = /^[a-z0-9._-]+$/i;
+
+export async function downloadExport(filename: string, data: string): Promise<void> {
+  if (!SAFE_FILENAME.test(filename)) {
+    throw new Error('Unsafe filename.');
+  }
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const blob = new Blob([data], { type: 'application/json;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.rel = 'noopener';
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}

--- a/tools/sign-diff.ts
+++ b/tools/sign-diff.ts
@@ -1,0 +1,66 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, extname, join } from 'node:path';
+import nacl from 'tweetnacl';
+
+import { stableStringify, type SignedDiff } from '../site/src/lib/exportDiff';
+
+function exitWithMessage(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+function resolveSecretKey(): Uint8Array {
+  const keyBase64 = process.env.DIFF_SIGN_KEY_BASE64;
+  if (!keyBase64) {
+    return exitWithMessage('DIFF_SIGN_KEY_BASE64 environment variable is required.');
+  }
+  const buffer = Buffer.from(keyBase64, 'base64');
+  if (buffer.length !== nacl.sign.secretKeyLength) {
+    return exitWithMessage(
+      `DIFF_SIGN_KEY_BASE64 must decode to ${nacl.sign.secretKeyLength} bytes, received ${buffer.length}.`
+    );
+  }
+  return new Uint8Array(buffer);
+}
+
+function loadDiff(path: string): SignedDiff {
+  const contents = readFileSync(path, 'utf8');
+  return JSON.parse(contents) as SignedDiff;
+}
+
+function stripSignature(diff: SignedDiff): SignedDiff {
+  const copy: SignedDiff = { ...diff };
+  delete copy.signature;
+  delete copy.signer;
+  return copy;
+}
+
+function writeSignedDiff(path: string, diff: SignedDiff): void {
+  writeFileSync(path, stableStringify(diff), 'utf8');
+}
+
+async function main(): Promise<void> {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    exitWithMessage('Usage: tsx tools/sign-diff.ts <diff.json>');
+  }
+  const secretKey = resolveSecretKey();
+  const keyId = process.env.DIFF_SIGN_KEY_ID ?? 'local';
+  const diff = loadDiff(inputPath);
+  const unsigned = stripSignature(diff);
+  const canonical = stableStringify(unsigned);
+  const message = new TextEncoder().encode(canonical);
+  const signature = nacl.sign.detached(message, secretKey);
+  const signed: SignedDiff = {
+    ...unsigned,
+    signer: { algo: 'ed25519', key_id: keyId },
+    signature: Buffer.from(signature).toString('base64')
+  };
+  const directory = dirname(inputPath);
+  const base = basename(inputPath, extname(inputPath));
+  const outputPath = join(directory, `${base}.signed.json`);
+  writeSignedDiff(outputPath, signed);
+  console.log(`Signed diff written to ${outputPath}`);
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add stable diff serialization utilities with optional ed25519 signing and browser download helper
- update ScenarioCompare to accept manifests and expose an export button that emits deterministic payloads
- document the export workflow, add a signing CLI, and pin CI to Node 20 with pnpm 9

## Testing
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e5cb942b24832ca55fdf656c38e141