### PR TITLE
feat: add omni navigation and deep link support

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-switch": "^1.1.3",
         "@radix-ui/react-toolbar": "^1.1.2",
+        "@tanstack/react-virtual": "^3.0.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "dompurify": "^3.1.6",
@@ -1815,6 +1816,33 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/site/package.json
+++ b/site/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-scroll-area": "^1.1.3",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-switch": "^1.1.3",
+    "@tanstack/react-virtual": "^3.0.1",
     "@radix-ui/react-toolbar": "^1.1.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-toolbar':
         specifier: ^1.1.2
         version: 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.0.1
+        version: 3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -808,6 +811,15 @@ packages:
 
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -2618,6 +2630,14 @@ snapshots:
   '@swc/types@0.1.25':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@tanstack/react-virtual@3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@testing-library/dom@9.3.4':
     dependencies:

--- a/site/src/components/CommandPalette.tsx
+++ b/site/src/components/CommandPalette.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useMemo, useState, useCallback, useId, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+
+import { useOmniNavigation } from './OmniBrowser/useOmniNavigation';
+import type { OmniNodeDescriptor } from './OmniBrowser/types';
+import type { StageId } from './Layout';
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  focusMode: boolean;
+  onFocusModeChange: (focusMode: boolean) => void;
+  onToggleReferences: () => void;
+  stage: StageId;
+  onStageChange: (stage: StageId) => void;
+  onNavigateToNode?: (nodeId: string) => void;
+}
+
+interface CommandItem {
+  id: string;
+  label: string;
+  description?: string;
+  group: string;
+  action: () => void;
+  searchableText: string;
+}
+
+function scoreMatch(query: string, text: string): number {
+  if (!query) {
+    return 0;
+  }
+  let score = 0;
+  let queryIndex = 0;
+  const queryLower = query.toLowerCase();
+  const textLower = text.toLowerCase();
+  for (let i = 0; i < textLower.length; i += 1) {
+    if (textLower[i] === queryLower[queryIndex]) {
+      score += 2;
+      queryIndex += 1;
+      if (queryIndex === queryLower.length) {
+        break;
+      }
+    } else if (queryLower.includes(textLower[i])) {
+      score += 1;
+    }
+  }
+  return queryIndex === queryLower.length ? score : score / 2;
+}
+
+function buildCommandFromNode(node: OmniNodeDescriptor, action: () => void): CommandItem {
+  return {
+    id: node.id,
+    label: node.label,
+    description: node.description ?? undefined,
+    group: 'Navigation',
+    action,
+    searchableText: node.searchableText,
+  } satisfies CommandItem;
+}
+
+export default function CommandPalette({
+  open,
+  onOpenChange,
+  focusMode,
+  onFocusModeChange,
+  onToggleReferences,
+  stage,
+  onStageChange,
+  onNavigateToNode,
+}: CommandPaletteProps): JSX.Element | null {
+  const { state, openNode } = useOmniNavigation();
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const labelId = useId();
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        onOpenChange(!open);
+      } else if (event.key === 'Escape' && open) {
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onOpenChange]);
+
+  const navigationCommands = useMemo(() => {
+    const commands: CommandItem[] = [];
+    state.nodes.forEach((node) => {
+      if (node.type === 'group') {
+        return;
+      }
+      const action = () => {
+        openNode(node.id);
+        onNavigateToNode?.(node.id);
+        onOpenChange(false);
+      };
+      commands.push(buildCommandFromNode(node, action));
+    });
+    return commands;
+  }, [onNavigateToNode, onOpenChange, openNode, state.nodes]);
+
+  const systemCommands = useMemo<CommandItem[]>(() => {
+    return [
+      {
+        id: 'cmd:toggle-focus',
+        label: focusMode ? 'Disable focus mode' : 'Enable focus mode',
+        group: 'Workspace',
+        searchableText: 'focus mode',
+        action: () => {
+          onFocusModeChange(!focusMode);
+          onOpenChange(false);
+        },
+      },
+      {
+        id: 'cmd:toggle-references',
+        label: 'Toggle references rail',
+        group: 'Workspace',
+        searchableText: 'references rail toggle',
+        action: () => {
+          onToggleReferences();
+          onOpenChange(false);
+        },
+      },
+      {
+        id: 'cmd:stage-sector',
+        label: 'Show sector rail',
+        group: 'Workspace',
+        searchableText: 'sector rail stage left',
+        action: () => {
+          onStageChange('sector');
+          onOpenChange(false);
+        },
+      },
+      {
+        id: 'cmd:stage-profile',
+        label: 'Show profile controls',
+        group: 'Workspace',
+        searchableText: 'profile controls stage',
+        action: () => {
+          onStageChange('profile');
+          onOpenChange(false);
+        },
+      },
+      {
+        id: 'cmd:stage-activity',
+        label: 'Show activity planner',
+        group: 'Workspace',
+        searchableText: 'activity planner stage',
+        action: () => {
+          onStageChange('activity');
+          onOpenChange(false);
+        },
+      },
+    ];
+  }, [focusMode, onFocusModeChange, onOpenChange, onStageChange, onToggleReferences]);
+
+  const commands = useMemo(() => [...systemCommands, ...navigationCommands], [navigationCommands, systemCommands]);
+
+  const filtered = useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return commands;
+    }
+    return commands
+      .map((command) => ({
+        command,
+        score: scoreMatch(trimmed, command.searchableText || command.label),
+      }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map((entry) => entry.command);
+  }, [commands, query]);
+
+  useEffect(() => {
+    if (activeIndex >= filtered.length) {
+      setActiveIndex(filtered.length > 0 ? filtered.length - 1 : 0);
+    }
+  }, [activeIndex, filtered.length]);
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex((index) => Math.min(index + 1, Math.max(filtered.length - 1, 0)));
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((index) => Math.max(index - 1, 0));
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        const command = filtered[activeIndex];
+        command?.action();
+      }
+    },
+    [activeIndex, filtered]
+  );
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-6" role="dialog" aria-modal="true" aria-labelledby={labelId}>
+      <div className="w-full max-w-xl rounded-xl border border-border/60 bg-background/95 shadow-lg" onKeyDown={handleKeyDown}>
+        <header className="border-b border-border/60 px-4 py-3">
+          <h2 id={labelId} className="text-sm font-semibold text-foreground">
+            Command palette
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">Search layers, activities, figures, scenarios, and commands.</p>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setActiveIndex(0);
+            }}
+            autoFocus
+            placeholder="Type a command or search for an entity"
+            className="mt-3 w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </header>
+        <div className="max-h-[340px] overflow-y-auto px-2 py-2">
+          {filtered.length === 0 ? (
+            <p className="px-2 py-4 text-sm text-muted-foreground">No matching commands</p>
+          ) : (
+            filtered.map((command, index) => {
+              const isActive = index === activeIndex;
+              return (
+                <button
+                  key={command.id}
+                  type="button"
+                  className={`flex w-full flex-col items-start rounded-md px-3 py-2 text-left text-sm ${
+                    isActive ? 'bg-primary/20 text-foreground' : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground'
+                  }`}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => command.action()}
+                >
+                  <span className="font-medium">{command.label}</span>
+                  {command.description ? (
+                    <span className="text-xs text-muted-foreground">{command.description}</span>
+                  ) : null}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/site/src/components/OmniBrowser/OmniBrowser.tsx
+++ b/site/src/components/OmniBrowser/OmniBrowser.tsx
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { ChevronRight, Search } from 'lucide-react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+import { cn } from '@/lib/utils';
+
+import { useOmniNavigation, type OmniScope } from './useOmniNavigation';
+import type { OmniNodeDescriptor } from './types';
+
+interface OmniBrowserProps {
+  selectedNodeId: string | null;
+  onSelectionChange?: (nodeId: string | null) => void;
+}
+
+interface VisibleNode {
+  node: OmniNodeDescriptor;
+  depth: number;
+}
+
+const DEFAULT_EXPANDED = new Set<string>([
+  'omni:root',
+  'omni:group:layers',
+  'omni:group:activities',
+  'omni:group:scenarios',
+]);
+
+function normaliseSearch(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function resolveDepth(nodes: Map<string, OmniNodeDescriptor>, node: OmniNodeDescriptor): number {
+  let depth = 0;
+  let current: OmniNodeDescriptor | undefined = node;
+  while (current?.parentId) {
+    const parent = nodes.get(current.parentId);
+    if (!parent) {
+      break;
+    }
+    depth += 1;
+    current = parent;
+  }
+  return depth;
+}
+
+function filterByScope(
+  scope: OmniScope,
+  node: OmniNodeDescriptor,
+  getScopeForType: (type: OmniNodeDescriptor['type']) => OmniScope,
+  rootId: string
+): boolean {
+  if (node.id === rootId) {
+    return true;
+  }
+  if (scope === 'entities') {
+    return true;
+  }
+  return getScopeForType(node.type) === scope;
+}
+
+export function OmniBrowser({ selectedNodeId, onSelectionChange }: OmniBrowserProps): JSX.Element {
+  const { state, ensureChildrenLoaded, openNode, focusNode, scopes, getScopeForType } = useOmniNavigation();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(DEFAULT_EXPANDED));
+  const [search, setSearch] = useState('');
+  const [scope, setScope] = useState<OmniScope>('entities');
+  const [activeId, setActiveId] = useState<string | null>(selectedNodeId);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setActiveId(selectedNodeId);
+  }, [selectedNodeId]);
+
+  const visibleNodes = useMemo<VisibleNode[]>(() => {
+    const nodes = state.nodes;
+    const searchTerm = normaliseSearch(search);
+    if (!searchTerm) {
+      const ordered: VisibleNode[] = [];
+      const visit = (id: string, depth: number) => {
+        const node = nodes.get(id);
+        if (!node) {
+          return;
+        }
+        if (!filterByScope(scope, node, getScopeForType, state.rootId)) {
+          return;
+        }
+        ordered.push({ node, depth });
+        if (!node.hasChildren) {
+          return;
+        }
+        if (!expanded.has(id)) {
+          return;
+        }
+        const children = node.children ?? [];
+        children.forEach((childId) => visit(childId, depth + 1));
+      };
+      visit(state.rootId, 0);
+      return ordered;
+    }
+    const matches = Array.from(nodes.values()).filter((node) => {
+      if (!filterByScope(scope, node, getScopeForType, state.rootId)) {
+        return false;
+      }
+      return node.searchableText.includes(searchTerm);
+    });
+    matches.sort((a, b) => a.order - b.order);
+    return matches.map((node) => ({ node, depth: resolveDepth(nodes, node) }));
+  }, [expanded, getScopeForType, scope, search, state]);
+
+  const activeIndex = useMemo(() => {
+    if (!activeId) {
+      return -1;
+    }
+    return visibleNodes.findIndex((entry) => entry.node.id === activeId);
+  }, [activeId, visibleNodes]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: visibleNodes.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => 36,
+    overscan: 8,
+  });
+
+  const setSelection = useCallback(
+    (nodeId: string | null) => {
+      setActiveId(nodeId);
+      onSelectionChange?.(nodeId);
+    },
+    [onSelectionChange]
+  );
+
+  const handleToggle = useCallback(
+    async (node: OmniNodeDescriptor) => {
+      if (!node.hasChildren) {
+        return;
+      }
+      const next = new Set(expanded);
+      if (next.has(node.id)) {
+        next.delete(node.id);
+      } else {
+        next.add(node.id);
+        await ensureChildrenLoaded(node.id);
+      }
+      setExpanded(next);
+    },
+    [ensureChildrenLoaded, expanded]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (visibleNodes.length === 0) {
+        return;
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        const nextIndex = activeIndex < 0 ? 0 : Math.min(activeIndex + 1, visibleNodes.length - 1);
+        const target = visibleNodes[nextIndex];
+        setSelection(target.node.id);
+        rowVirtualizer.scrollToIndex(nextIndex);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        const nextIndex = activeIndex <= 0 ? 0 : activeIndex - 1;
+        const target = visibleNodes[nextIndex];
+        setSelection(target.node.id);
+        rowVirtualizer.scrollToIndex(nextIndex);
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        const current = activeIndex >= 0 ? visibleNodes[activeIndex]?.node : null;
+        if (current && current.hasChildren && !expanded.has(current.id)) {
+          handleToggle(current);
+        } else if (current) {
+          openNode(current.id);
+        }
+      } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        const current = activeIndex >= 0 ? visibleNodes[activeIndex]?.node : null;
+        if (current && current.hasChildren && expanded.has(current.id)) {
+          handleToggle(current);
+          return;
+        }
+        if (current?.parentId) {
+          setSelection(current.parentId);
+        }
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        const current = activeIndex >= 0 ? visibleNodes[activeIndex]?.node : null;
+        if (current) {
+          if (event.shiftKey) {
+            focusNode(current.id);
+          } else {
+            openNode(current.id);
+          }
+        }
+      }
+    },
+    [activeIndex, expanded, focusNode, handleToggle, openNode, rowVirtualizer, setSelection, visibleNodes]
+  );
+
+  return (
+    <section className="flex h-full flex-col" aria-label="Omni browser">
+      <header className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
+        <div className="flex flex-1 items-center gap-2 rounded-md border border-border/60 bg-background/80 px-2 py-1">
+          <Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search navigation"
+            className="flex-1 bg-transparent text-xs outline-none"
+            aria-label="Search"
+          />
+        </div>
+        <label className="sr-only" htmlFor="omni-scope">
+          Filter scope
+        </label>
+        <select
+          id="omni-scope"
+          value={scope}
+          onChange={(event) => setScope(event.target.value as OmniScope)}
+          className="rounded-md border border-border/60 bg-background/80 px-2 py-1 text-xs"
+        >
+          {scopes.map((entry) => (
+            <option key={entry} value={entry}>
+              {entry.charAt(0).toUpperCase() + entry.slice(1)}
+            </option>
+          ))}
+        </select>
+      </header>
+      <div
+        ref={containerRef}
+        role="tree"
+        aria-label="Navigation results"
+        tabIndex={0}
+        className="relative flex-1 overflow-auto px-1 py-2 focus:outline-none"
+        onKeyDown={handleKeyDown}
+      >
+        <div
+          style={{ height: `${rowVirtualizer.getTotalSize()}px`, position: 'relative' }}
+        >
+          {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+            const item = visibleNodes[virtualRow.index];
+            if (!item) {
+              return null;
+            }
+            const { node, depth } = item;
+            const isExpanded = expanded.has(node.id);
+            const isSelected = node.id === activeId;
+            const showToggle = node.hasChildren;
+            const left = depth * 12;
+            return (
+              <div
+                key={node.id}
+                role="treeitem"
+                aria-selected={isSelected}
+                aria-level={depth + 1}
+                aria-expanded={node.hasChildren ? isExpanded : undefined}
+                className={cn(
+                  'absolute flex h-9 w-full items-center gap-2 rounded-md px-2 text-xs',
+                  isSelected ? 'bg-primary/20 text-foreground' : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground'
+                )}
+                style={{ transform: `translateY(${virtualRow.start}px)`, paddingLeft: `${left + 12}px` }}
+                onClick={() => {
+                  setSelection(node.id);
+                }}
+                onDoubleClick={() => {
+                  if (node.hasChildren) {
+                    handleToggle(node);
+                  } else {
+                    openNode(node.id);
+                  }
+                }}
+              >
+                {showToggle ? (
+                  <button
+                    type="button"
+                    className={cn(
+                      'mr-1 flex h-5 w-5 items-center justify-center rounded border border-border/40 bg-background/60 transition-transform',
+                      isExpanded && 'rotate-90'
+                    )}
+                    aria-label={isExpanded ? 'Collapse' : 'Expand'}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleToggle(node);
+                    }}
+                  >
+                    <ChevronRight className="h-3 w-3" aria-hidden="true" />
+                  </button>
+                ) : (
+                  <span className="ml-4" aria-hidden="true" />
+                )}
+                <span className="text-[10px] text-muted-foreground">[{node.order}]</span>
+                <span className="truncate text-xs text-foreground">{node.label}</span>
+                {typeof node.refCount === 'number' && node.refCount > 0 ? (
+                  <span className="ml-auto rounded-full bg-primary/20 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                    {node.refCount}
+                  </span>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/site/src/components/OmniBrowser/index.ts
+++ b/site/src/components/OmniBrowser/index.ts
@@ -1,0 +1,2 @@
+export { OmniBrowser } from './OmniBrowser';
+export type { OmniScope } from './useOmniNavigation';

--- a/site/src/components/OmniBrowser/registry.ts
+++ b/site/src/components/OmniBrowser/registry.ts
@@ -21,7 +21,7 @@ export class OmniRegistry {
     parentId: string | null,
     type: OmniNodeType,
     label: string,
-    options: Partial<Omit<OmniNodeDescriptor, 'id' | 'parentId' | 'type' | 'label' | 'order'>> = {}
+    options: Partial<Omit<OmniNodeDescriptor, 'id' | 'parentId' | 'type' | 'label'>> = {}
   ): OmniNodeDescriptor {
     const descriptor: OmniNodeDescriptor = {
       id,

--- a/site/src/components/OmniBrowser/registry.ts
+++ b/site/src/components/OmniBrowser/registry.ts
@@ -1,0 +1,82 @@
+import type { OmniNavigationState, OmniNodeDescriptor, OmniNodeType } from './types';
+
+let sequence = 0;
+
+export function resetRegistryOrder(): void {
+  sequence = 0;
+}
+
+function nextOrder(): number {
+  sequence += 1;
+  return sequence;
+}
+
+export class OmniRegistry {
+  private nodes = new Map<string, OmniNodeDescriptor>();
+
+  private rootId: string | null = null;
+
+  public registerNode(
+    id: string,
+    parentId: string | null,
+    type: OmniNodeType,
+    label: string,
+    options: Partial<Omit<OmniNodeDescriptor, 'id' | 'parentId' | 'type' | 'label' | 'order'>> = {}
+  ): OmniNodeDescriptor {
+    const descriptor: OmniNodeDescriptor = {
+      id,
+      parentId,
+      type,
+      label,
+      searchableText: options.searchableText ?? `${label}`.toLowerCase(),
+      description: options.description,
+      refCount: options.refCount,
+      hasChildren: options.hasChildren ?? false,
+      isLoaded: options.isLoaded,
+      children: options.children ? [...options.children] : [],
+      loadChildren: options.loadChildren,
+      order: options.order ?? nextOrder(),
+      metadata: options.metadata,
+    };
+    this.nodes.set(id, descriptor);
+    if (parentId) {
+      const parent = this.nodes.get(parentId);
+      if (parent) {
+        parent.children = parent.children ? [...parent.children, id] : [id];
+        parent.hasChildren = true;
+      }
+    } else {
+      this.rootId = id;
+    }
+    return descriptor;
+  }
+
+  public ensureRoot(id: string, label: string): OmniNodeDescriptor {
+    const existing = this.nodes.get(id);
+    if (existing) {
+      return existing;
+    }
+    return this.registerNode(id, null, 'group', label, { hasChildren: true, isLoaded: true });
+  }
+
+  public setChildren(id: string, childIds: string[]): void {
+    const node = this.nodes.get(id);
+    if (!node) {
+      return;
+    }
+    node.children = [...childIds];
+    node.hasChildren = childIds.length > 0;
+    node.isLoaded = true;
+  }
+
+  public getNode(id: string): OmniNodeDescriptor | undefined {
+    return this.nodes.get(id);
+  }
+
+  public finalise(): OmniNavigationState {
+    if (!this.rootId) {
+      throw new Error('Omni navigation root not defined');
+    }
+    return { rootId: this.rootId, nodes: this.nodes } satisfies OmniNavigationState;
+  }
+}

--- a/site/src/components/OmniBrowser/types.ts
+++ b/site/src/components/OmniBrowser/types.ts
@@ -1,0 +1,46 @@
+export type OmniNodeType =
+  | 'group'
+  | 'layer'
+  | 'activity'
+  | 'figure'
+  | 'scenario'
+  | 'reference';
+
+export interface OmniNodeActionContext {
+  focusMainPane?: () => void;
+}
+
+export interface OmniNodeActionHandlers {
+  open: (id: string, context?: OmniNodeActionContext) => void;
+  focus: (id: string, context?: OmniNodeActionContext) => void;
+}
+
+export interface OmniNodeMetadata {
+  summary?: string | null;
+  layerId?: string | null;
+  activityId?: string | null;
+  figureId?: string | null;
+  scenarioId?: string | null;
+  referenceId?: string | null;
+}
+
+export interface OmniNodeDescriptor {
+  id: string;
+  parentId: string | null;
+  type: OmniNodeType;
+  label: string;
+  description?: string | null;
+  searchableText: string;
+  refCount?: number;
+  order: number;
+  hasChildren: boolean;
+  isLoaded?: boolean;
+  children?: string[];
+  metadata?: OmniNodeMetadata;
+  loadChildren?: () => Promise<void> | void;
+}
+
+export interface OmniNavigationState {
+  rootId: string;
+  nodes: Map<string, OmniNodeDescriptor>;
+}

--- a/site/src/components/OmniBrowser/useOmniNavigation.ts
+++ b/site/src/components/OmniBrowser/useOmniNavigation.ts
@@ -1,0 +1,398 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useProfile } from '@/state/profile';
+import { useLayerCatalog } from '@/lib/useLayerCatalog';
+import { listFigures, type FigureManifestEntry } from '@/lib/DataLoader';
+import { useACXStore } from '@/store/useACXStore';
+
+import { OmniRegistry, resetRegistryOrder } from './registry';
+import type { OmniNavigationState, OmniNodeDescriptor, OmniNodeType } from './types';
+
+interface ReferenceMeta {
+  id: string;
+  label: string;
+  description?: string | null;
+}
+
+interface ScenarioMeta {
+  id: string;
+  label: string;
+  description?: string | null;
+}
+
+export type OmniScope = 'entities' | 'layers' | 'activities' | 'figures' | 'scenarios' | 'references';
+
+export interface UseOmniNavigationResult {
+  state: OmniNavigationState;
+  loading: boolean;
+  error: Error | null;
+  ensureChildrenLoaded: (id: string) => Promise<void>;
+  resolveNode: (id: string) => OmniNodeDescriptor | undefined;
+  scopes: OmniScope[];
+  getScopeForType: (type: OmniNodeType) => OmniScope;
+  openNode: (id: string) => void;
+  focusNode: (id: string) => void;
+}
+
+const ROOT_ID = 'omni:root';
+const GROUP_IDS: Record<Exclude<OmniScope, 'entities'>, string> = {
+  layers: 'omni:group:layers',
+  activities: 'omni:group:activities',
+  figures: 'omni:group:figures',
+  scenarios: 'omni:group:scenarios',
+  references: 'omni:group:references',
+};
+
+function normaliseLabel(label: string | null | undefined, fallback: string): string {
+  if (!label) {
+    return fallback;
+  }
+  const trimmed = label.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  return trimmed;
+}
+
+function buildLayerChildren(
+  registry: OmniRegistry,
+  layerIds: string[],
+  options: {
+    layerLookup: Map<string, string>;
+    activityLookup: Map<string, string[]>;
+    referenceCounts: Map<string, number>;
+  }
+): void {
+  layerIds.forEach((layerId) => {
+    const label = options.layerLookup.get(layerId) ?? layerId;
+    const refCount = options.referenceCounts.get(layerId);
+    const nodeId = `layer:${layerId}`;
+    const activities = options.activityLookup.get(layerId) ?? [];
+    const description = activities.length > 0 ? `${activities.length} activities` : null;
+    registry.registerNode(nodeId, GROUP_IDS.layers, 'layer', label, {
+      searchableText: `${label} ${layerId}`.toLowerCase(),
+      description,
+      refCount,
+      hasChildren: activities.length > 0,
+      isLoaded: activities.length > 0,
+      metadata: { layerId },
+    });
+    if (activities.length > 0) {
+      const children = activities.map((activityId) => {
+        const activityLabel = normaliseLabel(activityId.split('.').join(' › '), activityId);
+        const activityNodeId = `activity:${activityId}`;
+        registry.registerNode(activityNodeId, nodeId, 'activity', activityLabel, {
+          searchableText: `${activityLabel} ${activityId}`.toLowerCase(),
+          metadata: { activityId, layerId },
+        });
+        return activityNodeId;
+      });
+      registry.setChildren(nodeId, children);
+    }
+  });
+}
+
+function buildActivityLookup(audit: ReturnType<typeof useLayerCatalog>['audit']): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  const entries = audit?.activities_by_layer ?? {};
+  Object.entries(entries).forEach(([layerId, payload]) => {
+    const activities = payload?.activities ?? [];
+    const ids = activities
+      ?.map((activity) => activity?.id ?? activity?.activity_id)
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .map((value) => value.trim());
+    if (ids && ids.length > 0) {
+      map.set(layerId, ids);
+    }
+  });
+  return map;
+}
+
+function buildReferenceCounts(manifest: ReturnType<typeof useProfile>['result']): Map<string, number> {
+  const counts = new Map<string, number>();
+  const references = manifest?.manifest?.layer_references;
+  if (references && typeof references === 'object') {
+    Object.entries(references).forEach(([layerId, value]) => {
+      if (!layerId) {
+        return;
+      }
+      if (Array.isArray(value)) {
+        counts.set(layerId, value.length);
+        return;
+      }
+      if (value && typeof value === 'object') {
+        const arrayValue = (value as { references?: unknown }).references;
+        if (Array.isArray(arrayValue)) {
+          counts.set(layerId, arrayValue.length);
+        }
+      }
+    });
+  }
+  const citationKeys = manifest?.manifest?.layer_citation_keys;
+  if (citationKeys && typeof citationKeys === 'object') {
+    Object.entries(citationKeys).forEach(([layerId, value]) => {
+      if (!Array.isArray(value)) {
+        return;
+      }
+      const existing = counts.get(layerId) ?? 0;
+      counts.set(layerId, Math.max(existing, value.length));
+    });
+  }
+  return counts;
+}
+
+function buildScenarioMeta(manifest: ReturnType<typeof useProfile>['result']): ScenarioMeta[] {
+  const overrides = manifest?.manifest?.overrides ?? {};
+  return Object.keys(overrides)
+    .filter((id) => typeof id === 'string' && id.trim().length > 0)
+    .map((id) => ({ id, label: id.split('.').join(' › ') }));
+}
+
+function buildReferenceMeta(manifest: ReturnType<typeof useProfile>['result']): ReferenceMeta[] {
+  const references = manifest?.references ?? [];
+  return references
+    .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+    .map((id) => ({ id, label: id }));
+}
+
+function getScopeForType(type: OmniNodeType): OmniScope {
+  switch (type) {
+    case 'layer':
+      return 'layers';
+    case 'activity':
+      return 'activities';
+    case 'figure':
+      return 'figures';
+    case 'scenario':
+      return 'scenarios';
+    case 'reference':
+      return 'references';
+    default:
+      return 'entities';
+  }
+}
+
+interface BuildStateOptions {
+  layerLookup: Map<string, string>;
+  activityLookup: Map<string, string[]>;
+  referenceCounts: Map<string, number>;
+  scenarioMeta: ScenarioMeta[];
+  referenceMeta: ReferenceMeta[];
+  figures: FigureManifestEntry[] | null;
+}
+
+function createNavigationState(options: BuildStateOptions): OmniNavigationState {
+  resetRegistryOrder();
+  const registry = new OmniRegistry();
+  registry.ensureRoot(ROOT_ID, 'Navigation');
+
+  (Object.keys(GROUP_IDS) as (keyof typeof GROUP_IDS)[]).forEach((key) => {
+    const label = key.charAt(0).toUpperCase() + key.slice(1);
+    registry.registerNode(GROUP_IDS[key], ROOT_ID, 'group', label, {
+      hasChildren: true,
+      isLoaded: key !== 'figures' && key !== 'references' ? true : (key === 'figures' ? Boolean(options.figures) : options.referenceMeta.length > 0),
+    });
+  });
+
+  buildLayerChildren(registry, Array.from(options.layerLookup.keys()), {
+    layerLookup: options.layerLookup,
+    activityLookup: options.activityLookup,
+    referenceCounts: options.referenceCounts,
+  });
+
+  const allActivities = Array.from(options.activityLookup.values()).flat();
+  allActivities.forEach((activityId) => {
+    const activityLabel = normaliseLabel(activityId.split('.').join(' › '), activityId);
+    registry.registerNode(`activity:${activityId}`, GROUP_IDS.activities, 'activity', activityLabel, {
+      searchableText: `${activityLabel} ${activityId}`.toLowerCase(),
+      metadata: { activityId },
+    });
+  });
+  if (allActivities.length > 0) {
+    registry.setChildren(
+      GROUP_IDS.activities,
+      allActivities.map((activityId) => `activity:${activityId}`)
+    );
+  }
+
+  options.scenarioMeta.forEach((entry) => {
+    registry.registerNode(`scenario:${entry.id}`, GROUP_IDS.scenarios, 'scenario', entry.label, {
+      searchableText: `${entry.label} ${entry.id}`.toLowerCase(),
+      metadata: { scenarioId: entry.id },
+    });
+  });
+  if (options.scenarioMeta.length > 0) {
+    registry.setChildren(
+      GROUP_IDS.scenarios,
+      options.scenarioMeta.map((entry) => `scenario:${entry.id}`)
+    );
+  }
+
+  options.referenceMeta.forEach((entry) => {
+    registry.registerNode(`reference:${entry.id}`, GROUP_IDS.references, 'reference', entry.label, {
+      searchableText: `${entry.label}`.toLowerCase(),
+      metadata: { referenceId: entry.id },
+    });
+  });
+  if (options.referenceMeta.length > 0) {
+    registry.setChildren(
+      GROUP_IDS.references,
+      options.referenceMeta.map((entry) => `reference:${entry.id}`)
+    );
+  }
+
+  if (options.figures) {
+    options.figures.forEach((entry) => {
+      const id = typeof entry.figure_id === 'string' ? entry.figure_id : '';
+      if (!id) {
+        return;
+      }
+      const label = normaliseLabel((entry as { title?: string }).title ?? id, id);
+      registry.registerNode(`figure:${id}`, GROUP_IDS.figures, 'figure', label, {
+        searchableText: `${label} ${id}`.toLowerCase(),
+        metadata: { figureId: id },
+      });
+    });
+    if (options.figures.length > 0) {
+      registry.setChildren(
+        GROUP_IDS.figures,
+        options.figures
+          .map((entry) => entry.figure_id)
+          .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+          .map((id) => `figure:${id}`)
+      );
+    }
+  }
+
+  return registry.finalise();
+}
+
+export function useOmniNavigation(): UseOmniNavigationResult {
+  const { layers, audit } = useLayerCatalog();
+  const profile = useProfile();
+  const setFigureId = useACXStore((state) => state.setFigureId);
+  const setSelectedLayers = useACXStore((state) => state.setSelectedLayers);
+  const setFocusMode = useACXStore((state) => state.setFocusMode);
+
+  const activityLookup = useMemo(() => buildActivityLookup(audit), [audit]);
+  const layerLabelLookup = useMemo(() => {
+    const map = new Map<string, string>();
+    layers.forEach((layer) => {
+      if (layer?.id) {
+        map.set(layer.id, normaliseLabel(layer.title, layer.id));
+      }
+    });
+    return map;
+  }, [layers]);
+  const referenceCounts = useMemo(() => buildReferenceCounts(profile.result), [profile.result]);
+  const scenarioMeta = useMemo(() => buildScenarioMeta(profile.result), [profile.result]);
+  const referenceMeta = useMemo(() => buildReferenceMeta(profile.result), [profile.result]);
+
+  const [figures, setFigures] = useState<FigureManifestEntry[] | null>(null);
+  const [figureError, setFigureError] = useState<Error | null>(null);
+  const [figureLoading, setFigureLoading] = useState(false);
+
+  const [state, setState] = useState<OmniNavigationState>(() =>
+    createNavigationState({
+      layerLookup: layerLabelLookup,
+      activityLookup,
+      referenceCounts,
+      scenarioMeta,
+      referenceMeta,
+      figures: null,
+    })
+  );
+
+  useEffect(() => {
+    setState(
+      createNavigationState({
+        layerLookup: layerLabelLookup,
+        activityLookup,
+        referenceCounts,
+        scenarioMeta,
+        referenceMeta,
+        figures,
+      })
+    );
+  }, [activityLookup, layerLabelLookup, referenceCounts, scenarioMeta, referenceMeta, figures]);
+
+  const pendingLoads = useRef(new Map<string, Promise<void>>());
+
+  const ensureChildrenLoaded = useCallback(
+    async (id: string) => {
+      const node = state.nodes.get(id);
+      if (!node || node.isLoaded) {
+        return;
+      }
+      if (pendingLoads.current.has(id)) {
+        await pendingLoads.current.get(id);
+        return;
+      }
+      if (id === GROUP_IDS.figures) {
+        const promise = (async () => {
+          try {
+            setFigureLoading(true);
+            const payload = await listFigures();
+            setFigures(payload);
+            setFigureError(null);
+          } catch (error) {
+            const resolved = error instanceof Error ? error : new Error(String(error));
+            setFigureError(resolved);
+          } finally {
+            setFigureLoading(false);
+          }
+        })();
+        pendingLoads.current.set(id, promise);
+        await promise;
+        pendingLoads.current.delete(id);
+      }
+    },
+    [state.nodes]
+  );
+
+  const openNode = useCallback(
+    (id: string) => {
+      if (id.startsWith('layer:')) {
+        const layerId = id.slice('layer:'.length);
+        const next = new Set(profile.activeLayers);
+        next.add(layerId);
+        setSelectedLayers(next);
+      } else if (id.startsWith('activity:')) {
+        const activityId = id.slice('activity:'.length);
+        console.debug('Activity selected', activityId);
+      } else if (id.startsWith('figure:')) {
+        const figureId = id.slice('figure:'.length);
+        setFigureId(figureId);
+      } else if (id.startsWith('scenario:')) {
+        setFocusMode(true);
+      }
+    },
+    [profile.activeLayers, setFigureId, setFocusMode, setSelectedLayers]
+  );
+
+  const focusNode = useCallback(
+    (id: string) => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      const target = document.getElementById('main');
+      if (target instanceof HTMLElement) {
+        target.focus({ preventScroll: true });
+      }
+      openNode(id);
+    },
+    [openNode]
+  );
+
+  return {
+    state,
+    loading: figureLoading,
+    error: figureError,
+    ensureChildrenLoaded,
+    resolveNode: (id) => state.nodes.get(id),
+    scopes: ['entities', 'layers', 'activities', 'figures', 'scenarios', 'references'],
+    getScopeForType,
+    openNode,
+    focusNode,
+  };
+}

--- a/site/src/components/__tests__/nav.integration.test.tsx
+++ b/site/src/components/__tests__/nav.integration.test.tsx
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React, { useState } from 'react';
+
+import { OmniBrowser } from '../OmniBrowser/OmniBrowser';
+import type { OmniNavigationState, OmniNodeDescriptor } from '../OmniBrowser/types';
+import CommandPalette from '../CommandPalette';
+import { useACXStore } from '@/store/useACXStore';
+import { useDeepLink } from '@/hooks/useDeepLink';
+import type { StageId } from '../Layout';
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, start: index * 36 })),
+    getTotalSize: () => count * 36,
+    scrollToIndex: () => {},
+  }),
+}));
+
+const navMock = {
+  state: { rootId: 'omni:root', nodes: new Map<string, OmniNodeDescriptor>() } as OmniNavigationState,
+  ensureChildrenLoaded: vi.fn(),
+  openNode: vi.fn(),
+  focusNode: vi.fn(),
+  resolveNode: (id: string) => navMock.state.nodes.get(id),
+  scopes: ['entities', 'layers', 'activities', 'figures', 'scenarios', 'references'],
+  getScopeForType: (type: OmniNodeDescriptor['type']) => {
+    switch (type) {
+      case 'layer':
+        return 'layers';
+      case 'activity':
+        return 'activities';
+      case 'figure':
+        return 'figures';
+      case 'scenario':
+        return 'scenarios';
+      case 'reference':
+        return 'references';
+      default:
+        return 'entities';
+    }
+  },
+  loading: false,
+  error: null,
+};
+
+vi.mock('../OmniBrowser/useOmniNavigation', () => ({
+  useOmniNavigation: () => navMock,
+}));
+
+function createNode(partial: Partial<OmniNodeDescriptor>): OmniNodeDescriptor {
+  if (!partial.id) {
+    throw new Error('Node id required');
+  }
+  return {
+    id: partial.id,
+    parentId: partial.parentId ?? null,
+    type: partial.type ?? 'group',
+    label: partial.label ?? partial.id,
+    searchableText: partial.searchableText ?? partial.label?.toLowerCase() ?? partial.id,
+    order: partial.order ?? 1,
+    hasChildren: partial.hasChildren ?? false,
+    isLoaded: partial.isLoaded ?? true,
+    children: partial.children ? [...partial.children] : [],
+    metadata: partial.metadata,
+    description: partial.description,
+    refCount: partial.refCount,
+  } satisfies OmniNodeDescriptor;
+}
+
+function seedNavigationTree(): void {
+  const nodes = new Map<string, OmniNodeDescriptor>();
+  nodes.set(
+    'omni:root',
+    createNode({
+      id: 'omni:root',
+      parentId: null,
+      type: 'group',
+      label: 'Navigation',
+      order: 1,
+      hasChildren: true,
+      children: ['omni:group:layers'],
+    })
+  );
+  nodes.set(
+    'omni:group:layers',
+    createNode({
+      id: 'omni:group:layers',
+      parentId: 'omni:root',
+      type: 'group',
+      label: 'Layers',
+      order: 2,
+      hasChildren: true,
+      children: ['layer:alpha'],
+    })
+  );
+  nodes.set(
+    'layer:alpha',
+    createNode({
+      id: 'layer:alpha',
+      parentId: 'omni:group:layers',
+      type: 'layer',
+      label: 'Alpha layer',
+      searchableText: 'alpha layer',
+      order: 3,
+      hasChildren: true,
+      children: ['activity:alpha.1'],
+      refCount: 3,
+    })
+  );
+  nodes.set(
+    'activity:alpha.1',
+    createNode({
+      id: 'activity:alpha.1',
+      parentId: 'layer:alpha',
+      type: 'activity',
+      label: 'Alpha activity',
+      searchableText: 'alpha activity',
+      order: 4,
+      hasChildren: false,
+    })
+  );
+  navMock.state = { rootId: 'omni:root', nodes };
+  navMock.openNode.mockClear();
+  navMock.ensureChildrenLoaded.mockClear();
+}
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: 400,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: 600,
+  });
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-expect-error jsdom global
+  global.ResizeObserver = ResizeObserverMock;
+});
+
+beforeEach(() => {
+  seedNavigationTree();
+});
+
+afterEach(() => {
+  useACXStore.getState().reset();
+  window.history.replaceState({}, '', '/');
+});
+
+describe('OmniBrowser', () => {
+  it('supports keyboard navigation and actions', () => {
+    const onSelectionChange = vi.fn();
+    render(<OmniBrowser selectedNodeId={null} onSelectionChange={onSelectionChange} />);
+    const tree = screen.getByRole('tree');
+
+    fireEvent.keyDown(tree, { key: 'ArrowDown' });
+    expect(onSelectionChange).toHaveBeenCalledWith('omni:root');
+    onSelectionChange.mockClear();
+
+    fireEvent.keyDown(tree, { key: 'ArrowDown' });
+    expect(onSelectionChange).toHaveBeenCalledWith('omni:group:layers');
+    onSelectionChange.mockClear();
+
+    fireEvent.keyDown(tree, { key: 'ArrowDown' });
+    expect(onSelectionChange).toHaveBeenCalledWith('layer:alpha');
+
+    fireEvent.keyDown(tree, { key: 'Enter' });
+    expect(navMock.openNode).toHaveBeenCalledWith('layer:alpha');
+
+    const search = screen.getByRole('searchbox', { name: /search/i });
+    fireEvent.change(search, { target: { value: 'activity' } });
+    expect(screen.getByText('Alpha activity')).toBeInTheDocument();
+  });
+});
+
+describe('CommandPalette', () => {
+  it('filters navigation commands and executes actions', () => {
+    render(
+      <CommandPalette
+        open
+        onOpenChange={() => {}}
+        focusMode={false}
+        onFocusModeChange={() => {}}
+        onToggleReferences={() => {}}
+        stage="sector"
+        onStageChange={() => {}}
+        onNavigateToNode={() => {}}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/type a command/i);
+    fireEvent.change(input, { target: { value: 'alpha' } });
+
+    const commandButton = screen.getByRole('button', { name: /alpha layer/i });
+    fireEvent.click(commandButton);
+
+    expect(navMock.openNode).toHaveBeenCalledWith('layer:alpha');
+  });
+});
+
+describe('useDeepLink', () => {
+  function createHarness() {
+    let stageSetter: ((stage: StageId) => void) | null = null;
+    let omniSetter: ((nodes: string[]) => void) | null = null;
+    let latestStage: StageId = 'sector';
+    let latestSelection: string[] = [];
+    function Harness() {
+      const [stage, setStage] = useState<StageId>('sector');
+      const [selection, setSelection] = useState<string[]>([]);
+      latestStage = stage;
+      latestSelection = selection;
+      stageSetter = setStage;
+      omniSetter = setSelection;
+      useDeepLink({
+        stage,
+        onStageChange: setStage,
+        selectedOmniNodes: selection,
+        onOmniSelectionChange: setSelection,
+      });
+      return null;
+    }
+    return {
+      Harness,
+      getStage: () => latestStage,
+      getSelection: () => latestSelection,
+      setStage: (next: StageId) => stageSetter?.(next),
+      setSelection: (nodes: string[]) => omniSetter?.(nodes ?? []),
+    };
+  }
+
+  it('synchronises store state with URL parameters', async () => {
+    window.history.replaceState({}, '', '/?figure=FIG1&nav=layer:alpha&pane=profile&focus=1');
+    const harness = createHarness();
+    render(<harness.Harness />);
+
+    await waitFor(() => expect(useACXStore.getState().figureId).toBe('FIG1'));
+    expect(useACXStore.getState().focusMode).toBe(true);
+    await waitFor(() => expect(harness.getStage()).toBe('profile'));
+    await waitFor(() => expect(harness.getSelection()).toContain('layer:alpha'));
+
+    useACXStore.getState().setFigureId('FIG2');
+    await waitFor(() => expect(window.location.search).toContain('figure=FIG2'));
+
+    act(() => {
+      harness.setStage('activity');
+    });
+    await waitFor(() => expect(window.location.search).toContain('pane=activity'));
+
+    act(() => {
+      harness.setSelection([]);
+    });
+    await waitFor(() => expect(window.location.search).not.toContain('nav='));
+  });
+});

