### PR TITLE
Move sector browser descriptions into tooltips

### DIFF
--- a/site/src/components/LayerBrowser.tsx
+++ b/site/src/components/LayerBrowser.tsx
@@ -319,6 +319,7 @@ export function SectorBrowser(): JSX.Element {
       </header>
       <div className="flex flex-col gap-[var(--gap-1)]">
         {layers.map((layer) => {
+          const summary = layer.summary && layer.summary.trim().length > 0 ? layer.summary.trim() : undefined;
           const activityBucket = activitiesByLayer[layer.id] ?? { count: 0, activities: [] };
           const coverage = coverageByLayer[layer.id];
           const operations = opsByLayer[layer.id]?.count ?? 0;
@@ -337,6 +338,7 @@ export function SectorBrowser(): JSX.Element {
               ? `${coverage.with_emission_factors}/${coverage.activities} EF`
               : null;
           const detailPanelId = `${layer.id}-panel`;
+          const summaryLabelId = summary ? `${layer.id}-summary` : undefined;
           return (
             <details
               key={layer.id}
@@ -347,7 +349,8 @@ export function SectorBrowser(): JSX.Element {
                 className="flex cursor-pointer flex-col gap-[calc(var(--gap-0)*0.75)] px-[var(--gap-1)] py-[6px] text-left outline-none transition hover:bg-slate-900/50"
                 aria-controls={detailPanelId}
                 aria-expanded={isActive}
-                title={layer.summary ?? undefined}
+                title={summary}
+                aria-describedby={summaryLabelId}
               >
                 <div className="flex items-start gap-[calc(var(--gap-0)*0.8)]">
                   <Icon
@@ -358,8 +361,13 @@ export function SectorBrowser(): JSX.Element {
                   />
                   <div className="flex-1">
                     <div className="flex flex-wrap items-start gap-[calc(var(--gap-0)*0.6)]">
-                      <div className="min-w-0 flex-1 space-y-[calc(var(--gap-0)*0.4)]">
+                      <div className="min-w-0 flex-1 space-y-[calc(var(--gap-0)*0.4)]" title={summary}>
                         <p className="text-sm font-semibold text-slate-100">{layer.title}</p>
+                        {summary ? (
+                          <span id={summaryLabelId} className="sr-only">
+                            {summary}
+                          </span>
+                        ) : null}
                         <div className="flex flex-wrap items-center gap-[8px] text-[10px] uppercase tracking-[0.25em] text-slate-400">
                           <span
                             className={`inline-flex items-center gap-[4px] rounded-full border px-2 py-[2px] text-[10px] font-semibold tracking-[0.18em] ${statusMeta.tone}`}


### PR DESCRIPTION
## Summary
- trim and reuse sector summaries as tooltip text inside the browser list
- hide the inline description text while keeping it available to assistive tech via sr-only content

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173`


------
https://chatgpt.com/codex/tasks/task_e_68e626f770ec832c82e35d48d5816e2a