### PR TITLE
feat: generate semantic model and typed schema queries

### DIFF
--- a/apps/carbon-acx-web/schema/sample-queries.ts
+++ b/apps/carbon-acx-web/schema/sample-queries.ts
@@ -1,0 +1,368 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const dataDir = path.join(repoRoot, 'data');
+const artifactsDir = path.join(repoRoot, 'dist', 'artifacts');
+
+interface CsvRecord {
+  [key: string]: string | null;
+}
+
+function stripBom(value: string): string {
+  return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
+}
+
+function parseCsv(content: string): CsvRecord[] {
+  const rows: string[][] = [];
+  const cleaned = stripBom(content);
+  let current = '';
+  let inQuotes = false;
+  let row: string[] = [];
+
+  for (let i = 0; i < cleaned.length; i += 1) {
+    const char = cleaned[i];
+
+    if (char === '"') {
+      const nextChar = cleaned[i + 1];
+      if (inQuotes && nextChar === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      row.push(current);
+      current = '';
+      continue;
+    }
+
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && cleaned[i + 1] === '\n') {
+        i += 1;
+      }
+      row.push(current);
+      current = '';
+      if (row.some((cell) => cell.trim().length > 0)) {
+        rows.push(row);
+      }
+      row = [];
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0 || row.length > 0) {
+    row.push(current);
+    if (row.some((cell) => cell.trim().length > 0)) {
+      rows.push(row);
+    }
+  }
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const [header, ...dataRows] = rows;
+  const headers = header.map((cell) => cell.trim());
+  return dataRows.map((cells) => {
+    const record: CsvRecord = {};
+    headers.forEach((key, index) => {
+      const value = index < cells.length ? cells[index] : '';
+      const trimmed = value.trim();
+      record[key] = trimmed.length > 0 ? trimmed : null;
+    });
+    return record;
+  });
+}
+
+async function loadCsvRecords(fileName: string): Promise<CsvRecord[]> {
+  const filePath = path.join(dataDir, fileName);
+  const content = await readFile(filePath, 'utf-8');
+  return parseCsv(content);
+}
+
+export interface SectorSummary {
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+export interface ActivitySummary {
+  id: string;
+  sectorId: string;
+  layerId: string | null;
+  category: string | null;
+  name: string | null;
+  defaultUnit: string | null;
+  description: string | null;
+}
+
+export interface DatasetSummary {
+  datasetId: string;
+  generatedAt: string | null;
+  figureCount: number | null;
+  manifestPath: string | null;
+  manifestSha256: string | null;
+}
+
+export interface ReferenceSummary {
+  referenceId: string;
+  text: string;
+  citation?: string | null;
+  url?: string | null;
+  year?: number | null;
+  layer?: string;
+}
+
+async function loadManifestIndex(): Promise<Record<string, unknown> | null> {
+  try {
+    const filePath = path.join(artifactsDir, 'manifest.json');
+    const raw = await readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch (error) {
+    return null;
+  }
+}
+
+async function loadDatasetManifest(): Promise<Record<string, unknown> | null> {
+  const manifestIndex = await loadManifestIndex();
+  if (!manifestIndex) {
+    return null;
+  }
+  const datasetManifest = manifestIndex['dataset_manifest'];
+  if (!datasetManifest || typeof datasetManifest !== 'object') {
+    return null;
+  }
+  const manifestObj = datasetManifest as Record<string, unknown>;
+  const manifestPath = manifestObj['path'];
+  if (typeof manifestPath !== 'string') {
+    return null;
+  }
+  try {
+    const filePath = path.join(artifactsDir, manifestPath);
+    const raw = await readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function listSectors(): Promise<SectorSummary[]> {
+  const records = await loadCsvRecords('sectors.csv');
+  return records.map((record) => ({
+    id: record['sector_id'] ?? '',
+    name: record['name'] ?? '',
+    description: record['description'],
+  }));
+}
+
+export async function getSector(id: string): Promise<SectorSummary | null> {
+  const sectors = await listSectors();
+  return sectors.find((sector) => sector.id === id) ?? null;
+}
+
+export async function listActivities(sectorId: string): Promise<ActivitySummary[]> {
+  const records = await loadCsvRecords('activities.csv');
+  return records
+    .filter((record) => (record['sector_id'] ?? '').toLowerCase() === sectorId.toLowerCase())
+    .map((record) => ({
+      id: record['activity_id'] ?? '',
+      sectorId: record['sector_id'] ?? '',
+      layerId: record['layer_id'] ?? null,
+      category: record['category'] ?? null,
+      name: record['name'] ?? null,
+      defaultUnit: record['default_unit'] ?? null,
+      description: record['description'] ?? null,
+    }));
+}
+
+export async function getDataset(id: string): Promise<DatasetSummary | null> {
+  const manifest = await loadDatasetManifest();
+  if (!manifest) {
+    return null;
+  }
+  const datasetId = typeof manifest['dataset_id'] === 'string' ? manifest['dataset_id'] : null;
+  if (!datasetId || datasetId !== id) {
+    return null;
+  }
+  const generatedAt = typeof manifest['generated_at'] === 'string' ? manifest['generated_at'] : null;
+  const figureCount = typeof manifest['figure_count'] === 'number' ? manifest['figure_count'] : null;
+
+  const manifestIndex = await loadManifestIndex();
+  let manifestPath: string | null = null;
+  let manifestSha256: string | null = null;
+  if (manifestIndex && manifestIndex['dataset_manifest'] && typeof manifestIndex['dataset_manifest'] === 'object') {
+    const datasetManifest = manifestIndex['dataset_manifest'] as Record<string, unknown>;
+    if (typeof datasetManifest['path'] === 'string') {
+      manifestPath = datasetManifest['path'];
+    }
+    if (typeof datasetManifest['sha256'] === 'string') {
+      manifestSha256 = datasetManifest['sha256'];
+    }
+  }
+
+  return {
+    datasetId,
+    generatedAt,
+    figureCount,
+    manifestPath,
+    manifestSha256,
+  };
+}
+
+async function loadSourcesById(): Promise<Map<string, CsvRecord>> {
+  const sources = await loadCsvRecords('sources.csv');
+  const map = new Map<string, CsvRecord>();
+  for (const source of sources) {
+    const sourceId = source['source_id'];
+    if (sourceId) {
+      map.set(sourceId, source);
+    }
+  }
+  return map;
+}
+
+function normaliseKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export async function listReferences(datasetId: string): Promise<ReferenceSummary[]> {
+  const dataset = await getDataset(datasetId);
+  if (!dataset) {
+    return [];
+  }
+
+  const manifestIndex = await loadManifestIndex();
+  const manifest = await loadDatasetManifest();
+  const sourcesById = await loadSourcesById();
+
+  const targetKeys = new Set<string>();
+  if (manifest) {
+    const layerKeys = manifest['layer_citation_keys'];
+    if (layerKeys && typeof layerKeys === 'object') {
+      for (const value of Object.values(layerKeys as Record<string, unknown>)) {
+        if (Array.isArray(value)) {
+          for (const entry of value) {
+            if (typeof entry === 'string') {
+              targetKeys.add(normaliseKey(entry));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const results: ReferenceSummary[] = [];
+  const seen = new Set<string>();
+
+  if (manifestIndex && Array.isArray(manifestIndex['figures'])) {
+    for (const figure of manifestIndex['figures'] as Array<Record<string, unknown>>) {
+      const references = figure['references'];
+      if (!Array.isArray(references)) {
+        continue;
+      }
+      for (const entry of references) {
+        if (!entry || typeof entry !== 'object') {
+          continue;
+        }
+        const refObj = entry as Record<string, unknown>;
+        const refPath = typeof refObj['path'] === 'string' ? refObj['path'] : null;
+        if (!refPath || !refPath.startsWith('references/')) {
+          continue;
+        }
+        const referenceId = refPath.replace(/^references\//, '').replace(/\.txt$/i, '');
+        if (seen.has(referenceId)) {
+          continue;
+        }
+        seen.add(referenceId);
+        try {
+          const content = await readFile(path.join(artifactsDir, refPath), 'utf-8');
+          const baseSummary: ReferenceSummary = {
+            referenceId,
+            text: content.trim(),
+          };
+          const sourceRecord = sourcesById.get(referenceId);
+          if (sourceRecord) {
+            baseSummary.citation = sourceRecord['ieee_citation'];
+            baseSummary.url = sourceRecord['url'];
+            const yearValue = sourceRecord['year'];
+            baseSummary.year = yearValue ? Number.parseInt(yearValue, 10) || null : null;
+          }
+          results.push(baseSummary);
+        } catch (error) {
+          // Ignore missing reference files.
+        }
+      }
+    }
+  }
+
+  if (results.length === 0 && targetKeys.size > 0) {
+    for (const [sourceId, record] of sourcesById.entries()) {
+      if (!targetKeys.has(normaliseKey(sourceId))) {
+        continue;
+      }
+      if (seen.has(sourceId)) {
+        continue;
+      }
+      seen.add(sourceId);
+      results.push({
+        referenceId: sourceId,
+        text: record['ieee_citation'] ?? sourceId,
+        citation: record['ieee_citation'],
+        url: record['url'],
+        year: record['year'] ? Number.parseInt(record['year'], 10) || null : null,
+      });
+    }
+  }
+
+  if (results.length === 0) {
+    let count = 0;
+    for (const [sourceId, record] of sourcesById.entries()) {
+      if (count >= 10) {
+        break;
+      }
+      if (seen.has(sourceId)) {
+        continue;
+      }
+      seen.add(sourceId);
+      results.push({
+        referenceId: sourceId,
+        text: record['ieee_citation'] ?? sourceId,
+        citation: record['ieee_citation'],
+        url: record['url'],
+        year: record['year'] ? Number.parseInt(record['year'], 10) || null : null,
+      });
+      count += 1;
+    }
+  }
+
+  if (manifest) {
+    const layerReferences = manifest['layer_references'];
+    if (layerReferences && typeof layerReferences === 'object') {
+      for (const [layer, values] of Object.entries(layerReferences as Record<string, unknown>)) {
+        if (!Array.isArray(values)) {
+          continue;
+        }
+        for (const value of values) {
+          if (typeof value !== 'string') {
+            continue;
+          }
+          results.push({
+            referenceId: `${layer}:${value.slice(0, 20).replace(/\s+/g, ' ')}`,
+            text: value,
+            layer,
+          });
+        }
+      }
+    }
+  }
+
+  return results;
+}

--- a/apps/carbon-acx-web/schema/semantic-model.preview.json
+++ b/apps/carbon-acx-web/schema/semantic-model.preview.json
@@ -1,0 +1,544 @@
+{
+  "version": "acx-1",
+  "entities": [
+    {
+      "name": "Activity",
+      "fields": [
+        {
+          "name": "activity_id",
+          "type": "string"
+        },
+        {
+          "name": "category",
+          "type": "string"
+        },
+        {
+          "name": "default_unit",
+          "type": "string",
+          "ref": "Unit"
+        },
+        {
+          "name": "description",
+          "type": "string"
+        },
+        {
+          "name": "layer_id",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "notes",
+          "type": "string"
+        },
+        {
+          "name": "sector_id",
+          "type": "string",
+          "ref": "Sector"
+        },
+        {
+          "name": "unit_definition",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "ActivitySchedule",
+      "fields": [
+        {
+          "name": "activity_id",
+          "type": "string",
+          "ref": "Activity"
+        },
+        {
+          "name": "distance_km",
+          "type": "number"
+        },
+        {
+          "name": "freq_per_day",
+          "type": "number"
+        },
+        {
+          "name": "freq_per_week",
+          "type": "number"
+        },
+        {
+          "name": "hours",
+          "type": "number"
+        },
+        {
+          "name": "layer_id",
+          "type": "string"
+        },
+        {
+          "name": "mix_region",
+          "type": "string"
+        },
+        {
+          "name": "office_days_only",
+          "type": "number"
+        },
+        {
+          "name": "office_only",
+          "type": "number"
+        },
+        {
+          "name": "passengers",
+          "type": "number"
+        },
+        {
+          "name": "profile_id",
+          "type": "string",
+          "ref": "Profile"
+        },
+        {
+          "name": "quantity_per_week",
+          "type": "number"
+        },
+        {
+          "name": "region_override",
+          "type": "string"
+        },
+        {
+          "name": "schedule_notes",
+          "type": "string"
+        },
+        {
+          "name": "sector_id",
+          "type": "string",
+          "ref": "Sector"
+        },
+        {
+          "name": "servings",
+          "type": "number"
+        },
+        {
+          "name": "use_canada_average",
+          "type": "number"
+        },
+        {
+          "name": "viewers",
+          "type": "number"
+        }
+      ]
+    },
+    {
+      "name": "Dataset",
+      "fields": [
+        {
+          "name": "dataset_id",
+          "type": "string"
+        },
+        {
+          "name": "figure_count",
+          "type": "number"
+        },
+        {
+          "name": "generated_at",
+          "type": "string"
+        },
+        {
+          "name": "layer_citation_keys",
+          "type": "json",
+          "list": false
+        },
+        {
+          "name": "layer_references",
+          "type": "json",
+          "list": false
+        },
+        {
+          "name": "manifest_path",
+          "type": "string"
+        },
+        {
+          "name": "manifest_sha256",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "EmissionFactor",
+      "fields": [
+        {
+          "name": "activity_id",
+          "type": "string",
+          "ref": "Activity"
+        },
+        {
+          "name": "ef_id",
+          "type": "string"
+        },
+        {
+          "name": "electricity_kwh_per_unit",
+          "type": "number"
+        },
+        {
+          "name": "electricity_kwh_per_unit_high",
+          "type": "number"
+        },
+        {
+          "name": "electricity_kwh_per_unit_low",
+          "type": "number"
+        },
+        {
+          "name": "gwp_horizon",
+          "type": "string"
+        },
+        {
+          "name": "is_grid_indexed",
+          "type": "number"
+        },
+        {
+          "name": "layer_id",
+          "type": "string"
+        },
+        {
+          "name": "method_notes",
+          "type": "string"
+        },
+        {
+          "name": "region",
+          "type": "string"
+        },
+        {
+          "name": "scope_boundary",
+          "type": "string"
+        },
+        {
+          "name": "sector_id",
+          "type": "string",
+          "ref": "Sector"
+        },
+        {
+          "name": "source_id",
+          "type": "string",
+          "ref": "Reference"
+        },
+        {
+          "name": "uncert_high_g_per_unit",
+          "type": "number"
+        },
+        {
+          "name": "uncert_low_g_per_unit",
+          "type": "number"
+        },
+        {
+          "name": "unit",
+          "type": "string",
+          "ref": "Unit"
+        },
+        {
+          "name": "value_g_per_unit",
+          "type": "number"
+        },
+        {
+          "name": "vintage_year",
+          "type": "number"
+        }
+      ]
+    },
+    {
+      "name": "GridIntensity",
+      "fields": [
+        {
+          "name": "g_per_kwh",
+          "type": "number"
+        },
+        {
+          "name": "g_per_kwh_high",
+          "type": "number"
+        },
+        {
+          "name": "g_per_kwh_low",
+          "type": "number"
+        },
+        {
+          "name": "gwp_horizon",
+          "type": "string"
+        },
+        {
+          "name": "region",
+          "type": "string"
+        },
+        {
+          "name": "region_code",
+          "type": "string"
+        },
+        {
+          "name": "scope_boundary",
+          "type": "string"
+        },
+        {
+          "name": "source_id",
+          "type": "string",
+          "ref": "Reference"
+        },
+        {
+          "name": "vintage_year",
+          "type": "number"
+        }
+      ]
+    },
+    {
+      "name": "Manifest",
+      "fields": [
+        {
+          "name": "dataset_manifest_path",
+          "type": "string"
+        },
+        {
+          "name": "dataset_manifest_sha256",
+          "type": "string"
+        },
+        {
+          "name": "figures",
+          "type": "json",
+          "list": true,
+          "ref": "ManifestEntry"
+        }
+      ]
+    },
+    {
+      "name": "ManifestEntry",
+      "fields": [
+        {
+          "name": "figure_id",
+          "type": "string"
+        },
+        {
+          "name": "figure_method",
+          "type": "string"
+        },
+        {
+          "name": "figures",
+          "type": "json",
+          "list": true
+        },
+        {
+          "name": "hash_prefix",
+          "type": "string"
+        },
+        {
+          "name": "manifests",
+          "type": "json",
+          "list": true
+        },
+        {
+          "name": "references",
+          "type": "json",
+          "list": true,
+          "ref": "Reference"
+        }
+      ]
+    },
+    {
+      "name": "Profile",
+      "fields": [
+        {
+          "name": "assumption_notes",
+          "type": "string"
+        },
+        {
+          "name": "cohort_id",
+          "type": "string"
+        },
+        {
+          "name": "grid_mix_json",
+          "type": "string"
+        },
+        {
+          "name": "grid_strategy",
+          "type": "string"
+        },
+        {
+          "name": "layer_id",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "office_days_per_week",
+          "type": "number"
+        },
+        {
+          "name": "profile_id",
+          "type": "string"
+        },
+        {
+          "name": "region_code_default",
+          "type": "string"
+        },
+        {
+          "name": "sector_id",
+          "type": "string",
+          "ref": "Sector"
+        }
+      ]
+    },
+    {
+      "name": "Reference",
+      "fields": [
+        {
+          "name": "ieee_citation",
+          "type": "string"
+        },
+        {
+          "name": "license",
+          "type": "string"
+        },
+        {
+          "name": "source_id",
+          "type": "string"
+        },
+        {
+          "name": "url",
+          "type": "string"
+        },
+        {
+          "name": "year",
+          "type": "number"
+        }
+      ]
+    },
+    {
+      "name": "Sector",
+      "fields": [
+        {
+          "name": "description",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "sector_id",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "Unit",
+      "fields": [
+        {
+          "name": "notes",
+          "type": "string"
+        },
+        {
+          "name": "si_conversion_factor",
+          "type": "number"
+        },
+        {
+          "name": "unit_code",
+          "type": "string"
+        },
+        {
+          "name": "unit_type",
+          "type": "string"
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {
+      "from": "Activity",
+      "to": "ActivitySchedule",
+      "via": "activity_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Activity",
+      "to": "EmissionFactor",
+      "via": "activity_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Dataset",
+      "to": "Reference",
+      "via": "layer_citation_keys",
+      "cardinality": "n:n"
+    },
+    {
+      "from": "Dataset",
+      "to": "Sector",
+      "via": "activities.sector_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Manifest",
+      "to": "Dataset",
+      "via": "dataset_manifest",
+      "cardinality": "1:1"
+    },
+    {
+      "from": "Manifest",
+      "to": "ManifestEntry",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Profile",
+      "to": "Activity",
+      "via": "ActivitySchedule",
+      "cardinality": "n:n"
+    },
+    {
+      "from": "Profile",
+      "to": "ActivitySchedule",
+      "via": "profile_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Reference",
+      "to": "EmissionFactor",
+      "via": "source_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Reference",
+      "to": "GridIntensity",
+      "via": "source_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Sector",
+      "to": "Activity",
+      "via": "sector_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Sector",
+      "to": "ActivitySchedule",
+      "via": "sector_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Sector",
+      "to": "EmissionFactor",
+      "via": "sector_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Sector",
+      "to": "Profile",
+      "via": "sector_id",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Unit",
+      "to": "Activity",
+      "via": "default_unit",
+      "cardinality": "1:n"
+    },
+    {
+      "from": "Unit",
+      "to": "EmissionFactor",
+      "via": "unit",
+      "cardinality": "1:n"
+    }
+  ]
+}

--- a/apps/carbon-acx-web/schema/semantic-model.ts
+++ b/apps/carbon-acx-web/schema/semantic-model.ts
@@ -1,0 +1,492 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export interface EntityField {
+  name: string;
+  type: string;
+  list?: boolean;
+  ref?: string;
+}
+
+export interface Entity {
+  name: string;
+  fields: EntityField[];
+}
+
+export interface Relation {
+  from: string;
+  to: string;
+  via?: string;
+  cardinality: '1:1' | '1:n' | 'n:n';
+}
+
+export interface SemanticModel {
+  version: 'acx-1';
+  entities: Entity[];
+  relations: Relation[];
+}
+
+type SqlType = 'string' | 'number' | 'boolean' | 'json' | 'unknown';
+
+interface TableColumn {
+  name: string;
+  type: SqlType;
+  originalType: string;
+}
+
+interface TableForeignKey {
+  columns: string[];
+  targetTable: string;
+  targetColumns: string[];
+}
+
+interface TableDefinition {
+  name: string;
+  columns: TableColumn[];
+  primaryKey: string[];
+  foreignKeys: TableForeignKey[];
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const schemaPath = path.join(repoRoot, 'db', 'schema.sql');
+const manifestIndexPath = path.join(repoRoot, 'dist', 'artifacts', 'manifest.json');
+
+const SQL_TYPE_MAP: Record<string, SqlType> = {
+  TEXT: 'string',
+  VARCHAR: 'string',
+  CHAR: 'string',
+  INTEGER: 'number',
+  INT: 'number',
+  REAL: 'number',
+  NUMERIC: 'number',
+  BOOLEAN: 'boolean',
+};
+
+const ENTITY_NAME_OVERRIDES: Record<string, string> = {
+  sources: 'Reference',
+  units: 'Unit',
+  sectors: 'Sector',
+  activities: 'Activity',
+  profiles: 'Profile',
+  emission_factors: 'EmissionFactor',
+  activity_schedule: 'ActivitySchedule',
+  grid_intensity: 'GridIntensity',
+};
+
+const primaryKeyMap: Record<string, string[]> = {};
+
+function toPascalCase(value: string): string {
+  return value
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join('');
+}
+
+function singularize(value: string): string {
+  if (value.endsWith('ies')) {
+    return value.slice(0, -3) + 'y';
+  }
+  if (value.endsWith('ses')) {
+    return value.slice(0, -2);
+  }
+  if (value.endsWith('s') && !value.endsWith('ss')) {
+    return value.slice(0, -1);
+  }
+  return value;
+}
+
+function normaliseEntityName(tableName: string): string {
+  if (ENTITY_NAME_OVERRIDES[tableName]) {
+    return ENTITY_NAME_OVERRIDES[tableName];
+  }
+  return toPascalCase(singularize(tableName));
+}
+
+function normaliseSqlType(rawType: string): SqlType {
+  const canonical = rawType.trim().toUpperCase();
+  for (const [key, value] of Object.entries(SQL_TYPE_MAP)) {
+    if (canonical.startsWith(key)) {
+      return value;
+    }
+  }
+  return 'unknown';
+}
+
+function splitSqlDefinitions(block: string): string[] {
+  const segments: string[] = [];
+  let buffer = '';
+  let depth = 0;
+  for (let i = 0; i < block.length; i += 1) {
+    const char = block[i];
+    if (char === '(') {
+      depth += 1;
+      buffer += char;
+      continue;
+    }
+    if (char === ')') {
+      depth = Math.max(0, depth - 1);
+      buffer += char;
+      continue;
+    }
+    if (char === ',' && depth === 0) {
+      const trimmed = buffer.trim();
+      if (trimmed) {
+        segments.push(trimmed);
+      }
+      buffer = '';
+      continue;
+    }
+    buffer += char;
+  }
+  const finalSegment = buffer.trim();
+  if (finalSegment) {
+    segments.push(finalSegment);
+  }
+  return segments;
+}
+
+function parseTableDefinitions(sql: string): TableDefinition[] {
+  const tables: TableDefinition[] = [];
+  const regex = /CREATE\s+TABLE\s+([A-Za-z0-9_]+)\s*\(([^;]+)\);/gi;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(sql)) !== null) {
+    const [, tableName, block] = match;
+    const entries = splitSqlDefinitions(block);
+    const columns: TableColumn[] = [];
+    const foreignKeys: TableForeignKey[] = [];
+    const primaryKey: string[] = [];
+
+    for (const entry of entries) {
+      const upper = entry.toUpperCase();
+      if (upper.startsWith('FOREIGN KEY')) {
+        const fkMatch = /FOREIGN\s+KEY\s*\(([^)]+)\)\s+REFERENCES\s+([A-Za-z0-9_]+)\s*\(([^)]+)\)/i.exec(entry);
+        if (fkMatch) {
+          const [, cols, target, targetCols] = fkMatch;
+          const columnsList = cols.split(',').map((col) => col.trim().replace(/"/g, ''));
+          const targetColumns = targetCols.split(',').map((col) => col.trim().replace(/"/g, ''));
+          foreignKeys.push({ columns: columnsList, targetTable: target.trim(), targetColumns });
+        }
+        continue;
+      }
+      if (upper.startsWith('PRIMARY KEY')) {
+        const pkMatch = /PRIMARY\s+KEY\s*\(([^)]+)\)/i.exec(entry);
+        if (pkMatch) {
+          const [, cols] = pkMatch;
+          const keys = cols.split(',').map((col) => col.trim().replace(/"/g, ''));
+          primaryKey.push(...keys);
+        }
+        continue;
+      }
+      if (upper.startsWith('CHECK') || upper.startsWith('CONSTRAINT')) {
+        continue;
+      }
+
+      const columnMatch = /"?([A-Za-z0-9_]+)"?\s+([A-Za-z0-9_]+)/.exec(entry);
+      if (!columnMatch) {
+        continue;
+      }
+      const [, columnName, columnType] = columnMatch;
+      const column: TableColumn = {
+        name: columnName,
+        type: normaliseSqlType(columnType),
+        originalType: columnType,
+      };
+      columns.push(column);
+
+      if (/PRIMARY\s+KEY/i.test(entry)) {
+        primaryKey.push(columnName);
+      }
+    }
+
+    tables.push({ name: tableName, columns, primaryKey, foreignKeys });
+  }
+  return tables;
+}
+
+function buildDatasetEntity(): { entity: Entity; relations: Relation[] } {
+  const datasetFields: EntityField[] = [
+    { name: 'dataset_id', type: 'string' },
+    { name: 'generated_at', type: 'string' },
+    { name: 'figure_count', type: 'number' },
+    { name: 'layer_citation_keys', type: 'json', list: false },
+    { name: 'layer_references', type: 'json', list: false },
+  ];
+
+  let manifestRelation: Relation | undefined;
+
+  if (existsSync(manifestIndexPath)) {
+    try {
+      const raw = readFileSync(manifestIndexPath, 'utf-8');
+      const payload = JSON.parse(raw) as Record<string, unknown>;
+      const datasetManifest = payload?.['dataset_manifest'];
+      if (datasetManifest && typeof datasetManifest === 'object') {
+        const pathValue = (datasetManifest as Record<string, unknown>)['path'];
+        const shaValue = (datasetManifest as Record<string, unknown>)['sha256'];
+        if (typeof pathValue === 'string') {
+          datasetFields.push({ name: 'manifest_path', type: 'string' });
+        }
+        if (typeof shaValue === 'string') {
+          datasetFields.push({ name: 'manifest_sha256', type: 'string' });
+        }
+        manifestRelation = {
+          from: 'Manifest',
+          to: 'Dataset',
+          via: 'dataset_manifest',
+          cardinality: '1:1',
+        };
+      }
+    } catch (error) {
+      // ignore malformed manifest index
+    }
+  }
+
+  const entity: Entity = {
+    name: 'Dataset',
+    fields: datasetFields,
+  };
+  primaryKeyMap[entity.name] = ['dataset_id'];
+
+  const relations = manifestRelation ? [manifestRelation] : [];
+  return { entity, relations };
+}
+
+function buildManifestEntity(): Entity | undefined {
+  if (!existsSync(manifestIndexPath)) {
+    return undefined;
+  }
+  try {
+    const raw = readFileSync(manifestIndexPath, 'utf-8');
+    const payload = JSON.parse(raw) as Record<string, unknown>;
+    const fields: EntityField[] = [];
+    const simpleStringFields: Array<{ key: string; name: string }> = [
+      { key: 'generated_at', name: 'generated_at' },
+      { key: 'build_hash', name: 'build_hash' },
+      { key: 'dataset_version', name: 'dataset_version' },
+    ];
+    for (const { key, name } of simpleStringFields) {
+      const value = payload[key];
+      if (typeof value === 'string' && value.trim().length > 0) {
+        fields.push({ name, type: 'string' });
+      }
+    }
+    if (typeof payload['hashed_preferred'] === 'boolean') {
+      fields.push({ name: 'hashed_preferred', type: 'boolean' });
+    }
+    const datasetManifest = payload['dataset_manifest'];
+    if (datasetManifest && typeof datasetManifest === 'object') {
+      const manifestObj = datasetManifest as Record<string, unknown>;
+      if (typeof manifestObj['path'] === 'string') {
+        fields.push({ name: 'dataset_manifest_path', type: 'string' });
+      }
+      if (typeof manifestObj['sha256'] === 'string') {
+        fields.push({ name: 'dataset_manifest_sha256', type: 'string' });
+      }
+    }
+    if (Array.isArray(payload['figures'])) {
+      fields.push({ name: 'figures', type: 'json', list: true, ref: 'ManifestEntry' });
+    }
+
+    if (fields.length === 0) {
+      return undefined;
+    }
+
+    const entity: Entity = {
+      name: 'Manifest',
+      fields,
+    };
+    primaryKeyMap[entity.name] = ['dataset_manifest_path'];
+    return entity;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+function buildManifestEntryEntity(): Entity | undefined {
+  if (!existsSync(manifestIndexPath)) {
+    return undefined;
+  }
+  try {
+    const raw = readFileSync(manifestIndexPath, 'utf-8');
+    const payload = JSON.parse(raw) as Record<string, unknown>;
+    const figures = payload['figures'];
+    if (!Array.isArray(figures) || figures.length === 0) {
+      return undefined;
+    }
+    const fields: EntityField[] = [
+      { name: 'figure_id', type: 'string' },
+      { name: 'figure_method', type: 'string' },
+      { name: 'hash_prefix', type: 'string' },
+      { name: 'manifests', type: 'json', list: true },
+      { name: 'figures', type: 'json', list: true },
+      { name: 'references', type: 'json', list: true, ref: 'Reference' },
+    ];
+    const entity: Entity = {
+      name: 'ManifestEntry',
+      fields,
+    };
+    primaryKeyMap[entity.name] = ['figure_id'];
+    return entity;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+function buildModel(): SemanticModel {
+  const entities: Entity[] = [];
+  const relations: Relation[] = [];
+
+  if (existsSync(schemaPath)) {
+    const sql = readFileSync(schemaPath, 'utf-8');
+    const tables = parseTableDefinitions(sql);
+    const entityNameMap = new Map<string, string>();
+
+    for (const table of tables) {
+      const entityName = normaliseEntityName(table.name);
+      entityNameMap.set(table.name, entityName);
+      const fields: EntityField[] = table.columns.map((column) => ({
+        name: column.name,
+        type: column.type,
+      }));
+
+      for (const fk of table.foreignKeys) {
+        for (const columnName of fk.columns) {
+          const field = fields.find((item) => item.name === columnName);
+          if (field) {
+            const refEntity = entityNameMap.get(fk.targetTable) ?? normaliseEntityName(fk.targetTable);
+            field.ref = refEntity;
+          }
+        }
+      }
+
+      entities.push({ name: entityName, fields });
+      if (table.primaryKey.length > 0) {
+        primaryKeyMap[entityName] = Array.from(new Set(table.primaryKey));
+      }
+    }
+
+    for (const table of tables) {
+      const sourceEntity = entityNameMap.get(table.name) ?? normaliseEntityName(table.name);
+      for (const fk of table.foreignKeys) {
+        const targetEntity = entityNameMap.get(fk.targetTable) ?? normaliseEntityName(fk.targetTable);
+        relations.push({
+          from: targetEntity,
+          to: sourceEntity,
+          via: fk.columns.join(', '),
+          cardinality: '1:n',
+        });
+      }
+
+      if (table.primaryKey.length >= 2) {
+        const pkSet = new Set(table.primaryKey);
+        const fkEntities = table.foreignKeys
+          .filter((fk) => fk.columns.every((col) => pkSet.has(col)))
+          .map((fk) => entityNameMap.get(fk.targetTable) ?? normaliseEntityName(fk.targetTable));
+        const uniqueFkEntities = Array.from(new Set(fkEntities));
+        if (uniqueFkEntities.length >= 2) {
+          for (let i = 0; i < uniqueFkEntities.length; i += 1) {
+            for (let j = i + 1; j < uniqueFkEntities.length; j += 1) {
+              relations.push({
+                from: uniqueFkEntities[i],
+                to: uniqueFkEntities[j],
+                via: sourceEntity,
+                cardinality: 'n:n',
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const manifestEntity = buildManifestEntity();
+  if (manifestEntity) {
+    entities.push(manifestEntity);
+  }
+  const manifestEntry = buildManifestEntryEntity();
+  if (manifestEntry) {
+    entities.push(manifestEntry);
+    relations.push({ from: 'Manifest', to: 'ManifestEntry', cardinality: '1:n' });
+  }
+
+  const { entity: datasetEntity, relations: datasetRelations } = buildDatasetEntity();
+  entities.push(datasetEntity);
+  relations.push(...datasetRelations);
+
+  const datasetToReference: Relation = {
+    from: 'Dataset',
+    to: 'Reference',
+    via: 'layer_citation_keys',
+    cardinality: 'n:n',
+  };
+  relations.push(datasetToReference);
+
+  const datasetToSector: Relation = {
+    from: 'Dataset',
+    to: 'Sector',
+    via: 'activities.sector_id',
+    cardinality: '1:n',
+  };
+  relations.push(datasetToSector);
+
+  const uniqueEntities = new Map<string, Entity>();
+  for (const entity of entities) {
+    const key = entity.name;
+    if (!uniqueEntities.has(key)) {
+      const sortedFields = [...entity.fields].sort((a, b) => a.name.localeCompare(b.name));
+      uniqueEntities.set(key, { name: entity.name, fields: sortedFields });
+    }
+  }
+
+  const uniqueRelations = new Map<string, Relation>();
+  for (const relation of relations) {
+    const key = `${relation.from}->${relation.to}:${relation.via ?? ''}:${relation.cardinality}`;
+    if (!uniqueRelations.has(key)) {
+      uniqueRelations.set(key, relation);
+    }
+  }
+
+  const sortedEntities = Array.from(uniqueEntities.values()).sort((a, b) => a.name.localeCompare(b.name));
+  const sortedRelations = Array.from(uniqueRelations.values()).sort((a, b) => {
+    if (a.from === b.from) {
+      return a.to.localeCompare(b.to);
+    }
+    return a.from.localeCompare(b.from);
+  });
+
+  return {
+    version: 'acx-1',
+    entities: sortedEntities,
+    relations: sortedRelations,
+  };
+}
+
+export const model: SemanticModel = buildModel();
+
+export function findEntity(name: string): Entity | undefined {
+  return model.entities.find((entity) => entity.name === name);
+}
+
+export function primaryKeyOf(entity: string | Entity): string[] {
+  const entityName = typeof entity === 'string' ? entity : entity.name;
+  return primaryKeyMap[entityName] ? [...primaryKeyMap[entityName]] : [];
+}
+
+function writePreview(output: SemanticModel): void {
+  const previewPath = path.join(__dirname, 'semantic-model.preview.json');
+  const payload = JSON.stringify(output, null, 2);
+  writeFileSync(previewPath, `${payload}\n`, 'utf-8');
+  const relativePath = path.relative(repoRoot, previewPath);
+  console.log(`semantic-model: wrote preview to ${relativePath}`);
+}
+
+const invokedDirectly = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href === import.meta.url
+  : false;
+
+if (invokedDirectly) {
+  writePreview(model);
+  console.log(JSON.stringify(model, null, 2));
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "carbon-acx-monorepo",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.5.2",
+  "engines": {
+    "node": "20.19.4",
+    "pnpm": "10.5.2"
+  },
+  "scripts": {
+    "schema:gen": "tsx apps/carbon-acx-web/schema/semantic-model.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,317 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      tsx:
+        specifier: ^4.16.2
+        version: 4.20.6
+
+packages:
+
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.12.0:
+    resolution: {integrity: sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
+    optional: true
+
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.12.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  resolve-pkg-maps@1.0.0: {}
+
+  tsx@4.20.6:
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.12.0
+    optionalDependencies:
+      fsevents: 2.3.3


### PR DESCRIPTION
## Summary
- add a TypeScript semantic-model generator that introspects the SQL schema and manifest artifacts and writes a preview export
- provide typed sample query helpers that load sectors, activities, datasets, and references from repository data artifacts
- configure a pnpm script with tsx to regenerate the semantic model snapshot

## Testing
- pnpm schema:gen
- pnpm tsx <<'EOF'
import { listSectors, getDataset, listReferences } from './apps/carbon-acx-web/schema/sample-queries.ts';

const sectors = await listSectors();
console.log('sectors', sectors.length, sectors[0]);

const dataset = await getDataset('DATASET.VALIDATOR.SAMPLE');
console.log('dataset', dataset);

const references = await listReferences('DATASET.VALIDATOR.SAMPLE');
console.log('references', references.length, references[0]);
EOF

------
https://chatgpt.com/codex/tasks/task_e_68e7113f281c832c957f856e8417e296