--- a/site/src/hooks/useDeepLink.ts
+++ b/site/src/hooks/useDeepLink.ts
@@ -1,0 +1,170 @@
+import { useEffect, useRef } from 'react';
+
+import { useACXStore, setACXStoreState, type ACXStoreState } from '@/store/useACXStore';
+import { buildSearchFromState, parseACXStateFromSearch } from '@/utils/url';
+
+import type { StageId } from '@/components/Layout';
+
+export interface UseDeepLinkOptions {
+  stage: StageId;
+  onStageChange: (stage: StageId) => void;
+  selectedOmniNodes: readonly string[];
+  onOmniSelectionChange: (nodes: readonly string[]) => void;
+}
+
+interface StoreSnapshot {
+  figureId: string | null;
+  layers: string[];
+  scale: ACXStoreState['scale'];
+  period: ACXStoreState['period'];
+  focusMode: boolean;
+}
+
+function createSnapshot(state: ACXStoreState): StoreSnapshot {
+  return {
+    figureId: state.figureId,
+    layers: Array.from(state.selectedLayers),
+    scale: state.scale,
+    period: state.period,
+    focusMode: state.focusMode,
+  } satisfies StoreSnapshot;
+}
+
+function arraysAreEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((value, index) => value === b[index]);
+}
+
+function snapshotsAreEqual(a: StoreSnapshot | null, b: StoreSnapshot): boolean {
+  if (!a) {
+    return false;
+  }
+  if (a.figureId !== b.figureId || a.scale !== b.scale || a.period !== b.period || a.focusMode !== b.focusMode) {
+    return false;
+  }
+  return arraysAreEqual(a.layers, b.layers);
+}
+
+export function useDeepLink({
+  stage,
+  onStageChange,
+  selectedOmniNodes,
+  onOmniSelectionChange,
+}: UseDeepLinkOptions): void {
+  const stageRef = useRef(stage);
+  const omniRef = useRef<readonly string[]>(selectedOmniNodes);
+  const appliedSearchRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    stageRef.current = stage;
+  }, [stage]);
+
+  useEffect(() => {
+    omniRef.current = selectedOmniNodes;
+  }, [selectedOmniNodes]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const applySearch = (search: string) => {
+      if (appliedSearchRef.current === search) {
+        return;
+      }
+      appliedSearchRef.current = search;
+      const parsed = parseACXStateFromSearch(search);
+      const current = useACXStore.getState();
+      const currentLayers = Array.from(current.selectedLayers);
+      const sameLayers = arraysAreEqual(currentLayers, parsed.layers);
+      const sameFigure = current.figureId === parsed.figureId;
+      const sameScale = current.scale === parsed.scale;
+      const samePeriod = current.period === parsed.period;
+      const sameFocus = current.focusMode === parsed.focusMode;
+      if (!(sameLayers && sameFigure && sameScale && samePeriod && sameFocus)) {
+        setACXStoreState({
+          figureId: parsed.figureId,
+          selectedLayers: new Set(parsed.layers),
+          scale: parsed.scale,
+          period: parsed.period,
+          focusMode: parsed.focusMode,
+        });
+      }
+      if (parsed.pane && ['sector', 'profile', 'activity'].includes(parsed.pane)) {
+        onStageChange(parsed.pane as StageId);
+      }
+      onOmniSelectionChange(parsed.omni);
+    };
+    applySearch(window.location.search);
+    const handlePopState = () => {
+      applySearch(window.location.search);
+    };
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [onOmniSelectionChange, onStageChange]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    let previousSnapshot: StoreSnapshot | null = null;
+    const updateUrl = () => {
+      const state = useACXStore.getState();
+      const search = buildSearchFromState(
+        {
+          figureId: state.figureId,
+          layers: state.selectedLayers,
+          scale: state.scale,
+          period: state.period,
+          focusMode: state.focusMode,
+          pane: stageRef.current,
+          omni: omniRef.current,
+        },
+        window.location.search,
+      );
+      if (search !== window.location.search) {
+        const nextUrl = `${window.location.pathname}${search}${window.location.hash}`;
+        window.history.replaceState({}, '', nextUrl);
+        appliedSearchRef.current = search;
+      }
+    };
+    const unsubscribe = useACXStore.subscribe((state) => {
+      const snapshot = createSnapshot(state);
+      if (snapshotsAreEqual(previousSnapshot, snapshot)) {
+        return;
+      }
+      previousSnapshot = snapshot;
+      updateUrl();
+    });
+    updateUrl();
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const state = useACXStore.getState();
+    const search = buildSearchFromState(
+      {
+        figureId: state.figureId,
+        layers: state.selectedLayers,
+        scale: state.scale,
+        period: state.period,
+        focusMode: state.focusMode,
+        pane: stage,
+        omni: selectedOmniNodes,
+      },
+      window.location.search,
+    );
+    if (search !== window.location.search) {
+      const nextUrl = `${window.location.pathname}${search}${window.location.hash}`;
+      window.history.replaceState({}, '', nextUrl);
+    }
+  }, [selectedOmniNodes, stage]);
+}

--- a/site/src/lib/useLayerCatalog.ts
+++ b/site/src/lib/useLayerCatalog.ts
@@ -16,6 +16,7 @@ export interface LayerAuditActivity {
   id: string;
   name: string;
   category?: string;
+  activity_id?: string;
 }
 
 export interface LayerAuditActivities {


### PR DESCRIPTION
## Summary
- add a virtualized Omni Browser with keyboard navigation, scoped search, and reference badges for large navigation trees
- introduce a lazily loaded command palette that searches the Omni data set and exposes workspace commands
- synchronize navigation state with URLs via a new deep link hook and update the app shell/tests for the new flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e67ea8507c832cb962312cdb994d2b