### PR TITLE
Relax artifact CORS headers for preview domains

### DIFF
--- a/scripts/prepare_pages_bundle.py
+++ b/scripts/prepare_pages_bundle.py
@@ -18,7 +18,7 @@ HEADERS_TEMPLATE = (
     /artifacts/*
       Cache-Control: public, max-age=31536000, immutable
       Content-Type: application/json; charset=utf-8
-      Access-Control-Allow-Origin: https://boot.industries
+      Access-Control-Allow-Origin: *
       Access-Control-Allow-Methods: GET, HEAD, OPTIONS
       Access-Control-Allow-Headers: Content-Type
     """


### PR DESCRIPTION
## Summary
- allow static artifact responses to be fetched from preview hosts by setting `Access-Control-Allow-Origin: *` in the generated Pages headers
- regenerate the bundle headers via `prepare_pages_bundle` so artifact manifests are accessible regardless of origin

## Testing
- pytest tests/test_prepare_pages_bundle.py

------
https://chatgpt.com/codex/tasks/task_e_68e623d721f0832caae2ba4c62ea99ad