### PR TITLE
feat(site): load figures from manifest with cached data

### DIFF
--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -11,12 +11,39 @@ importers:
       '@mlc-ai/web-llm':
         specifier: ^0.2.79
         version: 0.2.79
+      '@radix-ui/react-checkbox':
+        specifier: ^1.1.3
+        version: 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label':
+        specifier: ^2.1.1
+        version: 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.1.3
+        version: 1.2.10(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.1
+        version: 1.2.3(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-switch':
+        specifier: ^1.1.3
+        version: 1.2.6(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toolbar':
+        specifier: ^1.1.2
+        version: 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      class-variance-authority:
+        specifier: ^0.7.0
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       dompurify:
         specifier: ^3.1.6
         version: 3.2.7
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
+      lucide-react:
+        specifier: ^0.441.0
+        version: 0.441.0(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -26,6 +53,9 @@ importers:
       react-window:
         specifier: ^1.8.11
         version: 1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tailwind-merge:
+        specifier: ^2.3.0
+        version: 2.6.0
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
@@ -78,6 +108,9 @@ importers:
       tailwindcss:
         specifier: ^3.3.5
         version: 3.4.18
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.18)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -317,6 +350,267 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -707,6 +1001,13 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1125,6 +1426,11 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lucide-react@0.441.0:
+    resolution: {integrity: sha512-0vfExYtvSDhkC2lqg0zYVW1Uu9GsI4knuV9GP9by5z0Xhc4Zi5RejTxfz9LsjRmCyWVzHCJvxGKZWcRyvQCWVg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1531,6 +1837,14 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tailwind-merge@2.6.0:
+    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
+
+  tailwindcss-animate@1.0.7:
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+
   tailwindcss@3.4.18:
     resolution: {integrity: sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==}
     engines: {node: '>=14.0.0'}
@@ -1919,6 +2233,237 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@radix-ui/number@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-context@1.1.2(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-direction@1.1.1(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-id@1.1.1(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.25)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.25)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.25)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.25
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.52.4':
@@ -2271,6 +2816,12 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -2743,6 +3294,10 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lucide-react@0.441.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.19:
@@ -3152,6 +3707,12 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@2.6.0: {}
+
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.18):
+    dependencies:
+      tailwindcss: 3.4.18
 
   tailwindcss@3.4.18:
     dependencies:

--- a/site/src/components/ChartContainer.tsx
+++ b/site/src/components/ChartContainer.tsx
@@ -1,0 +1,348 @@
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  FigureDataStatus,
+  FigureManifestEntry,
+  LoadedFigureData,
+  listFigures,
+  loadFigure
+} from '../lib/DataLoader';
+import { formatEmission } from '../lib/format';
+import type { BubbleDatum } from './Bubble';
+import { Bubble } from './Bubble';
+import type { SankeyData } from './Sankey';
+import { Sankey } from './Sankey';
+import type { StackedDatum } from './Stacked';
+import { Stacked } from './Stacked';
+import { useACXStore } from '../store/useACXStore';
+
+export interface FigureDataUpdate {
+  figureId: string | null;
+  references: string[];
+  citationKeys: string[];
+  status: FigureDataStatus;
+  error: string | null;
+}
+
+interface ChartContainerProps {
+  onFigureDataChange?: (update: FigureDataUpdate) => void;
+}
+
+interface FigureOption {
+  id: string;
+  label: string;
+  method?: string;
+}
+
+interface FigureLoadState {
+  status: FigureDataStatus;
+  error: string | null;
+  data: LoadedFigureData | null;
+}
+
+const FIGURE_METHOD_LABEL: Record<string, string> = {
+  'figures.stacked': 'Stacked emissions',
+  'figures.bubble': 'Bubble chart',
+  'figures.sankey': 'Sankey pathways',
+  'figures.feedback': 'Feedback pathways'
+};
+
+const FIGURE_SUMMARY_LABEL: Record<string, string> = {
+  'figures.stacked': 'Total emissions',
+  'figures.bubble': 'Highest emission activity',
+  'figures.sankey': 'Total pathway emissions',
+  'figures.feedback': 'Feedback intensity'
+};
+
+function buildFigureOptions(entries: FigureManifestEntry[]): FigureOption[] {
+  return entries
+    .map((entry) => ({
+      id: entry.figure_id,
+      label: entry.figure_id,
+      method: entry.figure_method
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function getSummaryValue(result: LoadedFigureData | null): string | null {
+  if (!result) {
+    return null;
+  }
+  const data = result.payload?.data as unknown;
+  const method = result.manifest.figure_method ?? result.payload.figure_method ?? '';
+  switch (method) {
+    case 'figures.stacked': {
+      const rows = Array.isArray(data) ? (data as StackedDatum[]) : [];
+      const total = rows.reduce((sum, row) => {
+        const mean = typeof row?.values?.mean === 'number' ? row.values.mean : 0;
+        return sum + (Number.isFinite(mean) ? mean : 0);
+      }, 0);
+      return total > 0 ? formatEmission(total) : null;
+    }
+    case 'figures.bubble': {
+      const points = Array.isArray(data) ? (data as BubbleDatum[]) : [];
+      const top = points.reduce((max, point) => {
+        const mean = typeof point?.values?.mean === 'number' ? point.values.mean : null;
+        if (mean == null || !Number.isFinite(mean) || mean <= (max ?? 0)) {
+          return max;
+        }
+        return mean;
+      }, null as number | null);
+      return top != null && top > 0 ? formatEmission(top) : null;
+    }
+    case 'figures.sankey':
+    case 'figures.feedback': {
+      const payload = (data as SankeyData) ?? { nodes: [], links: [] };
+      const links = Array.isArray(payload?.links) ? payload.links ?? [] : [];
+      const total = links.reduce((sum, link) => {
+        const mean = typeof link?.values?.mean === 'number' ? link.values.mean : null;
+        if (mean == null || !Number.isFinite(mean) || mean <= 0) {
+          return sum;
+        }
+        return sum + mean;
+      }, 0);
+      return total > 0 ? formatEmission(total) : null;
+    }
+    default:
+      return null;
+  }
+}
+
+function getMethodLabel(method: string | undefined): string | undefined {
+  if (!method) {
+    return undefined;
+  }
+  return FIGURE_METHOD_LABEL[method] ?? method;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+export function ChartContainer({ onFigureDataChange }: ChartContainerProps): JSX.Element {
+  const figureId = useACXStore((state) => state.figureId);
+  const setFigureId = useACXStore((state) => state.setFigureId);
+
+  const [manifestStatus, setManifestStatus] = useState<FigureDataStatus>('idle');
+  const [manifestError, setManifestError] = useState<string | null>(null);
+  const [figureOptions, setFigureOptions] = useState<FigureOption[]>([]);
+
+  const [loadState, setLoadState] = useState<FigureLoadState>({
+    status: 'idle',
+    error: null,
+    data: null
+  });
+
+  useEffect(() => {
+    let mounted = true;
+    const controller = new AbortController();
+    setManifestStatus('loading');
+    setManifestError(null);
+    listFigures(controller.signal)
+      .then((entries) => {
+        if (!mounted) {
+          return;
+        }
+        const options = buildFigureOptions(entries);
+        setFigureOptions(options);
+        setManifestStatus('success');
+        if ((!figureId || figureId.trim().length === 0) && options.length > 0) {
+          setFigureId(options[0].id);
+        }
+      })
+      .catch((error) => {
+        if (!mounted) {
+          return;
+        }
+        if (isAbortError(error)) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : 'Unable to load figure manifest';
+        setManifestError(message);
+        setManifestStatus('error');
+      });
+    return () => {
+      mounted = false;
+      controller.abort();
+    };
+  }, [figureId, setFigureId]);
+
+  useEffect(() => {
+    if (!figureId) {
+      setLoadState({ status: 'idle', error: null, data: null });
+      return;
+    }
+    let mounted = true;
+    const controller = new AbortController();
+    setLoadState({ status: 'loading', error: null, data: null });
+    loadFigure(figureId, controller.signal)
+      .then((result) => {
+        if (!mounted) {
+          return;
+        }
+        setLoadState({ status: 'success', error: null, data: result });
+      })
+      .catch((error) => {
+        if (!mounted) {
+          return;
+        }
+        if (isAbortError(error)) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : 'Unable to load figure data';
+        setLoadState({ status: 'error', error: message, data: null });
+      });
+    return () => {
+      mounted = false;
+      controller.abort();
+    };
+  }, [figureId]);
+
+  useEffect(() => {
+    if (!onFigureDataChange) {
+      return;
+    }
+    if (!figureId) {
+      onFigureDataChange({
+        figureId: null,
+        references: [],
+        citationKeys: [],
+        status: 'idle',
+        error: null
+      });
+      return;
+    }
+    onFigureDataChange({
+      figureId,
+      references: loadState.data?.references ?? [],
+      citationKeys: loadState.data?.citationKeys ?? [],
+      status: loadState.status,
+      error: loadState.error
+    });
+  }, [figureId, loadState, onFigureDataChange]);
+
+  useEffect(() => {
+    return () => {
+      if (onFigureDataChange) {
+        onFigureDataChange({
+          figureId: null,
+          references: [],
+          citationKeys: [],
+          status: 'idle',
+          error: null
+        });
+      }
+    };
+  }, [onFigureDataChange]);
+
+  const handleSelectChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const nextId = event.target.value;
+      setFigureId(nextId || null);
+    },
+    [setFigureId]
+  );
+
+  const figureMethod = loadState.data?.manifest.figure_method ?? loadState.data?.payload.figure_method;
+  const methodLabel = getMethodLabel(figureMethod);
+  const summaryLabel = figureMethod ? FIGURE_SUMMARY_LABEL[figureMethod] : undefined;
+  const summaryValue = getSummaryValue(loadState.data);
+
+  const chartContent = useMemo(() => {
+    if (loadState.status === 'loading') {
+      return <p className="text-sm text-muted-foreground">Loading figure data…</p>;
+    }
+    if (loadState.status === 'error') {
+      return (
+        <p className="text-sm text-destructive" role="alert">
+          {loadState.error ?? 'Unable to load figure data.'}
+        </p>
+      );
+    }
+    if (!loadState.data) {
+      if (manifestStatus === 'loading') {
+        return <p className="text-sm text-muted-foreground">Loading manifest…</p>;
+      }
+      if (manifestStatus === 'error') {
+        return (
+          <p className="text-sm text-destructive" role="alert">
+            {manifestError ?? 'Unable to load figure manifest.'}
+          </p>
+        );
+      }
+      return <p className="text-sm text-muted-foreground">Select a figure to view its data.</p>;
+    }
+
+    const payload = loadState.data.payload;
+    const data = payload?.data;
+    const referenceLookup = loadState.data.referenceLookup;
+
+    switch (figureMethod) {
+      case 'figures.stacked':
+        return (
+          <Stacked
+            data={(data as StackedDatum[]) ?? []}
+            referenceLookup={referenceLookup}
+            variant="embedded"
+          />
+        );
+      case 'figures.bubble':
+        return (
+          <Bubble data={(data as BubbleDatum[]) ?? []} referenceLookup={referenceLookup} variant="embedded" />
+        );
+      case 'figures.sankey':
+      case 'figures.feedback':
+        return (
+          <Sankey data={(data as SankeyData) ?? { nodes: [], links: [] }} referenceLookup={referenceLookup} variant="embedded" />
+        );
+      default:
+        return (
+          <pre className="max-h-[320px] overflow-auto rounded-md bg-muted/40 p-4 text-xs text-muted-foreground">
+            {JSON.stringify(payload ?? {}, null, 2)}
+          </pre>
+        );
+    }
+  }, [figureMethod, loadState, manifestError, manifestStatus]);
+
+  return (
+    <section className="acx-card flex flex-col gap-4 bg-card/70">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <p className="text-2xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+            Manifest explorer
+          </p>
+          <h2 className="text-lg font-semibold text-foreground">Figure data</h2>
+          {methodLabel ? (
+            <p className="text-xs text-muted-foreground">{methodLabel}</p>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="figure-select" className="text-xs font-medium text-muted-foreground">
+            Figure
+          </label>
+          <select
+            id="figure-select"
+            className="rounded-md border border-border/70 bg-background/80 px-3 py-2 text-sm text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            value={figureId ?? ''}
+            onChange={handleSelectChange}
+            disabled={manifestStatus !== 'success' || figureOptions.length === 0}
+          >
+            {figureOptions.length === 0 ? <option value="">No figures available</option> : null}
+            {figureOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+      {summaryLabel && summaryValue ? (
+        <div className="rounded-lg border border-border/70 bg-muted/30 px-4 py-3">
+          <p className="text-2xs uppercase tracking-[0.3em] text-muted-foreground">{summaryLabel}</p>
+          <p className="text-base font-semibold text-foreground">{summaryValue}</p>
+        </div>
+      ) : null}
+      <div className="min-h-[320px] flex-1">{chartContent}</div>
+    </section>
+  );
+}

--- a/site/src/components/ReferencesDrawer.tsx
+++ b/site/src/components/ReferencesDrawer.tsx
@@ -1,30 +1,20 @@
-import {
-  forwardRef,
-  type HTMLAttributes,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import { useEffect, useMemo } from 'react';
 import { ChevronDown } from 'lucide-react';
 
-import {
-  VariableSizeList as VirtualizedList,
-  type ListChildComponentProps,
-  type VariableSizeList as VariableSizeListComponent
-} from 'react-window';
-
 import { cn } from '@/lib/utils';
+import type { FigureDataStatus } from '../lib/DataLoader';
 import { useProfile } from '../state/profile';
+import { ReferencesPanel } from './ReferencesPanel';
 import { ScenarioManifest } from './ScenarioManifest';
 import { Button } from './ui/button';
-import { ScrollArea } from './ui/scroll-area';
 
 type ReferencesDrawerProps = {
   id?: string;
   open: boolean;
   onToggle: () => void;
+  referencesOverride?: string[] | null;
+  referencesStatus?: FigureDataStatus | null;
+  referencesError?: string | null;
 };
 
 function normaliseReferences(value: unknown): string[] {
@@ -36,114 +26,29 @@ function normaliseReferences(value: unknown): string[] {
     .filter((entry): entry is string => Boolean(entry));
 }
 
-const VIRTUALIZATION_THRESHOLD = 30;
-const ESTIMATED_CHARACTERS_PER_LINE = 90;
-// Base height covers the card content plus the padding applied by the
-// `.pad-compact` utility (`p-4`, i.e. 16px on the top and bottom). This was
-// increased during the design-system refresh, so the virtualization constants
-// need to reflect the additional padding to avoid clipping rows once the list
-// virtualizes.
-const ITEM_BASE_HEIGHT = 80;
-const ITEM_LINE_HEIGHT = 20;
-const ITEM_VERTICAL_PADDING = 12;
-
-function estimateItemHeight(reference: string): number {
-  const lines = Math.max(1, Math.ceil(reference.length / ESTIMATED_CHARACTERS_PER_LINE));
-  return ITEM_BASE_HEIGHT + ITEM_VERTICAL_PADDING * 2 + (lines - 1) * ITEM_LINE_HEIGHT;
-}
-
-type ReferenceItemData = {
-  references: string[];
-};
-
-const VirtualizedOrderedList = forwardRef<HTMLOListElement, HTMLAttributes<HTMLOListElement>>(
-  function VirtualizedOrderedList(props, ref) {
-    return <ol ref={ref} {...props} aria-label="Reference list" />;
-  }
-);
-
-function ReferenceRow({ index, style, data }: ListChildComponentProps<ReferenceItemData>): JSX.Element {
-  const reference = data.references[index];
-  return (
-    <li
-      style={{
-        ...style,
-        left: style.left ?? 0,
-        width: style.width ?? '100%',
-        paddingTop: ITEM_VERTICAL_PADDING / 2,
-        paddingBottom: ITEM_VERTICAL_PADDING / 2
-      }}
-    >
-      <div className="h-full rounded-lg border border-border/70 bg-card/70 pad-compact text-left shadow-inner shadow-black/30">
-        <span className="block text-2xs font-semibold uppercase tracking-[0.3em] text-primary">[{index + 1}]</span>
-        <p className="mt-1 text-compact text-foreground/90">{reference.replace(/^\[[0-9]+\]\s*/, '')}</p>
-      </div>
-    </li>
-  );
-}
-
-export function ReferencesDrawer({ id = 'references', open, onToggle }: ReferencesDrawerProps): JSX.Element {
+export function ReferencesDrawer({
+  id = 'references',
+  open,
+  onToggle,
+  referencesOverride = null,
+  referencesStatus = null,
+  referencesError = null
+}: ReferencesDrawerProps): JSX.Element {
   const { activeReferences } = useProfile();
 
-  const references = useMemo(() => normaliseReferences(activeReferences), [activeReferences]);
-
-  const shouldVirtualize = references.length > VIRTUALIZATION_THRESHOLD;
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const listRef = useRef<VariableSizeListComponent | null>(null);
-  const [viewportHeight, setViewportHeight] = useState(0);
-
-  useEffect(() => {
-    if (!shouldVirtualize) {
-      setViewportHeight(0);
-      return undefined;
-    }
-
-    const element = containerRef.current;
-    if (!element) {
-      return undefined;
-    }
-
-    const updateHeight = () => {
-      setViewportHeight(element.clientHeight);
-    };
-
-    updateHeight();
-
-    if (typeof ResizeObserver === 'undefined') {
-      return undefined;
-    }
-
-    const observer = new ResizeObserver(() => {
-      updateHeight();
-    });
-    observer.observe(element);
-
-    return () => observer.disconnect();
-  }, [shouldVirtualize, open]);
-
-  const itemHeights = useMemo(() => references.map(estimateItemHeight), [references]);
-
-  useEffect(() => {
-    if (!shouldVirtualize) {
-      return;
-    }
-    listRef.current?.resetAfterIndex(0, true);
-  }, [itemHeights, shouldVirtualize]);
-
-  const getItemSize = useCallback((index: number) => itemHeights[index], [itemHeights]);
-
-  const averageItemHeight = useMemo(() => {
-    if (itemHeights.length === 0) {
-      return ITEM_BASE_HEIGHT + ITEM_VERTICAL_PADDING * 2;
-    }
-    const total = itemHeights.reduce((sum, size) => sum + size, 0);
-    return total / itemHeights.length;
-  }, [itemHeights]);
-
-  const itemKey = useCallback(
-    (index: number, data: ReferenceItemData) => `${index}-${data.references[index]}`,
-    []
+  const fallbackReferences = useMemo(() => normaliseReferences(activeReferences), [activeReferences]);
+  const overrideReferences = useMemo(
+    () => (Array.isArray(referencesOverride) ? referencesOverride.map((entry) => entry.trim()).filter(Boolean) : []),
+    [referencesOverride]
   );
+
+  const hasOverride = referencesStatus !== null && referencesStatus !== undefined;
+  const resolvedReferences = hasOverride ? overrideReferences : fallbackReferences;
+  const isLoading = hasOverride && referencesStatus === 'loading';
+  const errorMessage =
+    hasOverride && referencesStatus === 'error'
+      ? referencesError ?? 'Unable to load references.'
+      : null;
 
   useEffect(() => {
     if (!open) {
@@ -196,47 +101,16 @@ export function ReferencesDrawer({ id = 'references', open, onToggle }: Referenc
         Primary sources supporting the figures. Press <kbd className="rounded bg-muted px-1">Esc</kbd> to close.
       </p>
       <ScenarioManifest />
-      <ScrollArea
-        id={`${id}-content`}
-        hidden={!open}
-        viewportRef={containerRef}
-        className="flex-1 rounded-xl border border-border/60 bg-background/40"
-        viewportClassName="p-4"
-      >
-        {references.length === 0 ? (
-          <p className="text-compact text-muted-foreground">No references available for the current selection.</p>
-        ) : shouldVirtualize ? (
-          viewportHeight > 0 ? (
-            <VirtualizedList
-              ref={listRef}
-              height={viewportHeight}
-              width="100%"
-              itemCount={references.length}
-              itemData={{ references }}
-              itemKey={itemKey}
-              itemSize={getItemSize}
-              estimatedItemSize={averageItemHeight}
-              innerElementType={VirtualizedOrderedList}
-            >
-              {ReferenceRow}
-            </VirtualizedList>
-          ) : null
-        ) : (
-          <ol className="space-y-4" aria-label="Reference list">
-            {references.map((reference, index) => (
-              <li
-                key={reference}
-                className="rounded-lg border border-border/70 bg-card/70 pad-compact text-left shadow-inner shadow-black/30"
-              >
-                <span className="block text-2xs font-semibold uppercase tracking-[0.3em] text-primary">
-                  [{index + 1}]
-                </span>
-                <p className="mt-1 text-compact text-foreground/90">{reference.replace(/^\[[0-9]+\]\s*/, '')}</p>
-              </li>
-            ))}
-          </ol>
-        )}
-      </ScrollArea>
+      <div className="flex-1 rounded-xl border border-border/60 bg-background/40 p-4" hidden={!open}>
+        <ReferencesPanel
+          id={`${id}-content`}
+          labelledBy="references-heading"
+          references={resolvedReferences}
+          isLoading={isLoading}
+          error={errorMessage}
+          open={open}
+        />
+      </div>
     </aside>
   );
 }

--- a/site/src/components/ReferencesPanel.tsx
+++ b/site/src/components/ReferencesPanel.tsx
@@ -1,0 +1,195 @@
+import {
+  forwardRef,
+  type HTMLAttributes,
+  type OlHTMLAttributes,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import {
+  VariableSizeList as VirtualizedList,
+  type ListChildComponentProps,
+  type VariableSizeList as VariableSizeListComponent
+} from 'react-window';
+
+import { cn } from '@/lib/utils';
+import { ScrollArea } from './ui/scroll-area';
+
+export interface ReferencesPanelProps {
+  id?: string;
+  labelledBy?: string;
+  references: string[];
+  isLoading?: boolean;
+  error?: string | null;
+  open?: boolean;
+}
+
+const VIRTUALIZATION_THRESHOLD = 30;
+const ESTIMATED_CHARACTERS_PER_LINE = 90;
+const ITEM_BASE_HEIGHT = 80;
+const ITEM_LINE_HEIGHT = 20;
+const ITEM_VERTICAL_PADDING = 12;
+
+function estimateItemHeight(reference: string): number {
+  const lines = Math.max(1, Math.ceil(reference.length / ESTIMATED_CHARACTERS_PER_LINE));
+  return ITEM_BASE_HEIGHT + ITEM_VERTICAL_PADDING * 2 + (lines - 1) * ITEM_LINE_HEIGHT;
+}
+
+type ReferenceItemData = {
+  references: string[];
+};
+
+const VirtualizedOrderedList = forwardRef<HTMLOListElement, OlHTMLAttributes<HTMLOListElement>>(function VirtualizedOrderedList(
+  props,
+  ref
+) {
+  return <ol ref={ref} {...props} aria-label="Reference list" />;
+});
+
+const VirtualizedOuterDiv = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function VirtualizedOuterDiv(
+  props,
+  ref
+) {
+  const { className, ...rest } = props;
+  return <div ref={ref} {...rest} className={cn('pr-4', className)} />;
+});
+
+function ReferenceRow({ index, style, data }: ListChildComponentProps<ReferenceItemData>): JSX.Element {
+  const reference = data.references[index];
+  return (
+    <li
+      style={{
+        ...style,
+        left: style.left ?? 0,
+        width: style.width ?? '100%',
+        paddingTop: ITEM_VERTICAL_PADDING / 2,
+        paddingBottom: ITEM_VERTICAL_PADDING / 2
+      }}
+    >
+      <div className="h-full rounded-lg border border-border/70 bg-card/70 pad-compact text-left shadow-inner shadow-black/30">
+        <span className="block text-2xs font-semibold uppercase tracking-[0.3em] text-primary">[{index + 1}]</span>
+        <p className="mt-1 text-compact text-foreground/90">{reference.replace(/^\[[0-9]+\]\s*/, '')}</p>
+      </div>
+    </li>
+  );
+}
+
+export function ReferencesPanel({
+  id,
+  labelledBy,
+  references,
+  isLoading = false,
+  error = null,
+  open = true
+}: ReferencesPanelProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<VariableSizeListComponent | null>(null);
+  const [viewportHeight, setViewportHeight] = useState(0);
+
+  const shouldVirtualize = references.length > VIRTUALIZATION_THRESHOLD;
+
+  useEffect(() => {
+    if (!shouldVirtualize) {
+      setViewportHeight(0);
+      return undefined;
+    }
+    const element = containerRef.current;
+    if (!element) {
+      return undefined;
+    }
+    const updateHeight = () => {
+      setViewportHeight(element.clientHeight);
+    };
+    updateHeight();
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+    const observer = new ResizeObserver(() => {
+      updateHeight();
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [shouldVirtualize, open]);
+
+  const itemHeights = useMemo(() => references.map(estimateItemHeight), [references]);
+
+  useEffect(() => {
+    if (!shouldVirtualize) {
+      return;
+    }
+    listRef.current?.resetAfterIndex(0, true);
+  }, [itemHeights, shouldVirtualize]);
+
+  const getItemSize = useCallback((index: number) => itemHeights[index], [itemHeights]);
+
+  const averageItemHeight = useMemo(() => {
+    if (itemHeights.length === 0) {
+      return ITEM_BASE_HEIGHT + ITEM_VERTICAL_PADDING * 2;
+    }
+    const total = itemHeights.reduce((sum, size) => sum + size, 0);
+    return total / itemHeights.length;
+  }, [itemHeights]);
+
+  const itemKey = useCallback(
+    (index: number, data: ReferenceItemData) => `${index}-${data.references[index]}`,
+    []
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading references…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-destructive" role="alert">
+        {error}
+      </div>
+    );
+  }
+
+  if (references.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+        No references available for this figure.
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea id={id} aria-labelledby={labelledBy} ref={containerRef} className="relative h-full">
+      {shouldVirtualize ? (
+        <VirtualizedList
+          height={viewportHeight || averageItemHeight * Math.min(references.length, 8)}
+          itemCount={references.length}
+          itemSize={getItemSize}
+          itemData={{ references }}
+          width="100%"
+          outerElementType={VirtualizedOuterDiv}
+          innerElementType={VirtualizedOrderedList}
+          ref={listRef}
+          estimatedItemSize={averageItemHeight}
+          itemKey={itemKey}
+        >
+          {ReferenceRow}
+        </VirtualizedList>
+      ) : (
+        <ol className="space-y-3 pr-4" aria-label="Reference list">
+          {references.map((reference, index) => (
+            <li key={`${index}-${reference}`}>
+              <div className="h-full rounded-lg border border-border/70 bg-card/70 pad-compact text-left shadow-inner shadow-black/30">
+                <span className="block text-2xs font-semibold uppercase tracking-[0.3em] text-primary">[{index + 1}]</span>
+                <p className="mt-1 text-compact text-foreground/90">{reference.replace(/^\[[0-9]+\]\s*/, '')}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </ScrollArea>
+  );
+}

--- a/site/src/components/VizCanvas.tsx
+++ b/site/src/components/VizCanvas.tsx
@@ -9,6 +9,7 @@ import { buildReferenceLookup } from '../lib/references';
 import { useProfile } from '../state/profile';
 
 import { Bubble, BubbleDatum } from './Bubble';
+import { ChartContainer, type FigureDataUpdate } from './ChartContainer';
 import { ExportMenu } from './ExportMenu';
 import { Sankey, SankeyData, SankeyLink, SankeyNode } from './Sankey';
 import { Stacked, StackedDatum } from './Stacked';
@@ -672,9 +673,10 @@ const STATUS_LABEL: Record<string, string> = {
 
 interface VizCanvasProps {
   stage: StageId;
+  onFigureDataChange?: (update: FigureDataUpdate) => void;
 }
 
-export function VizCanvas({ stage }: VizCanvasProps): JSX.Element {
+export function VizCanvas({ stage, onFigureDataChange }: VizCanvasProps): JSX.Element {
   const {
     status,
     result,
@@ -1061,6 +1063,9 @@ export function VizCanvas({ stage }: VizCanvasProps): JSX.Element {
               </p>
             </div>
           ) : null}
+          <div className="mb-[var(--gap-1)] shrink-0">
+            <ChartContainer onFigureDataChange={onFigureDataChange} />
+          </div>
           {status !== 'error' && result === null ? (
             <div className="grid min-h-[200px] flex-1 place-items-center text-center text-compact text-slate-400">
               <div className="space-y-[var(--gap-0)]">

--- a/site/src/components/__tests__/__snapshots__/Bubble.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/Bubble.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
   class="w-full text-slate-400"
   data-testid="bubble-svg"
   role="img"
-  viewBox="0 0 640 360"
+  viewBox="0 0 640 480"
 >
   <defs>
     <radialgradient
@@ -30,7 +30,7 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
   <rect
     fill="url(#bubble-fill)"
     fill-opacity="0.08"
-    height="260"
+    height="380"
     rx="24"
     stroke="rgba(148, 163, 184, 0.25)"
     width="480"
@@ -56,7 +56,7 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
   <g
     class="group"
     data-testid="bubble-point-1"
-    transform="translate(440, 185.2)"
+    transform="translate(440, 247.6)"
   >
     <circle
       class="fill-sky-400/80 transition-transform duration-300 ease-out group-hover:scale-110 group-focus-within:scale-110"
@@ -74,7 +74,7 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
     style="font-size: 10px;"
     text-anchor="middle"
     x="200"
-    y="348"
+    y="468"
   >
     HVAC
   </text>
@@ -83,7 +83,7 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
     style="font-size: 10px;"
     text-anchor="middle"
     x="440"
-    y="348"
+    y="468"
   >
     Facilities
   </text>
@@ -92,15 +92,15 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
       stroke="rgba(148, 163, 184, 0.4)"
       x1="72"
       x2="80"
-      y1="310"
-      y2="310"
+      y1="430"
+      y2="430"
     />
     <text
       class="fill-slate-400"
       style="font-size: 10px;"
       text-anchor="end"
       x="68"
-      y="314"
+      y="434"
     >
       0.0 kg
     </text>
@@ -110,15 +110,15 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
       stroke="rgba(148, 163, 184, 0.4)"
       x1="72"
       x2="80"
-      y1="180"
-      y2="180"
+      y1="240"
+      y2="240"
     />
     <text
       class="fill-slate-400"
       style="font-size: 10px;"
       text-anchor="end"
       x="68"
-      y="184"
+      y="244"
     >
       1.3 kg
     </text>
@@ -146,9 +146,9 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
     id="bubble-axis-description"
     style="font-size: 11px;"
     text-anchor="middle"
-    transform="rotate(-90 32 180)"
+    transform="rotate(-90 32 240)"
     x="32"
-    y="180"
+    y="240"
   >
     Annual emissions (kg CO₂e)
   </text>
@@ -157,7 +157,7 @@ exports[`Bubble > renders bubble chart with pulsing circles 1`] = `
     style="font-size: 11px;"
     text-anchor="middle"
     x="320"
-    y="356"
+    y="476"
   >
     Activity category
   </text>

--- a/site/src/components/__tests__/__snapshots__/ReferencesDrawer.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/ReferencesDrawer.test.tsx.snap
@@ -107,55 +107,64 @@ exports[`ReferencesDrawer > renders references and closes on escape 1`] = `
       </div>
     </section>
     <div
-      class="relative overflow-hidden flex-1 rounded-xl border border-border/60 bg-background/40"
-      dir="ltr"
-      id="references-content"
-      style="position: relative; --radix-scroll-area-corner-width: 0px; --radix-scroll-area-corner-height: 0px;"
+      class="flex-1 rounded-xl border border-border/60 bg-background/40 p-4"
     >
-      <style>
-        [data-radix-scroll-area-viewport]{scrollbar-width:none;-ms-overflow-style:none;-webkit-overflow-scrolling:touch;}[data-radix-scroll-area-viewport]::-webkit-scrollbar{display:none}
-      </style>
       <div
-        class="h-full w-full rounded-[inherit] p-4"
-        data-radix-scroll-area-viewport=""
-        style="overflow-x: scroll; overflow-y: scroll;"
+        aria-labelledby="references-heading"
+        class="overflow-hidden relative h-full"
+        dir="ltr"
+        id="references-content"
+        style="position: relative; --radix-scroll-area-corner-width: 0px; --radix-scroll-area-corner-height: 0px;"
       >
+        <style>
+          [data-radix-scroll-area-viewport]{scrollbar-width:none;-ms-overflow-style:none;-webkit-overflow-scrolling:touch;}[data-radix-scroll-area-viewport]::-webkit-scrollbar{display:none}
+        </style>
         <div
-          style="min-width: 100%; display: table;"
+          class="h-full w-full rounded-[inherit]"
+          data-radix-scroll-area-viewport=""
+          style="overflow-x: scroll; overflow-y: scroll;"
         >
-          <ol
-            aria-label="Reference list"
-            class="space-y-4"
+          <div
+            style="min-width: 100%; display: table;"
           >
-            <li
-              class="rounded-lg border border-border/70 bg-card/70 pad-compact text-left shadow-inner shadow-black/30"
+            <ol
+              aria-label="Reference list"
+              class="space-y-3 pr-4"
             >
-              <span
-                class="block text-2xs font-semibold uppercase tracking-[0.3em] text-primary"
-              >
-                [1]
-              </span>
-              <p
-                class="mt-1 text-compact text-foreground/90"
-              >
-                First reference.
-              </p>
-            </li>
-            <li
-              class="rounded-lg border border-border/70 bg-card/70 pad-compact text-left shadow-inner shadow-black/30"
-            >
-              <span
-                class="block text-2xs font-semibold uppercase tracking-[0.3em] text-primary"
-              >
-                [2]
-              </span>
-              <p
-                class="mt-1 text-compact text-foreground/90"
-              >
-                Second reference.
-              </p>
-            </li>
-          </ol>
+              <li>
+                <div
+                  class="h-full rounded-lg border border-border/70 bg-card/70 pad-compact text-left shadow-inner shadow-black/30"
+                >
+                  <span
+                    class="block text-2xs font-semibold uppercase tracking-[0.3em] text-primary"
+                  >
+                    [1]
+                  </span>
+                  <p
+                    class="mt-1 text-compact text-foreground/90"
+                  >
+                    First reference.
+                  </p>
+                </div>
+              </li>
+              <li>
+                <div
+                  class="h-full rounded-lg border border-border/70 bg-card/70 pad-compact text-left shadow-inner shadow-black/30"
+                >
+                  <span
+                    class="block text-2xs font-semibold uppercase tracking-[0.3em] text-primary"
+                  >
+                    [2]
+                  </span>
+                  <p
+                    class="mt-1 text-compact text-foreground/90"
+                  >
+                    Second reference.
+                  </p>
+                </div>
+              </li>
+            </ol>
+          </div>
         </div>
       </div>
     </div>

--- a/site/src/components/__tests__/__snapshots__/Sankey.test.tsx.snap
+++ b/site/src/components/__tests__/__snapshots__/Sankey.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Sankey > renders gradient links with reference hints 1`] = `
   class="mt-4 w-full text-slate-400"
   data-testid="sankey-svg"
   role="img"
-  viewBox="0 0 640 360"
+  viewBox="0 0 640 480"
 >
   <defs>
     <lineargradient

--- a/site/src/lib/DataLoader.ts
+++ b/site/src/lib/DataLoader.ts
@@ -128,17 +128,19 @@ function normaliseManifestEntry(entry: unknown): FigureManifestEntry | null {
     }
     if (Array.isArray(referencesRecord.order)) {
       references.order = (referencesRecord.order as unknown[])
-        .map((item) => {
+        .map((item): ManifestReferenceOrderEntry | null => {
           if (!item || typeof item !== 'object') {
             return null;
           }
           const row = item as Record<string, unknown>;
-          const index = typeof row.index === 'number' ? row.index : null;
-          const sourceId = typeof row.source_id === 'string' ? row.source_id : null;
-          if (!index || !sourceId) {
+          if (typeof row.source_id !== 'string') {
             return null;
           }
-          return { index, source_id: sourceId } satisfies ManifestReferenceOrderEntry;
+          const entry: ManifestReferenceOrderEntry = { source_id: row.source_id };
+          if (typeof row.index === 'number') {
+            entry.index = row.index;
+          }
+          return entry;
         })
         .filter((value): value is ManifestReferenceOrderEntry => value !== null);
     }

--- a/site/src/lib/DataLoader.ts
+++ b/site/src/lib/DataLoader.ts
@@ -300,34 +300,21 @@ function buildLookupFromOrder(
   citationKeys: readonly string[]
 ): Map<string, number> {
   const orderEntries = entry.references?.order;
+  const lookup = buildReferenceLookup(citationKeys);
   if (!Array.isArray(orderEntries) || orderEntries.length === 0) {
-    return buildReferenceLookup(citationKeys);
+    return lookup;
   }
-  const orderMap = new Map<string, number>();
   orderEntries.forEach((item) => {
     if (!item) {
       return;
     }
     const sourceId = typeof item.source_id === 'string' ? item.source_id : null;
     const index = typeof item.index === 'number' ? item.index : null;
-    if (!sourceId || !index) {
+    if (!sourceId || !index || index <= 0 || !Number.isFinite(index)) {
       return;
     }
-    orderMap.set(sourceId, index);
+    lookup.set(sourceId, index);
   });
-  if (orderMap.size === 0) {
-    return buildReferenceLookup(citationKeys);
-  }
-  const lookup = new Map<string, number>();
-  citationKeys.forEach((key) => {
-    const index = orderMap.get(key);
-    if (typeof index === 'number') {
-      lookup.set(key, index);
-    }
-  });
-  if (lookup.size === 0) {
-    return buildReferenceLookup(citationKeys);
-  }
   return lookup;
 }
 

--- a/site/src/lib/DataLoader.ts
+++ b/site/src/lib/DataLoader.ts
@@ -1,0 +1,436 @@
+import { FetchJSONError, fetchJSON } from './fetchJSON';
+import { artifactUrl } from './paths';
+import { parseReferenceList } from './api';
+import { buildReferenceLookup } from './references';
+
+export type FigureDataStatus = 'idle' | 'loading' | 'success' | 'error';
+
+interface ManifestReferenceOrderEntry {
+  index?: number;
+  source_id?: string;
+}
+
+interface ManifestReferences {
+  path?: string;
+  legacy_path?: string;
+  order?: ManifestReferenceOrderEntry[];
+  line_count?: number;
+}
+
+export interface FigureManifestEntry {
+  figure_id: string;
+  figure_method?: string;
+  figure_path: string;
+  legacy_figure_path?: string;
+  citation_keys?: string[];
+  references?: ManifestReferences;
+  numeric_invariance?: {
+    passed?: boolean;
+    tolerance_percent?: number;
+  };
+  [key: string]: unknown;
+}
+
+export interface FigureJsonPayload {
+  figure_id?: string;
+  figure_method?: string;
+  citation_keys?: string[];
+  data?: unknown;
+  [key: string]: unknown;
+}
+
+export interface LoadedFigureData {
+  manifest: FigureManifestEntry;
+  payload: FigureJsonPayload;
+  references: string[];
+  citationKeys: string[];
+  referenceLookup: Map<string, number>;
+}
+
+interface ManifestIndexArtifactEntry {
+  path?: string;
+  preferred?: boolean;
+}
+
+interface ManifestIndexFigureEntry {
+  figure_id?: string;
+  manifests?: ManifestIndexArtifactEntry[];
+}
+
+interface ManifestIndexPayload {
+  figures?: ManifestIndexFigureEntry[];
+}
+
+interface AggregateManifestPayload {
+  figures?: unknown;
+  [key: string]: unknown;
+}
+
+const manifestCache: {
+  data: Map<string, FigureManifestEntry> | null;
+  promise: Promise<Map<string, FigureManifestEntry>> | null;
+} = {
+  data: null,
+  promise: null
+};
+
+const figureCache = new Map<string, LoadedFigureData>();
+const pendingFigures = new Map<string, Promise<LoadedFigureData>>();
+
+function normalisePath(path: string): string {
+  return path.replace(/^\/+/, '');
+}
+
+function resolveArtifactUrl(path: string): string {
+  return artifactUrl(normalisePath(path));
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+function normaliseManifestEntry(entry: unknown): FigureManifestEntry | null {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const record = entry as Record<string, unknown>;
+  const figureId = typeof record.figure_id === 'string' ? record.figure_id : null;
+  const figurePath = typeof record.figure_path === 'string' ? record.figure_path : null;
+  if (!figureId || !figurePath) {
+    return null;
+  }
+  const manifestEntry: FigureManifestEntry = {
+    figure_id: figureId,
+    figure_path: figurePath
+  };
+  if (typeof record.figure_method === 'string') {
+    manifestEntry.figure_method = record.figure_method;
+  }
+  if (typeof record.legacy_figure_path === 'string') {
+    manifestEntry.legacy_figure_path = record.legacy_figure_path;
+  }
+  if (Array.isArray(record.citation_keys)) {
+    manifestEntry.citation_keys = (record.citation_keys as unknown[]).filter(
+      (value): value is string => typeof value === 'string'
+    );
+  }
+  if (record.references && typeof record.references === 'object') {
+    const referencesRecord = record.references as Record<string, unknown>;
+    const references: ManifestReferences = {};
+    if (typeof referencesRecord.path === 'string') {
+      references.path = referencesRecord.path;
+    }
+    if (typeof referencesRecord.legacy_path === 'string') {
+      references.legacy_path = referencesRecord.legacy_path;
+    }
+    if (typeof referencesRecord.line_count === 'number') {
+      references.line_count = referencesRecord.line_count;
+    }
+    if (Array.isArray(referencesRecord.order)) {
+      references.order = (referencesRecord.order as unknown[])
+        .map((item) => {
+          if (!item || typeof item !== 'object') {
+            return null;
+          }
+          const row = item as Record<string, unknown>;
+          const index = typeof row.index === 'number' ? row.index : null;
+          const sourceId = typeof row.source_id === 'string' ? row.source_id : null;
+          if (!index || !sourceId) {
+            return null;
+          }
+          return { index, source_id: sourceId } satisfies ManifestReferenceOrderEntry;
+        })
+        .filter((value): value is ManifestReferenceOrderEntry => value !== null);
+    }
+    manifestEntry.references = references;
+  }
+  if (record.numeric_invariance && typeof record.numeric_invariance === 'object') {
+    const invarianceRecord = record.numeric_invariance as Record<string, unknown>;
+    manifestEntry.numeric_invariance = {
+      passed: typeof invarianceRecord.passed === 'boolean' ? invarianceRecord.passed : undefined,
+      tolerance_percent:
+        typeof invarianceRecord.tolerance_percent === 'number'
+          ? invarianceRecord.tolerance_percent
+          : undefined
+    };
+  }
+  Object.keys(record).forEach((key) => {
+    if (!(key in manifestEntry)) {
+      (manifestEntry as Record<string, unknown>)[key] = record[key];
+    }
+  });
+  return manifestEntry;
+}
+
+function extractAggregateManifestEntries(payload: AggregateManifestPayload): FigureManifestEntry[] {
+  const { figures } = payload;
+  if (!figures) {
+    return [];
+  }
+  if (Array.isArray(figures)) {
+    return figures
+      .map((entry) => normaliseManifestEntry(entry))
+      .filter((entry): entry is FigureManifestEntry => entry !== null);
+  }
+  if (typeof figures === 'object') {
+    return Object.values(figures as Record<string, unknown>)
+      .map((entry) => normaliseManifestEntry(entry))
+      .filter((entry): entry is FigureManifestEntry => entry !== null);
+  }
+  return [];
+}
+
+function selectPreferredArtifact(entries: ManifestIndexArtifactEntry[] | undefined): string | null {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return null;
+  }
+  const preferred = entries.find((entry) => entry && entry.preferred && typeof entry.path === 'string');
+  if (preferred?.path) {
+    return preferred.path;
+  }
+  const first = entries.find((entry) => entry && typeof entry.path === 'string');
+  return first?.path ?? null;
+}
+
+async function fetchAggregateManifest(signal?: AbortSignal): Promise<FigureManifestEntry[] | null> {
+  try {
+    const payload = await fetchJSON<AggregateManifestPayload>(resolveArtifactUrl('figure_manifest.json'), {
+      signal,
+      headers: { Accept: 'application/json' },
+      cache: 'no-store'
+    });
+    const entries = extractAggregateManifestEntries(payload);
+    if (entries.length === 0) {
+      return null;
+    }
+    return entries;
+  } catch (error) {
+    if (error instanceof FetchJSONError) {
+      return null;
+    }
+    if (error instanceof Error && /Unable to parse JSON/.test(error.message)) {
+      return null;
+    }
+    if (isAbortError(error)) {
+      throw error;
+    }
+    return null;
+  }
+}
+
+async function fetchManifestFromIndex(signal?: AbortSignal): Promise<FigureManifestEntry[]> {
+  const payload = await fetchJSON<ManifestIndexPayload>(resolveArtifactUrl('manifest.json'), {
+    signal,
+    headers: { Accept: 'application/json' },
+    cache: 'no-store'
+  });
+  const figures = Array.isArray(payload.figures) ? payload.figures : [];
+  const entries: FigureManifestEntry[] = [];
+  for (const entry of figures) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const figureId = typeof entry.figure_id === 'string' ? entry.figure_id : null;
+    if (!figureId) {
+      continue;
+    }
+    const manifestPath = selectPreferredArtifact(entry.manifests);
+    if (!manifestPath) {
+      continue;
+    }
+    try {
+      const manifest = await fetchJSON<AggregateManifestPayload>(resolveArtifactUrl(manifestPath), {
+        signal,
+        headers: { Accept: 'application/json' },
+        cache: 'no-store'
+      });
+      const normalised = normaliseManifestEntry(manifest as unknown);
+      if (normalised) {
+        entries.push(normalised);
+      }
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+      if (error instanceof Error) {
+        console.warn(`Failed to load figure manifest for ${figureId}`, error);
+      }
+    }
+  }
+  return entries;
+}
+
+async function loadManifest(signal?: AbortSignal): Promise<Map<string, FigureManifestEntry>> {
+  if (manifestCache.data) {
+    return manifestCache.data;
+  }
+  if (manifestCache.promise) {
+    return manifestCache.promise;
+  }
+  const promise = (async () => {
+    const aggregate = await fetchAggregateManifest(signal);
+    const entries = aggregate ?? (await fetchManifestFromIndex(signal));
+    const map = new Map<string, FigureManifestEntry>();
+    entries.forEach((entry) => {
+      if (!map.has(entry.figure_id)) {
+        map.set(entry.figure_id, entry);
+      }
+    });
+    manifestCache.data = map;
+    manifestCache.promise = null;
+    return map;
+  })()
+    .catch((error) => {
+      manifestCache.promise = null;
+      throw error;
+    });
+  manifestCache.promise = promise;
+  return promise;
+}
+
+export async function listFigures(signal?: AbortSignal): Promise<FigureManifestEntry[]> {
+  const manifest = await loadManifest(signal);
+  return Array.from(manifest.values()).sort((a, b) => a.figure_id.localeCompare(b.figure_id));
+}
+
+function buildLookupFromOrder(
+  entry: FigureManifestEntry,
+  citationKeys: readonly string[]
+): Map<string, number> {
+  const orderEntries = entry.references?.order;
+  if (!Array.isArray(orderEntries) || orderEntries.length === 0) {
+    return buildReferenceLookup(citationKeys);
+  }
+  const orderMap = new Map<string, number>();
+  orderEntries.forEach((item) => {
+    if (!item) {
+      return;
+    }
+    const sourceId = typeof item.source_id === 'string' ? item.source_id : null;
+    const index = typeof item.index === 'number' ? item.index : null;
+    if (!sourceId || !index) {
+      return;
+    }
+    orderMap.set(sourceId, index);
+  });
+  if (orderMap.size === 0) {
+    return buildReferenceLookup(citationKeys);
+  }
+  const lookup = new Map<string, number>();
+  citationKeys.forEach((key) => {
+    const index = orderMap.get(key);
+    if (typeof index === 'number') {
+      lookup.set(key, index);
+    }
+  });
+  if (lookup.size === 0) {
+    return buildReferenceLookup(citationKeys);
+  }
+  return lookup;
+}
+
+function reorderReferences(entry: FigureManifestEntry, references: string[]): string[] {
+  const orderEntries = entry.references?.order;
+  if (!Array.isArray(orderEntries) || orderEntries.length === 0) {
+    return references;
+  }
+  const ordered = [...references];
+  orderEntries.forEach((item, index) => {
+    if (!item) {
+      return;
+    }
+    const targetIndex = typeof item.index === 'number' ? item.index - 1 : index;
+    if (targetIndex < 0) {
+      return;
+    }
+    const value = references[index] ?? references[targetIndex] ?? '';
+    ordered[targetIndex] = value;
+  });
+  return ordered;
+}
+
+async function fetchFigurePayload(entry: FigureManifestEntry, signal?: AbortSignal): Promise<FigureJsonPayload> {
+  const payload = await fetchJSON<FigureJsonPayload>(resolveArtifactUrl(entry.figure_path), {
+    signal,
+    headers: { Accept: 'application/json' },
+    cache: 'no-store'
+  });
+  return payload;
+}
+
+async function fetchReferences(entry: FigureManifestEntry, signal?: AbortSignal): Promise<string[]> {
+  const path = entry.references?.path;
+  if (!path) {
+    return [];
+  }
+  const response = await fetch(resolveArtifactUrl(path), {
+    signal,
+    headers: { Accept: 'text/plain' },
+    cache: 'no-store'
+  });
+  if (!response.ok) {
+    throw new Error(`Reference fetch failed with status ${response.status}`);
+  }
+  const text = await response.text();
+  const parsed = parseReferenceList(text);
+  return reorderReferences(entry, parsed);
+}
+
+export async function loadFigure(figureId: string, signal?: AbortSignal): Promise<LoadedFigureData> {
+  const trimmed = figureId.trim();
+  if (!trimmed) {
+    throw new Error('Figure ID is required');
+  }
+  if (figureCache.has(trimmed)) {
+    return figureCache.get(trimmed)!;
+  }
+  if (pendingFigures.has(trimmed)) {
+    return pendingFigures.get(trimmed)!;
+  }
+  const promise = (async () => {
+    const manifest = await loadManifest(signal);
+    const entry = manifest.get(trimmed);
+    if (!entry) {
+      throw new Error(`Figure not found: ${trimmed}`);
+    }
+    const [payload, references] = await Promise.all([
+      fetchFigurePayload(entry, signal),
+      fetchReferences(entry, signal).catch((error) => {
+        if (isAbortError(error)) {
+          throw error;
+        }
+        console.warn(`Failed to load references for ${entry.figure_id}`, error);
+        return [] as string[];
+      })
+    ]);
+    const citationKeys = Array.isArray(payload.citation_keys)
+      ? payload.citation_keys.filter((key): key is string => typeof key === 'string')
+      : Array.isArray(entry.citation_keys)
+        ? entry.citation_keys
+        : [];
+    const referenceLookup = buildLookupFromOrder(entry, citationKeys);
+    const result: LoadedFigureData = {
+      manifest: entry,
+      payload,
+      references,
+      citationKeys,
+      referenceLookup
+    };
+    figureCache.set(trimmed, result);
+    pendingFigures.delete(trimmed);
+    return result;
+  })()
+    .catch((error) => {
+      pendingFigures.delete(trimmed);
+      throw error;
+    });
+  pendingFigures.set(trimmed, promise);
+  return promise;
+}
+
+export function clearFigureCache(): void {
+  manifestCache.data = null;
+  manifestCache.promise = null;
+  figureCache.clear();
+  pendingFigures.clear();
+}


### PR DESCRIPTION
## Summary
- add a manifest-aware data loader that caches figure metadata, JSON payloads, and references
- render a new manifest-driven chart container and references panel tied into the visualization canvas
- update the references drawer and snapshots to reflect the new manifest-backed UX

## Testing
- pnpm --dir site test

------
https://chatgpt.com/codex/tasks/task_e_68e61052cff0832c8ef7fd5b01640302