### PR TITLE
feat(shell+context): refine layout controls and references rail

### DIFF
--- a/site/src/components/BrandHeader.tsx
+++ b/site/src/components/BrandHeader.tsx
@@ -1,0 +1,21 @@
+export interface BrandHeaderProps {
+  landmark?: 'banner' | 'heading';
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export function BrandHeader({ landmark = 'banner', level = 2 }: BrandHeaderProps): JSX.Element {
+  if (landmark === 'banner') {
+    return (
+      <header role="banner" aria-label="Carbon ACX" className="px-3 py-2 text-sm font-semibold select-none">
+        Carbon ACX
+      </header>
+    );
+  }
+  return (
+    <div role="heading" aria-level={level} aria-label="Carbon ACX" className="px-3 py-2 text-sm font-semibold select-none">
+      Carbon ACX
+    </div>
+  );
+}
+
+export default BrandHeader;

--- a/site/src/components/ContextRail/tabs/ReferencesTab.tsx
+++ b/site/src/components/ContextRail/tabs/ReferencesTab.tsx
@@ -1,4 +1,8 @@
-import { useMemo } from 'react';
+import { useCallback, useId, useMemo, type CSSProperties } from 'react';
+import { ChevronDown, Copy } from 'lucide-react';
+
+import { useShellLayout } from '@/hooks/useShellLayout';
+import { density } from '@/theme/tokens';
 
 export interface ReferencesTabProps {
   manifestHash?: string | null;
@@ -19,6 +23,9 @@ function normaliseReference(value: unknown): string | null {
 }
 
 export default function ReferencesTab({ manifestHash = null, references }: ReferencesTabProps): JSX.Element {
+  const { rightCollapsed, setRightCollapsed } = useShellLayout();
+  const headerId = useId();
+
   const orderedReferences = useMemo(() => {
     return references
       .map((value, index) => ({ value: normaliseReference(value), index }))
@@ -36,40 +43,97 @@ export default function ReferencesTab({ manifestHash = null, references }: Refer
       .map((entry) => entry.value);
   }, [references]);
 
+  const paddingStyle = {
+    padding: `${density.padY}px ${density.padX}px`
+  } satisfies CSSProperties;
+
+  const headerStyle = {
+    padding: `${density.padY}px ${density.padX}px`
+  } satisfies CSSProperties;
+
+  const copyJson = useCallback(async () => {
+    try {
+      const payload = JSON.stringify({ manifestHash, references: orderedReferences }, null, 2);
+      await navigator.clipboard?.writeText(payload);
+    } catch (error) {
+      console.warn('Failed to copy manifest JSON', error);
+    }
+  }, [manifestHash, orderedReferences]);
+
   return (
-    <section className="space-y-4" aria-label="Reference list">
-      <header className="space-y-2">
-        <p className="text-2xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-          Active manifest
-        </p>
-        {manifestHash ? (
-          <div className="rounded-lg border border-border/60 bg-background/60 p-3" data-testid="context-rail-manifest">
-            <p className="text-[11px] font-mono text-muted-foreground">{manifestHash}</p>
-          </div>
-        ) : (
-          <p className="text-xs text-muted-foreground" data-testid="context-rail-manifest-empty">
-            Manifest hash unavailable for this context.
-          </p>
-        )}
+    <div className="flex h-full min-h-0 flex-col" aria-label="Reference list" data-testid="context-rail-refs">
+      <header
+        className="sticky top-0 z-10 flex items-center justify-between border-b border-border/60 bg-background/80"
+        style={headerStyle}
+      >
+        <h2 id={headerId} className="text-sm font-medium">
+          References
+        </h2>
+        <div className="flex items-center gap-2">
+          <button
+            aria-label="Copy manifest JSON"
+            title="Copy JSON"
+            className="icon-btn"
+            type="button"
+            onClick={copyJson}
+            data-testid="context-rail-copy-json"
+          >
+            <Copy aria-hidden />
+          </button>
+          <button
+            type="button"
+            aria-controls="references-panel"
+            aria-expanded={!rightCollapsed}
+            onClick={() => setRightCollapsed((value) => !value)}
+            className="icon-btn"
+            title={rightCollapsed ? 'Show references' : 'Hide references'}
+            data-testid="context-rail-toggle"
+          >
+            <ChevronDown className={!rightCollapsed ? 'rotate-180 transition-transform' : 'transition-transform'} aria-hidden />
+          </button>
+        </div>
       </header>
-      <div className="space-y-3">
-        <p className="text-2xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">References</p>
-        {orderedReferences.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No references available.</p>
-        ) : (
-          <ol className="space-y-2" data-testid="context-rail-reference-list">
-            {orderedReferences.map((reference, index) => (
-              <li
-                key={`${index}-${reference}`}
-                className="rounded-lg border border-border/60 bg-background/60 p-3 text-sm text-muted-foreground"
-              >
-                <span className="mr-2 font-mono text-[11px] text-primary">[{index + 1}]</span>
-                <span className="align-middle text-foreground">{reference}</span>
-              </li>
-            ))}
-          </ol>
-        )}
-      </div>
-    </section>
+      <section
+        id="references-panel"
+        hidden={rightCollapsed}
+        className="flex-1 overflow-auto"
+        style={paddingStyle}
+        aria-labelledby={headerId}
+        role="region"
+      >
+        <div className="space-y-4">
+          <header className="space-y-2" data-testid="context-rail-manifest">
+            <p className="text-2xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Active manifest</p>
+            {manifestHash ? (
+              <div className="rounded-lg border border-border/60 bg-background/60 p-3">
+                <p className="text-[11px] font-mono text-muted-foreground">{manifestHash}</p>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground" data-testid="context-rail-manifest-empty">
+                Manifest hash unavailable for this context.
+              </p>
+            )}
+          </header>
+          <div className="space-y-3">
+            <p className="text-2xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">References</p>
+            {orderedReferences.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No references available.</p>
+            ) : (
+              <ol className="space-y-2" data-testid="context-rail-reference-list">
+                {orderedReferences.map((reference, index) => (
+                  <li
+                    key={`${index}-${reference}`}
+                    className="rounded-lg border border-border/60 bg-background/60 p-3 text-sm text-muted-foreground"
+                  >
+                    <span className="mr-2 font-mono text-[11px] text-primary">[{index + 1}]</span>
+                    <span className="align-middle text-foreground">{reference}</span>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/site/src/components/FocusButton.tsx
+++ b/site/src/components/FocusButton.tsx
@@ -1,0 +1,23 @@
+import { Maximize2 as MaximizeIcon } from 'lucide-react';
+
+export interface FocusButtonProps {
+  pressed: boolean;
+  onToggle: () => void;
+}
+
+export function FocusButton({ pressed, onToggle }: FocusButtonProps): JSX.Element {
+  return (
+    <button
+      type="button"
+      className="icon-btn absolute -top-8 right-2"
+      aria-pressed={pressed}
+      aria-label={pressed ? 'Exit focus mode' : 'Enter focus mode'}
+      onClick={onToggle}
+      data-testid="shell-focus-toggle"
+    >
+      <MaximizeIcon aria-hidden />
+    </button>
+  );
+}
+
+export default FocusButton;

--- a/site/src/components/OmniBrowser/OmniBrowser.tsx
+++ b/site/src/components/OmniBrowser/OmniBrowser.tsx
@@ -1,8 +1,19 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent
+} from 'react';
 import { ChevronRight, Search } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 import { cn } from '@/lib/utils';
+
+import { density } from '@/theme/tokens';
+import BrandHeader from '../BrandHeader';
 
 import { useOmniNavigation, type OmniScope } from './useOmniNavigation';
 import type { OmniNodeDescriptor } from './types';
@@ -195,9 +206,12 @@ export function OmniBrowser({ selectedNodeId, onSelectionChange }: OmniBrowserPr
     [activeIndex, expanded, focusNode, handleToggle, openNode, rowVirtualizer, setSelection, visibleNodes]
   );
 
+  const paddingStyle = { padding: `${density.padY}px ${density.padX}px` } satisfies CSSProperties;
+
   return (
     <section className="flex h-full flex-col" aria-label="Omni browser">
-      <header className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
+      <BrandHeader landmark="heading" level={2} />
+      <header className="flex items-center gap-2 border-b border-border/60" style={paddingStyle}>
         <div className="flex flex-1 items-center gap-2 rounded-md border border-border/60 bg-background/80 px-2 py-1">
           <Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           <input
@@ -230,7 +244,8 @@ export function OmniBrowser({ selectedNodeId, onSelectionChange }: OmniBrowserPr
         role="tree"
         aria-label="Navigation results"
         tabIndex={0}
-        className="relative flex-1 overflow-auto px-1 py-2 focus:outline-none"
+        className="relative flex-1 overflow-auto focus:outline-none"
+        style={paddingStyle}
         onKeyDown={handleKeyDown}
       >
         <div

--- a/site/src/components/VisualizerSurface.tsx
+++ b/site/src/components/VisualizerSurface.tsx
@@ -230,14 +230,6 @@ export function VisualizerSurface({
     };
   }, [exitFocus, view]);
 
-  const handleFocusToggle = useCallback(() => {
-    if (view === 'focus') {
-      exitFocus();
-    } else {
-      setView('focus');
-    }
-  }, [exitFocus, setView, view]);
-
   const topLevelColumns = useMemo(() => {
     return view === 'focus' ? 'minmax(0, 1fr) 0px' : 'minmax(0, 1fr) 340px';
   }, [view]);
@@ -318,17 +310,6 @@ export function VisualizerSurface({
           <p className="text-2xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Visualizer</p>
           <p className="text-xs text-muted-foreground">Inspect your scenario and supporting context.</p>
         </div>
-        <button
-          type="button"
-          className={cn(
-            'rounded-full border border-border/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.28em] transition',
-            focusActive ? 'bg-primary/20 text-primary hover:bg-primary/30' : 'bg-muted/40 text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-          )}
-          onClick={handleFocusToggle}
-          data-testid="visualizer-focus-toggle"
-        >
-          {focusActive ? 'Exit focus' : 'Focus mode'}
-        </button>
       </header>
       <div
         className="grid min-h-0 flex-1 gap-0"

--- a/site/src/components/__tests__/context+viz.test.tsx
+++ b/site/src/components/__tests__/context+viz.test.tsx
@@ -97,25 +97,26 @@ describe('Visualizer focus mode', () => {
     renderSurface();
     const user = userEvent.setup();
 
-    const focusToggle = screen.getByTestId('visualizer-focus-toggle');
     await screen.findByTestId('context-rail-tabs');
     const railWrapper = screen.getByTestId('context-rail-container');
 
     expect(screen.getByTestId('visualizer-surface')).not.toBeNull();
 
-    await user.click(focusToggle);
+    act(() => {
+      window.history.replaceState({}, '', '?view=focus');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
 
     await waitFor(() => {
-      expect(railWrapper).toHaveAttribute('aria-hidden', 'true');
+      expect(document.querySelector('[data-visualizer-view="focus"]')).not.toBeNull();
     });
-    expect(focusToggle).toHaveTextContent(/Exit focus/i);
-    expect(document.querySelector('[data-visualizer-view="focus"]')).not.toBeNull();
+    expect(railWrapper).toHaveAttribute('aria-hidden', 'true');
 
     await user.keyboard('{Escape}');
     await waitFor(() => {
-      expect(railWrapper).not.toHaveAttribute('aria-hidden', 'true');
+      expect(document.querySelector('[data-visualizer-view="focus"]')).toBeNull();
     });
-    expect(focusToggle).toHaveTextContent(/Focus mode/i);
+    expect(railWrapper).not.toHaveAttribute('aria-hidden', 'true');
   });
 });
 

--- a/site/src/routes/(app)/__tests__/context.refs-toggle.test.tsx
+++ b/site/src/routes/(app)/__tests__/context.refs-toggle.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import ReferencesTab from '@/components/ContextRail/tabs/ReferencesTab';
+
+describe('References tab toggle behaviour', () => {
+  const REFERENCES = ['A note about Scope 2', 'Baseline methodology'];
+
+  it('exposes a single references toggle control', () => {
+    render(<ReferencesTab manifestHash="hash" references={REFERENCES} />);
+    const referenceButtons = screen.getAllByRole('button', { name: /references/i });
+    expect(referenceButtons).toHaveLength(1);
+  });
+
+  it('toggles the references panel visibility and aria-expanded state', async () => {
+    render(<ReferencesTab manifestHash="hash" references={REFERENCES} />);
+    const user = userEvent.setup();
+
+    const toggle = screen.getByRole('button', { name: /references/i });
+    const panel = screen.getByRole('region', { hidden: true, name: /references/i });
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(panel).not.toHaveAttribute('hidden');
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(panel).toHaveAttribute('hidden');
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(panel).not.toHaveAttribute('hidden');
+  });
+});

--- a/site/src/routes/(app)/__tests__/shell.layout.test.tsx
+++ b/site/src/routes/(app)/__tests__/shell.layout.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import ShellRoute from '../shell';
+import { getACXStoreState, setACXStoreState } from '@/store/useACXStore';
+
+describe('Shell workspace layout', () => {
+  beforeEach(() => {
+    setACXStoreState({ focusMode: false });
+  });
+
+  it('places the brand heading above the navigation rail', () => {
+    render(<ShellRoute />);
+    const brandHeading = screen.getByRole('heading', { name: /carbon acx/i });
+    const navigationRail = screen.getByRole('complementary', { name: /navigation/i });
+    expect(brandHeading.compareDocumentPosition(navigationRail) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('positions the focus toggle above the context header and syncs store state', async () => {
+    render(<ShellRoute />);
+    const user = userEvent.setup();
+
+    const contextRail = screen.getByRole('complementary', { name: /context/i });
+    const focusToggle = within(contextRail).getByRole('button', { name: /focus mode/i });
+    const referencesHeading = within(contextRail).getByText(/reference notes/i);
+
+    expect(focusToggle).toHaveAttribute('aria-pressed', 'false');
+    expect(getACXStoreState().focusMode).toBe(false);
+    expect(focusToggle.compareDocumentPosition(referencesHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    await user.click(focusToggle);
+
+    await waitFor(() => {
+      expect(focusToggle).toHaveAttribute('aria-pressed', 'true');
+    });
+    expect(getACXStoreState().focusMode).toBe(true);
+  });
+});

--- a/site/src/routes/(app)/shell.tsx
+++ b/site/src/routes/(app)/shell.tsx
@@ -8,12 +8,15 @@ import type {
 
 import { useShellLayout } from '@/hooks/useShellLayout';
 import {
-  SHELL_HEADER_MAX_HEIGHT,
   SHELL_MAX_LEFT_FRACTION,
   SHELL_MAX_RIGHT_FRACTION,
   SHELL_MIN_LEFT_FRACTION,
-  SHELL_MIN_RIGHT_FRACTION
+  SHELL_MIN_RIGHT_FRACTION,
+  density
 } from '@/theme/tokens';
+import { useACXStore } from '@/store/useACXStore';
+import BrandHeader from '@/components/BrandHeader';
+import FocusButton from '@/components/FocusButton';
 
 const KPI_ITEMS = [
   { label: 'Net emissions', value: '18.4 tCO₂e', helper: '−12% vs plan' },
@@ -85,6 +88,8 @@ export default function ShellRoute(): JSX.Element {
     reset,
     keyboardStep
   } = useShellLayout();
+  const focusMode = useACXStore((state) => state.focusMode);
+  const setFocusMode = useACXStore((state) => state.setFocusMode);
 
   const leftPaneId = useId();
   const mainPaneId = useId();
@@ -92,6 +97,11 @@ export default function ShellRoute(): JSX.Element {
   const leftPaneDomId = `${leftPaneId}-panel`;
   const mainPaneDomId = `${mainPaneId}-panel`;
   const rightPaneDomId = `${rightPaneId}-panel`;
+
+  const railStyle = {
+    gap: `${density.gap}px`,
+    padding: `${density.padY}px ${density.padX}px`
+  } satisfies CSSProperties;
 
   const layoutStyle = useMemo(() => {
     return {
@@ -239,70 +249,53 @@ export default function ShellRoute(): JSX.Element {
       >
         Skip to workspace content
       </a>
-      <div className="grid min-h-screen grid-rows-[auto_minmax(0,1fr)_auto]">
-        <header
-          className="flex h-16 min-h-[3.5rem] items-center justify-between gap-4 border-b border-slate-800/70 bg-slate-950/80 px-6"
-          style={{ maxHeight: SHELL_HEADER_MAX_HEIGHT }}
-          role="banner"
-        >
-          <div className="flex items-center gap-4">
-            <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-sky-500/20 text-base font-semibold text-sky-300">
-              ACX
-            </span>
-            <div>
-              <p className="text-sm font-semibold tracking-wide text-slate-50">Carbon Navigator</p>
-              <p className="text-xs text-slate-400">Split-pane workspace shell</p>
-            </div>
-          </div>
-          <nav className="hidden items-center gap-6 text-sm font-medium text-slate-300 md:flex">
-            <span className="text-slate-100">Overview</span>
-            <span className="text-slate-400">Playbooks</span>
-            <span className="text-slate-400">Insights</span>
-            <span className="text-slate-400">History</span>
-          </nav>
-          <div className="flex items-center gap-3">
-            <span className="text-xs uppercase tracking-[0.2em] text-slate-500">
-              L {leftPercentage.toFixed(0)}% · R {rightPercentage.toFixed(0)}%
-            </span>
-            <button
-              type="button"
-              onClick={reset}
-              className="rounded border border-slate-700/70 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-slate-200 transition hover:border-sky-500/70 hover:text-sky-300"
-            >
-              Reset layout
-            </button>
-          </div>
-        </header>
-
+      <div className="grid min-h-screen grid-rows-[minmax(0,1fr)_auto]">
         <div
           ref={containerRef}
           className="relative grid min-h-0 grid-cols-[var(--rail-left)_minmax(0,1fr)_var(--rail-right)] overflow-hidden"
           style={layoutStyle}
         >
-          <aside
-            id={leftPaneDomId}
-            aria-label="Planning rail"
-            className="flex h-full flex-col gap-6 border-r border-slate-800/70 bg-slate-950/70 px-6 py-6"
+          <div
+            className="flex h-full min-h-0 flex-col border-r border-slate-800/70 bg-slate-950/70"
+            style={railStyle}
           >
-            {PLAYBOOKS.map((section) => (
-              <section key={section.title} className="space-y-3">
-                <header className="space-y-1">
-                  <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
-                    {section.title}
-                  </p>
-                  <div className="h-px w-full bg-slate-800/70" />
-                </header>
-                <ul className="space-y-2 text-sm text-slate-200">
-                  {section.items.map((item) => (
-                    <li key={item} className="flex items-start gap-2">
-                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-sky-500/80" aria-hidden="true" />
-                      <span>{item}</span>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            ))}
-          </aside>
+            <BrandHeader landmark="heading" level={1} />
+            <aside
+              id={leftPaneDomId}
+              aria-label="Navigation"
+              className="flex flex-1 flex-col"
+              style={{ gap: `${density.gap}px` }}
+            >
+              {PLAYBOOKS.map((section) => (
+                <section key={section.title} className="space-y-3">
+                  <header className="space-y-1">
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+                      {section.title}
+                    </p>
+                    <div className="h-px w-full bg-slate-800/70" />
+                  </header>
+                  <ul className="space-y-2 text-sm text-slate-200">
+                    {section.items.map((item) => (
+                      <li key={item} className="flex items-start gap-2">
+                        <span className="mt-1 h-1.5 w-1.5 rounded-full bg-sky-500/80" aria-hidden="true" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+              <div className="mt-auto rounded border border-slate-800/70 bg-slate-900/60 p-3 text-xs text-slate-400">
+                Layout · L {leftPercentage.toFixed(0)}% · R {rightPercentage.toFixed(0)}%
+              </div>
+              <button
+                type="button"
+                onClick={reset}
+                className="rounded border border-slate-700/70 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-slate-200 transition hover:border-sky-500/70 hover:text-sky-300"
+              >
+                Reset layout
+              </button>
+            </aside>
+          </div>
 
           <main
             id={mainPaneDomId}
@@ -385,17 +378,24 @@ export default function ShellRoute(): JSX.Element {
 
           <aside
             id={rightPaneDomId}
-            aria-label="Reference rail"
-            className="flex h-full flex-col gap-5 border-l border-slate-800/70 bg-slate-950/70 px-6 py-6"
+            aria-label="Context"
+            className="relative flex h-full min-h-0 flex-col border-l border-slate-800/70 bg-slate-950/70"
+            style={railStyle}
           >
-            {REFERENCE_NOTES.map((entry) => (
-              <article key={entry.heading} className="space-y-2 rounded-lg border border-slate-800/60 bg-slate-900/60 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
-                  {entry.heading}
-                </p>
-                <p className="text-sm leading-relaxed text-slate-200">{entry.detail}</p>
-              </article>
-            ))}
+            <FocusButton pressed={focusMode} onToggle={() => setFocusMode(!focusMode)} />
+            <header className="pt-6">
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Reference notes</p>
+            </header>
+            <div className="flex-1 overflow-y-auto space-y-3 pt-2">
+              {REFERENCE_NOTES.map((entry) => (
+                <article key={entry.heading} className="space-y-2 rounded-lg border border-slate-800/60 bg-slate-900/60 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+                    {entry.heading}
+                  </p>
+                  <p className="text-sm leading-relaxed text-slate-200">{entry.detail}</p>
+                </article>
+              ))}
+            </div>
           </aside>
 
           <div

--- a/site/src/theme/global.css
+++ b/site/src/theme/global.css
@@ -23,6 +23,39 @@
   transform: translateY(0);
 }
 
+:root {
+  --icon-btn-bg: rgba(15, 23, 42, 0.6);
+  --icon-btn-border: rgba(100, 116, 139, 0.5);
+  --icon-btn-color: rgba(148, 163, 184, 0.9);
+  --icon-btn-hover-bg: rgba(30, 41, 59, 0.8);
+  --icon-btn-hover-color: rgba(226, 232, 240, 1);
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--icon-btn-border);
+  background: var(--icon-btn-bg);
+  color: var(--icon-btn-color);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.icon-btn:hover,
+.icon-btn:focus-visible {
+  background: var(--icon-btn-hover-bg);
+  color: var(--icon-btn-hover-color);
+  border-color: rgba(56, 189, 248, 0.6);
+}
+
+.icon-btn svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 :where(a, button, input, textarea, select, summary, [role='button']):focus-visible {
   outline: 2px solid hsl(var(--focus-ring-color));
   outline-offset: 3px;

--- a/site/src/theme/tokens.ts
+++ b/site/src/theme/tokens.ts
@@ -14,6 +14,12 @@ export const SHELL_DEFAULT_DOCK_FRACTION = 0.33;
 export const SHELL_DEFAULT_DOCK_POSITION = 'side' as const;
 export type ShellDockPosition = typeof SHELL_DEFAULT_DOCK_POSITION | 'bottom';
 
+export const density = {
+  padX: 8,
+  padY: 6,
+  gap: 6
+} as const;
+
 export interface ShellLayoutPreset {
   query: string;
   left: number;


### PR DESCRIPTION
## Summary
- add reusable BrandHeader and FocusButton components with shared icon button styling tokens
- tighten shell layout to position the brand heading, focus toggle, and navigation using density tokens while wiring right-rail collapse state
- refresh references tab to own the single toggle and update OmniBrowser and VisualizerSurface to align with the new controls
- add regression tests covering the shell layout focus button ordering and references toggle behaviour

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e6e481a3a4832ca94fe617b3f2cbad