### PR TITLE
feat: add design system and dataset visualization

### DIFF
--- a/apps/carbon-acx-web/package.json
+++ b/apps/carbon-acx-web/package.json
@@ -9,15 +9,30 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-scroll-area": "^1.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.1",
+    "@radix-ui/react-tooltip": "^1.1.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.11.17",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "recharts": "^2.12.7",
+    "swr": "^2.3.3",
+    "tailwind-merge": "^2.5.3"
   },
   "devDependencies": {
     "@types/node": "^22.8.5",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
+    "@types/recharts": "^2.0.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
     "typescript": "~5.5.4",
     "vite": "^5.4.8"
   }

--- a/apps/carbon-acx-web/postcss.config.cjs
+++ b/apps/carbon-acx-web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/carbon-acx-web/src/components/charts/BubbleFigure.tsx
+++ b/apps/carbon-acx-web/src/components/charts/BubbleFigure.tsx
@@ -1,0 +1,134 @@
+import { useId, useMemo } from 'react';
+import { motion } from 'framer-motion';
+import {
+  CartesianGrid,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from 'recharts';
+
+import type { BubbleDatum, BubbleFigure as BubbleFigureType } from '../../lib/api';
+import { cn } from '../../lib/cn';
+
+interface BubbleFigureProps {
+  figure: BubbleFigureType;
+  className?: string;
+}
+
+export function BubbleFigure({ figure, className }: BubbleFigureProps) {
+  const chartId = useId();
+  const descriptionId = `${chartId}-description`;
+
+  const points = useMemo(() => figure.data.points ?? [], [figure.data.points]);
+
+  return (
+    <motion.section
+      aria-labelledby={`${chartId}-title`}
+      aria-describedby={descriptionId}
+      role="figure"
+      layout
+      initial={{ opacity: 0, scale: 0.98 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+      className={cn('flex h-full w-full flex-col gap-6', className)}
+    >
+      <header className="flex flex-col gap-2">
+        <div>
+          <h3 id={`${chartId}-title`} className="text-xl font-semibold text-foreground">
+            {figure.title}
+          </h3>
+          {figure.data.subtitle && (
+            <p className="text-sm text-text-secondary">{figure.data.subtitle}</p>
+          )}
+        </div>
+        {figure.description && (
+          <p className="text-sm text-text-muted max-w-prose">{figure.description}</p>
+        )}
+      </header>
+      <div className="relative flex-1 rounded-xl border border-border bg-surface/70 p-4 shadow-sm">
+        <span id={descriptionId} className="sr-only">
+          Bubble chart plotting {points.length} data points. Values are read as {figure.data.xAxis.label} on the x axis,
+          {figure.data.yAxis.label} on the y axis, with bubble size representing {figure.data.valueAxis.label}.
+        </span>
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart
+            margin={{ top: 16, right: 24, bottom: 40, left: 48 }}
+            role="img"
+            aria-label={`${figure.title} bubble chart`}
+          >
+            <CartesianGrid stroke="rgba(23,28,42,0.08)" strokeDasharray="4 4" />
+            <XAxis
+              dataKey="x"
+              name={figure.data.xAxis.label}
+              tickLine={false}
+              axisLine={false}
+              stroke="var(--text-muted)"
+              label={{ value: axisLabel(figure.data.xAxis), position: 'bottom', fill: 'var(--text-muted)' }}
+            />
+            <YAxis
+              dataKey="y"
+              name={figure.data.yAxis.label}
+              tickLine={false}
+              axisLine={false}
+              stroke="var(--text-muted)"
+              label={{ value: axisLabel(figure.data.yAxis), angle: -90, position: 'insideLeft', fill: 'var(--text-muted)' }}
+            />
+            <ZAxis dataKey="value" range={[80, 400]} name={figure.data.valueAxis.label} />
+            <RechartsTooltip content={<BubbleTooltip />} cursor={{ fill: 'rgba(53, 88, 255, 0.08)' }} />
+            <Scatter
+              name={figure.title}
+              data={points}
+              fill="var(--accent-500)"
+              fillOpacity={0.8}
+              shape="circle"
+              animationDuration={180}
+              animationEasing="ease-out"
+              isAnimationActive
+            />
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+      <dl className="grid gap-4 text-xs text-text-muted sm:grid-cols-3">
+        <div>
+          <dt className="font-medium text-text-secondary">X axis</dt>
+          <dd>{axisLabel(figure.data.xAxis)}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-text-secondary">Y axis</dt>
+          <dd>{axisLabel(figure.data.yAxis)}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-text-secondary">Bubble size</dt>
+          <dd>{axisLabel(figure.data.valueAxis)}</dd>
+        </div>
+      </dl>
+    </motion.section>
+  );
+}
+
+function axisLabel(axis: { label: string; unit?: string | null }) {
+  return axis.unit ? `${axis.label} (${axis.unit})` : axis.label;
+}
+
+function BubbleTooltip({ active, payload }: { active?: boolean; payload?: Array<{ value: unknown; payload: BubbleDatum }> }) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+  const datum = payload[0]?.payload;
+  if (!datum) {
+    return null;
+  }
+  return (
+    <div className="rounded-md border border-border bg-surface/95 px-3 py-2 text-xs text-text-secondary shadow-md">
+      <p className="font-semibold text-foreground">{datum.label}</p>
+      <p>X: {datum.x.toLocaleString()}</p>
+      <p>Y: {datum.y.toLocaleString()}</p>
+      <p>Value: {datum.value.toLocaleString()}</p>
+      {datum.description && <p className="mt-1 text-[0.7rem]">{datum.description}</p>}
+    </div>
+  );
+}

--- a/apps/carbon-acx-web/src/components/ui/button.tsx
+++ b/apps/carbon-acx-web/src/components/ui/button.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/cn';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-transparent bg-accent-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all duration-default ease-[var(--motion-ease)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-accent-500 text-white hover:bg-accent-600',
+        secondary:
+          'bg-surface text-foreground border-border shadow-sm hover:bg-neutral-50/80 dark:hover:bg-neutral-800/70',
+        ghost: 'bg-transparent text-foreground hover:bg-neutral-100/70 dark:hover:bg-neutral-800/70',
+        outline:
+          'bg-transparent border-border text-foreground hover:border-accent-400 hover:text-accent-500',
+      },
+      size: {
+        default: 'h-10 px-4 py-2 text-sm',
+        sm: 'h-9 px-3 text-sm',
+        lg: 'h-11 px-5 text-base',
+        icon: 'h-10 w-10 p-0',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  },
+);
+Button.displayName = 'Button';

--- a/apps/carbon-acx-web/src/components/ui/card.tsx
+++ b/apps/carbon-acx-web/src/components/ui/card.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/cn';
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'rounded-lg border border-border bg-surface/90 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-surface/80',
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = 'Card';
+
+export const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col gap-1.5 p-6', className)} {...props} />
+  ),
+);
+CardHeader.displayName = 'CardHeader';
+
+export const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-lg font-semibold leading-snug text-foreground', className)} {...props} />
+  ),
+);
+CardTitle.displayName = 'CardTitle';
+
+export const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn('text-sm text-text-secondary', className)} {...props} />
+));
+CardDescription.displayName = 'CardDescription';
+
+export const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0 text-sm text-text-secondary', className)} {...props} />
+  ),
+);
+CardContent.displayName = 'CardContent';
+
+export const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center gap-2 p-6 pt-0', className)} {...props} />
+  ),
+);
+CardFooter.displayName = 'CardFooter';

--- a/apps/carbon-acx-web/src/components/ui/dialog.tsx
+++ b/apps/carbon-acx-web/src/components/ui/dialog.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '../../lib/cn';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-40 bg-neutral-900/60 backdrop-blur-sm transition-opacity duration-default data-[state=open]:opacity-100 data-[state=closed]:opacity-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-xl -translate-x-1/2 -translate-y-1/2 scale-95 gap-4 rounded-xl border border-border bg-surface p-6 shadow-lg transition-transform transition-opacity duration-default ease-[var(--motion-ease)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface data-[state=open]:scale-100 data-[state=open]:opacity-100 data-[state=closed]:opacity-0',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full bg-neutral-900/10 p-1 text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface">
+        <span className="sr-only">Close</span>
+        ×
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col gap-2 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-snug text-foreground', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-text-muted', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+};

--- a/apps/carbon-acx-web/src/components/ui/scroll-area.tsx
+++ b/apps/carbon-acx-web/src/components/ui/scroll-area.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+
+import { cn } from '../../lib/cn';
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn('relative overflow-hidden', className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-md">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner className="bg-transparent" />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      'flex touch-none select-none bg-neutral-900/5 transition-colors hover:bg-neutral-900/10 data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2 data-[orientation=horizontal]:h-2 data-[orientation=horizontal]:w-full',
+      className,
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-neutral-500/40" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/apps/carbon-acx-web/src/components/ui/sheet.tsx
+++ b/apps/carbon-acx-web/src/components/ui/sheet.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '../../lib/cn';
+
+const Sheet = DialogPrimitive.Root;
+const SheetTrigger = DialogPrimitive.Trigger;
+const SheetClose = DialogPrimitive.Close;
+
+const SheetPortal = DialogPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-40 bg-neutral-900/60 backdrop-blur-sm transition-opacity duration-default data-[state=open]:opacity-100 data-[state=closed]:opacity-0',
+      className,
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-md translate-x-full flex-col gap-4 border-l border-border bg-surface p-6 shadow-lg transition-transform duration-default ease-[var(--motion-ease)] data-[state=open]:translate-x-0',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full bg-neutral-900/10 p-1 text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface">
+        <span className="sr-only">Close panel</span>
+        ×
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = DialogPrimitive.Content.displayName;
+
+export { Sheet, SheetTrigger, SheetClose, SheetContent, SheetPortal, SheetOverlay };

--- a/apps/carbon-acx-web/src/components/ui/skeleton.tsx
+++ b/apps/carbon-acx-web/src/components/ui/skeleton.tsx
@@ -3,5 +3,13 @@ import type { HTMLAttributes } from 'react';
 import { cn } from '../../lib/cn';
 
 export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('skeleton animate-pulse rounded-md', className)} {...props} />;
+  return (
+    <div
+      className={cn(
+        'h-4 w-full animate-pulse rounded-md bg-neutral-200/70 dark:bg-neutral-700/60',
+        className,
+      )}
+      {...props}
+    />
+  );
 }

--- a/apps/carbon-acx-web/src/components/ui/tabs.tsx
+++ b/apps/carbon-acx-web/src/components/ui/tabs.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '../../lib/cn';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex items-center gap-1 rounded-lg border border-border bg-surface/80 p-1 text-text-muted shadow-sm backdrop-blur supports-[backdrop-filter]:bg-surface/60',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex min-w-[120px] items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-text-muted transition-colors duration-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface data-[state=active]:bg-accent-500 data-[state=active]:text-white data-[state=active]:shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn('rounded-lg border border-border bg-surface/90 p-6 shadow-sm', className)}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/carbon-acx-web/src/components/ui/tooltip.tsx
+++ b/apps/carbon-acx-web/src/components/ui/tooltip.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+import { cn } from '../../lib/cn';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+const Tooltip = TooltipPrimitive.Root;
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 overflow-hidden rounded-md border border-border bg-neutral-900 px-3 py-2 text-xs font-medium text-white shadow-lg transition-opacity duration-default data-[state=open]:opacity-100 data-[state=closed]:opacity-0',
+      className,
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/carbon-acx-web/src/hooks/useDataset.ts
+++ b/apps/carbon-acx-web/src/hooks/useDataset.ts
@@ -1,0 +1,116 @@
+import useSWR, { type SWRConfiguration, type SWRResponse } from 'swr';
+
+import type {
+  ActivitySummary,
+  DatasetDetail,
+  DatasetFigure,
+  DatasetSummary,
+  ReferenceSummary,
+  SectorSummary,
+} from '../lib/api';
+import { loadActivities, loadDataset, loadDatasets, loadSectors } from '../lib/api';
+
+const defaultSWRConfig = {
+  revalidateOnFocus: false,
+  revalidateIfStale: false,
+} satisfies SWRConfiguration<unknown, Error>;
+
+type DatasetPayload = Awaited<ReturnType<typeof loadDataset>>;
+type DatasetKey = readonly ['dataset', string];
+type DatasetPayloadResponse = SWRResponse<DatasetPayload, Error>;
+type DatasetPayloadConfig = SWRConfiguration<DatasetPayload, Error>;
+
+type DerivedResponse<Data> = Omit<DatasetPayloadResponse, 'data'> & { data: Data };
+
+type DatasetSelectConfig<Data> = DatasetPayloadConfig & {
+  select?: (payload: DatasetPayload) => Data;
+};
+
+function useDatasetResource<Data>(datasetId: string | undefined, config?: DatasetSelectConfig<Data>) {
+  const key = datasetId ? (['dataset', datasetId] as DatasetKey) : null;
+  return useSWR<DatasetPayload, Error>(
+    key,
+    async ([, id]: DatasetKey) => loadDataset(id),
+    {
+      ...defaultSWRConfig,
+      keepPreviousData: true,
+      ...config,
+    },
+  );
+}
+
+export function useSectors(config?: SWRConfiguration<SectorSummary[], Error>) {
+  return useSWR<SectorSummary[], Error>(
+    ['sectors'],
+    () => loadSectors(),
+    {
+      ...defaultSWRConfig,
+      ...config,
+    },
+  );
+}
+
+export function useDatasets(config?: SWRConfiguration<DatasetSummary[], Error>) {
+  return useSWR<DatasetSummary[], Error>(
+    ['datasets'],
+    () => loadDatasets(),
+    {
+      ...defaultSWRConfig,
+      ...config,
+    },
+  );
+}
+
+export function useActivities(
+  sectorId: string | undefined,
+  config?: SWRConfiguration<ActivitySummary[], Error>,
+) {
+  const key = sectorId ? (['activities', sectorId] as const) : null;
+  return useSWR<ActivitySummary[], Error>(
+    key,
+    ([, id]: readonly ['activities', string]) => loadActivities(id),
+    {
+      ...defaultSWRConfig,
+      ...config,
+    },
+  );
+}
+
+export function useDataset(
+  datasetId: string | undefined,
+  config?: DatasetPayloadConfig,
+): DerivedResponse<DatasetDetail | undefined> {
+  const response = useDatasetResource(datasetId, config);
+  return {
+    ...response,
+    data: response.data?.dataset,
+  } as DerivedResponse<DatasetDetail | undefined>;
+}
+
+export function useDatasetFigures(
+  datasetId: string | undefined,
+  config?: DatasetPayloadConfig,
+): DerivedResponse<DatasetFigure[] | undefined> {
+  const response = useDatasetResource(datasetId, {
+    ...config,
+    select: (payload) => payload.dataset.figures,
+  });
+  return {
+    ...response,
+    data: response.data?.dataset.figures,
+  } as DerivedResponse<DatasetFigure[] | undefined>;
+}
+
+export function useReferences(
+  datasetId: string | undefined,
+  config?: DatasetPayloadConfig,
+): DerivedResponse<ReferenceSummary[] | undefined> {
+  const response = useDatasetResource(datasetId, {
+    ...config,
+    select: (payload) => payload.references,
+  });
+  return {
+    ...response,
+    data: response.data?.references,
+  } as DerivedResponse<ReferenceSummary[] | undefined>;
+}

--- a/apps/carbon-acx-web/src/hooks/useDataset.ts
+++ b/apps/carbon-acx-web/src/hooks/useDataset.ts
@@ -22,11 +22,7 @@ type DatasetPayloadConfig = SWRConfiguration<DatasetPayload, Error>;
 
 type DerivedResponse<Data> = Omit<DatasetPayloadResponse, 'data'> & { data: Data };
 
-type DatasetSelectConfig<Data> = DatasetPayloadConfig & {
-  select?: (payload: DatasetPayload) => Data;
-};
-
-function useDatasetResource<Data>(datasetId: string | undefined, config?: DatasetSelectConfig<Data>) {
+function useDatasetResource(datasetId: string | undefined, config?: DatasetPayloadConfig) {
   const key = datasetId ? (['dataset', datasetId] as DatasetKey) : null;
   return useSWR<DatasetPayload, Error>(
     key,
@@ -91,10 +87,7 @@ export function useDatasetFigures(
   datasetId: string | undefined,
   config?: DatasetPayloadConfig,
 ): DerivedResponse<DatasetFigure[] | undefined> {
-  const response = useDatasetResource(datasetId, {
-    ...config,
-    select: (payload) => payload.dataset.figures,
-  });
+  const response = useDatasetResource(datasetId, config);
   return {
     ...response,
     data: response.data?.dataset.figures,
@@ -105,10 +98,7 @@ export function useReferences(
   datasetId: string | undefined,
   config?: DatasetPayloadConfig,
 ): DerivedResponse<ReferenceSummary[] | undefined> {
-  const response = useDatasetResource(datasetId, {
-    ...config,
-    select: (payload) => payload.references,
-  });
+  const response = useDatasetResource(datasetId, config);
   return {
     ...response,
     data: response.data?.references,

--- a/apps/carbon-acx-web/src/index.css
+++ b/apps/carbon-acx-web/src/index.css
@@ -1,65 +1,57 @@
-:root {
-  color-scheme: light;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-  --color-background: #f7f7f9;
-  --color-surface: #ffffff;
-  --color-muted: #f0f1f4;
-  --color-border: #d7d8de;
-  --color-text: #1e1f24;
-  --color-text-muted: #5b5d66;
-  --color-accent: #124dff;
-  --shadow-elevated: 0 20px 45px -20px rgba(18, 77, 255, 0.3);
-}
+@import './styles/tokens.css';
 
-* {
-  box-sizing: border-box;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-body {
-  margin: 0;
-  background: var(--color-background);
-  color: var(--color-text);
-  min-height: 100vh;
-}
-
-a {
-  color: var(--color-accent);
-}
-
-#root {
-  min-height: 100vh;
-}
-
-.error-view {
-  padding: 2rem;
-}
-
-.error-view h1 {
-  margin-top: 0;
-}
-
-.skeleton {
-  background: var(--color-muted);
-}
-
-.rounded-md {
-  border-radius: 0.75rem;
-}
-
-.animate-pulse {
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0% {
-    opacity: 0.6;
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
   }
-  50% {
-    opacity: 1;
+
+  html {
+    font-family: var(--font-sans);
+    background-color: var(--surface-background);
+    color: var(--text-primary);
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
   }
-  100% {
-    opacity: 0.6;
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--surface-background);
+    color: var(--text-primary);
+  }
+
+  :focus-visible {
+    outline: none;
+  }
+
+  :focus-visible:not(.focus-ring-off) {
+    box-shadow: 0 0 0 2px var(--surface-background), 0 0 0 4px var(--focus-color);
+    border-radius: inherit;
+  }
+
+  a {
+    color: var(--accent-500);
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  ::selection {
+    background: var(--accent-200);
+    color: var(--text-primary);
+  }
+}
+
+@layer utilities {
+  .focus-outline {
+    @apply focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface;
   }
 }

--- a/apps/carbon-acx-web/src/lib/api.ts
+++ b/apps/carbon-acx-web/src/lib/api.ts
@@ -22,6 +22,48 @@ export interface DatasetSummary {
   manifestSha256: string | null;
 }
 
+export interface BubbleDatum {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  value: number;
+  color?: string | null;
+  description?: string | null;
+}
+
+export interface BubbleFigureData {
+  id: string;
+  title: string;
+  subtitle?: string | null;
+  description?: string | null;
+  xAxis: { label: string; unit?: string | null };
+  yAxis: { label: string; unit?: string | null };
+  valueAxis: { label: string; unit?: string | null };
+  points: BubbleDatum[];
+}
+
+interface DatasetFigureBase {
+  figureId: string;
+  title: string;
+  description?: string | null;
+  figureType: string;
+  data: unknown;
+}
+
+export interface BubbleFigure extends DatasetFigureBase {
+  figureType: 'bubble';
+  data: BubbleFigureData;
+}
+
+export type DatasetFigure = DatasetFigureBase | BubbleFigure;
+
+export interface DatasetDetail extends DatasetSummary {
+  title: string | null;
+  description: string | null;
+  figures: DatasetFigure[];
+}
+
 export interface ReferenceSummary {
   referenceId: string;
   text: string;
@@ -47,6 +89,10 @@ export function loadDatasets(): Promise<DatasetSummary[]> {
   return fetchJson<{ datasets: DatasetSummary[] }>('/api/datasets').then((data) => data.datasets);
 }
 
+export function loadActivities(sectorId: string): Promise<ActivitySummary[]> {
+  return loadSector(sectorId).then((data) => data.activities);
+}
+
 export function loadSector(sectorId: string): Promise<{
   sector: SectorSummary;
   activities: ActivitySummary[];
@@ -56,11 +102,176 @@ export function loadSector(sectorId: string): Promise<{
   );
 }
 
+function normaliseString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function normaliseNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = typeof value === 'string' ? Number(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normaliseBubbleDatum(raw: unknown, fallbackId: number): BubbleDatum | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const record = raw as Record<string, unknown>;
+  const id = normaliseString(record['id']) ?? `${fallbackId}`;
+  const label = normaliseString(record['label']) ?? id;
+  const x = normaliseNumber(record['x']);
+  const y = normaliseNumber(record['y']);
+  const value = normaliseNumber(record['value']);
+  if (x == null || y == null || value == null) {
+    return null;
+  }
+  return {
+    id,
+    label,
+    x,
+    y,
+    value,
+    color: normaliseString(record['color']),
+    description: normaliseString(record['description']),
+  };
+}
+
+function normaliseBubbleFigure(raw: unknown, base: DatasetFigureBase): BubbleFigure | DatasetFigureBase {
+  if (!raw || typeof raw !== 'object') {
+    return base;
+  }
+  const record = raw as Record<string, unknown>;
+  const pointsValue = record['points'] ?? record['data'];
+  if (!Array.isArray(pointsValue)) {
+    return base;
+  }
+  const points = pointsValue
+    .map((entry, index) => normaliseBubbleDatum(entry, index))
+    .filter((value): value is BubbleDatum => Boolean(value));
+
+  if (points.length === 0) {
+    return base;
+  }
+
+  const axis = (value: unknown, fallback: string) => {
+    if (!value || typeof value !== 'object') {
+      return { label: fallback, unit: null };
+    }
+    const data = value as Record<string, unknown>;
+    return {
+      label: normaliseString(data['label']) ?? fallback,
+      unit: normaliseString(data['unit']),
+    };
+  };
+
+  const xAxis = axis(record['xAxis'] ?? record['x_axis'], 'X value');
+  const yAxis = axis(record['yAxis'] ?? record['y_axis'], 'Y value');
+  const valueAxis = axis(record['valueAxis'] ?? record['value_axis'], 'Bubble size');
+
+  return {
+    ...base,
+    figureType: 'bubble',
+    data: {
+      id: base.figureId,
+      title: base.title,
+      subtitle: normaliseString(record['subtitle']),
+      description: base.description ?? normaliseString(record['description']),
+      xAxis,
+      yAxis,
+      valueAxis,
+      points,
+    },
+  };
+}
+
+function normaliseFigures(raw: unknown): DatasetFigure[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const value = entry as Record<string, unknown>;
+      const figureId = normaliseString(value['id']) ?? normaliseString(value['figure_id']);
+      const title = normaliseString(value['title']) ?? 'Untitled figure';
+      if (!figureId) {
+        return null;
+      }
+      const base: DatasetFigureBase = {
+        figureId,
+        title,
+        description: normaliseString(value['description']),
+        figureType: (normaliseString(value['type']) ?? normaliseString(value['figure_type']) ?? 'unknown').toLowerCase(),
+        data: value['data'] ?? null,
+      };
+      if (base.figureType.includes('bubble')) {
+        return normaliseBubbleFigure(value['data'], base);
+      }
+      return base;
+    })
+    .filter((value): value is DatasetFigure => Boolean(value));
+}
+
+function normaliseDatasetDetail(raw: unknown): DatasetDetail {
+  const record = (raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}) ?? {};
+  const datasetId =
+    normaliseString(record['datasetId']) ??
+    normaliseString(record['dataset_id']) ??
+    normaliseString(record['id']) ??
+    '';
+  const generatedAt = normaliseString(record['generatedAt']) ?? normaliseString(record['generated_at']);
+  const figureCount = normaliseNumber(record['figureCount']) ?? normaliseNumber(record['figure_count']);
+  const manifestPath = normaliseString(record['manifestPath']) ?? normaliseString(record['manifest_path']);
+  const manifestSha256 =
+    normaliseString(record['manifestSha256']) ?? normaliseString(record['manifest_sha256']);
+
+  const detail: DatasetDetail = {
+    datasetId,
+    generatedAt,
+    figureCount,
+    manifestPath,
+    manifestSha256,
+    title: normaliseString(record['title']) ?? normaliseString(record['name']),
+    description: normaliseString(record['description']),
+    figures: normaliseFigures(record['figures']),
+  };
+
+  return detail;
+}
+
+function normaliseReference(raw: unknown): ReferenceSummary {
+  if (!raw || typeof raw !== 'object') {
+    return {
+      referenceId: 'unknown',
+      text: 'Unknown reference',
+    };
+  }
+  const value = raw as Record<string, unknown>;
+  const referenceId = normaliseString(value['referenceId']) ?? normaliseString(value['id']) ?? 'unknown';
+  return {
+    referenceId,
+    text: normaliseString(value['text']) ?? referenceId,
+    citation: normaliseString(value['citation']),
+    url: normaliseString(value['url']),
+    year: normaliseNumber(value['year']),
+    layer: normaliseString(value['layer']) ?? undefined,
+  };
+}
+
 export function loadDataset(datasetId: string): Promise<{
-  dataset: DatasetSummary;
+  dataset: DatasetDetail;
   references: ReferenceSummary[];
 }> {
-  return fetchJson<{ dataset: DatasetSummary; references: ReferenceSummary[] }>(
+  return fetchJson<{ dataset: unknown; references: ReferenceSummary[] }>(
     `/api/datasets/${encodeURIComponent(datasetId)}`,
-  );
+  ).then((payload) => ({
+    dataset: normaliseDatasetDetail(payload.dataset),
+    references: Array.isArray(payload.references)
+      ? payload.references.map(normaliseReference)
+      : [],
+  }));
 }

--- a/apps/carbon-acx-web/src/lib/cn.ts
+++ b/apps/carbon-acx-web/src/lib/cn.ts
@@ -1,3 +1,6 @@
-export function cn(...values: Array<string | null | false | undefined>): string {
-  return values.filter(Boolean).join(' ');
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
 }

--- a/apps/carbon-acx-web/src/lib/theme.ts
+++ b/apps/carbon-acx-web/src/lib/theme.ts
@@ -1,0 +1,53 @@
+export const theme = {
+  colors: {
+    neutral: {
+      50: '#f5f6f9',
+      100: '#eceef3',
+      200: '#d9dce5',
+      300: '#c4c9d6',
+      400: '#9aa1b5',
+      500: '#6f7794',
+      600: '#4c5470',
+      700: '#363d54',
+      800: '#222838',
+      900: '#141924',
+    },
+    accent: {
+      primary: '#3558ff',
+      secondary: '#00b3a4',
+      tertiary: '#f97316',
+      quaternary: '#8b5cf6',
+      success: '#27ae60',
+      warning: '#f39c12',
+      danger: '#e74c3c',
+    },
+  },
+  spacing: {
+    xs: '0.25rem',
+    sm: '0.5rem',
+    md: '0.75rem',
+    lg: '1rem',
+    xl: '1.5rem',
+    xxl: '2rem',
+  },
+  radius: {
+    base: '0.5rem',
+    md: '0.75rem',
+    lg: '1rem',
+    xl: '1.5rem',
+    full: '9999px',
+  },
+  shadows: {
+    sm: '0 1px 2px 0 rgba(12, 21, 42, 0.08)',
+    md: '0 6px 18px -8px rgba(12, 21, 42, 0.16)',
+    lg: '0 24px 48px -24px rgba(12, 21, 42, 0.24)',
+  },
+  motion: {
+    duration: '180ms',
+    durationFast: '120ms',
+    durationSlow: '280ms',
+    easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+  },
+} as const;
+
+export type Theme = typeof theme;

--- a/apps/carbon-acx-web/src/styles/layout.css
+++ b/apps/carbon-acx-web/src/styles/layout.css
@@ -1,65 +1,96 @@
 .app-layout {
   display: grid;
-  grid-template-columns: 280px minmax(0, 1fr) 320px;
-  gap: 1.5rem;
-  padding: 1.5rem;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-lg);
+  padding: var(--space-lg);
   min-height: 100vh;
+}
+
+@media (min-width: 1024px) {
+  .app-layout {
+    grid-template-columns: 320px minmax(0, 1fr) 360px;
+  }
 }
 
 .app-layout__nav,
 .app-layout__main,
 .app-layout__inspect {
-  background: var(--color-surface);
-  border-radius: 1.25rem;
-  border: 1px solid var(--color-border);
-  padding: 1.5rem;
-  overflow: hidden;
+  background: var(--surface-elevated);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-default);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(18px);
 }
 
 .app-layout__nav {
   display: flex;
   flex-direction: column;
+  gap: var(--space-md);
 }
 
 .app-layout__main {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--space-lg);
 }
 
 .app-layout__inspect {
   display: flex;
   flex-direction: column;
   position: sticky;
-  top: 1.5rem;
-  max-height: calc(100vh - 3rem);
-  box-shadow: var(--shadow-elevated);
-  transition: transform 0.3s ease;
+  top: var(--space-lg);
+  max-height: calc(100vh - (var(--space-lg) * 2));
+  transition: transform var(--motion-duration) var(--motion-ease);
+}
+
+.app-layout__inspect[data-open='false'] {
+  transform: translateX(100%);
+}
+
+@media (min-width: 1024px) {
+  .app-layout__inspect[data-open='false'] {
+    transform: translateX(0);
+  }
 }
 
 .app-layout__inspect-trigger {
-  display: none;
+  position: fixed;
+  bottom: var(--space-lg);
+  right: var(--space-lg);
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: var(--surface-default);
+  padding: 0.75rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-md);
+}
+
+@media (min-width: 1024px) {
+  .app-layout__inspect-trigger {
+    display: none;
+  }
 }
 
 .nav-sidebar__search {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-bottom: 1rem;
 }
 
 .nav-sidebar__search label {
   font-weight: 600;
   font-size: 0.875rem;
-  color: var(--color-text-muted);
+  color: var(--text-muted);
 }
 
 .nav-sidebar__search input {
   border-radius: 999px;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--border-default);
   padding: 0.75rem 1rem;
   font-size: 1rem;
-  background: var(--color-background);
+  background: var(--surface-background);
 }
 
 .nav-sidebar__list {
@@ -69,7 +100,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  overflow-y: auto;
 }
 
 .nav-sidebar__item {
@@ -77,20 +107,22 @@
   flex-direction: column;
   gap: 0.25rem;
   padding: 0.75rem 1rem;
-  border-radius: 1rem;
+  border-radius: var(--radius-lg);
   border: 1px solid transparent;
   text-decoration: none;
   color: inherit;
-  transition: background 0.2s ease, border 0.2s ease;
+  transition: background var(--motion-duration) var(--motion-ease),
+    border-color var(--motion-duration) var(--motion-ease);
 }
 
-.nav-sidebar__item:hover {
-  background: var(--color-muted);
+.nav-sidebar__item:hover,
+.nav-sidebar__item:focus-visible {
+  background: rgba(53, 88, 255, 0.12);
 }
 
 .nav-sidebar__item--active {
-  border-color: var(--color-accent);
-  background: rgba(18, 77, 255, 0.08);
+  border-color: rgba(53, 88, 255, 0.35);
+  background: rgba(53, 88, 255, 0.08);
 }
 
 .nav-sidebar__name {
@@ -99,17 +131,19 @@
 
 .nav-sidebar__meta,
 .nav-sidebar__empty {
-  color: var(--color-text-muted);
+  color: var(--text-muted);
   font-size: 0.875rem;
 }
 
-.scope-selector {
+.scope-selector,
+.profile-picker {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.scope-selector__header {
+.scope-selector__header,
+.profile-picker__header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
@@ -119,31 +153,18 @@
 .scope-selector__sector {
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
-  background: rgba(18, 77, 255, 0.1);
-  color: var(--color-accent);
+  background: rgba(53, 88, 255, 0.16);
+  color: var(--accent-500);
   font-weight: 600;
 }
 
 .scope-selector__description {
-  color: var(--color-text-muted);
+  color: var(--text-muted);
   font-size: 0.95rem;
 }
 
-.profile-picker {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.profile-picker__header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
 .profile-picker__count {
-  color: var(--color-text-muted);
+  color: var(--text-muted);
   font-size: 0.875rem;
   font-weight: 500;
 }
@@ -157,45 +178,14 @@
 .profile-picker__option {
   padding: 0.5rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid var(--color-border);
-  background: var(--color-background);
+  border: 1px solid var(--border-default);
+  background: var(--surface-background);
   font-size: 0.875rem;
 }
 
 .profile-picker__empty {
-  color: var(--color-text-muted);
+  color: var(--text-muted);
   font-size: 0.9rem;
-}
-
-.visualization-canvas {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  flex: 1;
-}
-
-.visualization-canvas__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.visualization-canvas__content {
-  flex: 1;
-  border-radius: 1rem;
-  border: 1px dashed var(--color-border);
-  background: var(--color-background);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 18rem;
-  padding: 1rem;
-}
-
-.visualization-canvas__empty {
-  text-align: center;
-  color: var(--color-text-muted);
 }
 
 .home-view,
@@ -209,9 +199,9 @@
 .sector-view__dataset {
   margin-top: 0.75rem;
   padding: 1rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(18, 77, 255, 0.15);
-  background: rgba(18, 77, 255, 0.05);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(53, 88, 255, 0.18);
+  background: rgba(53, 88, 255, 0.08);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -221,8 +211,8 @@
   align-self: flex-start;
   border-radius: 999px;
   padding: 0.6rem 1.25rem;
-  border: 1px solid var(--color-accent);
-  color: var(--color-accent);
+  border: 1px solid var(--accent-500);
+  color: var(--accent-500);
   font-weight: 600;
   text-decoration: none;
   transition: background 0.2s ease, color 0.2s ease;
@@ -230,62 +220,54 @@
 
 .sector-view__cta:hover,
 .sector-view__cta:focus-visible {
-  background: var(--color-accent);
+  background: var(--accent-500);
   color: #fff;
 }
 
 .home-view {
   text-align: center;
-  color: var(--color-text-muted);
+  color: var(--text-muted);
 }
 
 .home-view__dataset {
   margin: 1.5rem auto 0;
   padding: 1.25rem;
-  border-radius: 1rem;
-  border: 1px dashed var(--color-border);
-  background: rgba(18, 77, 255, 0.06);
+  border-radius: var(--radius-lg);
+  border: 1px dashed var(--border-default);
+  background: rgba(53, 88, 255, 0.08);
   max-width: 24rem;
-  color: var(--color-text);
+  color: var(--text-primary);
 }
 
 .reference-panel {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-md);
   height: 100%;
 }
 
 .reference-panel__header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
-}
-
-.reference-panel__toggle {
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  padding: 0.5rem 1rem;
-  background: var(--color-background);
-  font-size: 0.875rem;
-  display: none;
+  gap: var(--space-sm);
 }
 
 .reference-panel__list {
   list-style: decimal inside;
   margin: 0;
   padding: 0;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-md);
 }
 
 .reference-panel__item {
-  background: rgba(18, 77, 255, 0.05);
+  background: rgba(53, 88, 255, 0.08);
   padding: 1rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(18, 77, 255, 0.12);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(53, 88, 255, 0.16);
+  box-shadow: var(--shadow-sm);
 }
 
 .reference-panel__item p {
@@ -293,11 +275,11 @@
 }
 
 .reference-panel__meta {
-  margin: 0.75rem 0 0;
+  margin-top: 0.75rem;
   display: grid;
   gap: 0.5rem;
   font-size: 0.875rem;
-  color: var(--color-text-muted);
+  color: var(--text-muted);
 }
 
 .reference-panel__meta dt {
@@ -309,85 +291,7 @@
 }
 
 .reference-panel__empty {
-  color: var(--color-text-muted);
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
-@media (max-width: 1200px) {
-  .app-layout {
-    grid-template-columns: 240px minmax(0, 1fr) 280px;
-  }
-}
-
-@media (max-width: 960px) {
-  .app-layout {
-    grid-template-columns: 220px minmax(0, 1fr);
-    grid-template-areas:
-      'nav main'
-      'nav inspect';
-  }
-
-  .app-layout__nav {
-    grid-area: nav;
-  }
-
-  .app-layout__main {
-    grid-area: main;
-  }
-
-  .app-layout__inspect {
-    grid-area: inspect;
-  }
-}
-
-@media (max-width: 768px) {
-  .app-layout {
-    grid-template-columns: 1fr;
-    padding: 1rem;
-    gap: 1rem;
-  }
-
-  .app-layout__nav,
-  .app-layout__main {
-    padding: 1rem;
-  }
-
-  .app-layout__inspect {
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    margin: 0 auto;
-    max-height: 60vh;
-    transform: translateY(calc(100% - 3.5rem));
-    border-radius: 1.5rem 1.5rem 0 0;
-    box-shadow: var(--shadow-elevated);
-    padding: 1.25rem;
-    z-index: 20;
-  }
-
-  .app-layout__inspect[data-open='true'] {
-    transform: translateY(0);
-  }
-
-  .app-layout__inspect-trigger {
-    position: fixed;
-    bottom: 0.5rem;
-    right: 1rem;
-    border-radius: 999px;
-    padding: 0.75rem 1.25rem;
-    border: none;
-    background: var(--color-accent);
-    color: #fff;
-    font-weight: 600;
-    box-shadow: var(--shadow-elevated);
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    z-index: 30;
-  }
-
-  .reference-panel__toggle {
-    display: inline-flex;
-  }
-}

--- a/apps/carbon-acx-web/src/styles/tokens.css
+++ b/apps/carbon-acx-web/src/styles/tokens.css
@@ -1,0 +1,120 @@
+:root {
+  color-scheme: light;
+  --font-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, monospace;
+
+  --surface-background: #f4f6fb;
+  --surface-default: #ffffff;
+  --surface-muted: rgba(255, 255, 255, 0.72);
+  --surface-elevated: rgba(255, 255, 255, 0.92);
+
+  --border-default: rgba(20, 25, 36, 0.12);
+  --border-strong: rgba(20, 25, 36, 0.24);
+
+  --text-primary: #171c2a;
+  --text-secondary: rgba(23, 28, 42, 0.68);
+  --text-muted: rgba(23, 28, 42, 0.52);
+
+  --accent-50: #eef2ff;
+  --accent-100: #dbe4ff;
+  --accent-200: #bac7ff;
+  --accent-300: #91a2ff;
+  --accent-400: #5f76ff;
+  --accent-500: #3558ff;
+  --accent-600: #2646d6;
+  --accent-700: #1c35ad;
+  --accent-800: #182c8c;
+  --accent-900: #152472;
+
+  --neutral-50: #f5f6f9;
+  --neutral-100: #eceef3;
+  --neutral-200: #d9dce5;
+  --neutral-300: #c4c9d6;
+  --neutral-400: #9aa1b5;
+  --neutral-500: #6f7794;
+  --neutral-600: #4c5470;
+  --neutral-700: #363d54;
+  --neutral-800: #222838;
+  --neutral-900: #141924;
+
+  --accent-success: #27ae60;
+  --accent-warning: #f39c12;
+  --accent-danger: #e74c3c;
+
+  --focus-color: rgba(53, 88, 255, 0.72);
+  --focus-ring: rgba(53, 88, 255, 0.24);
+
+  --shadow-sm: 0 1px 2px 0 rgba(12, 21, 42, 0.08);
+  --shadow-md: 0 12px 24px -16px rgba(12, 21, 42, 0.24);
+  --shadow-lg: 0 32px 64px -32px rgba(12, 21, 42, 0.32);
+
+  --radius-base: 0.625rem;
+  --radius-md: 0.875rem;
+  --radius-lg: 1.25rem;
+  --radius-xl: 1.75rem;
+
+  --space-xs: 0.375rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+
+  --motion-duration-fast: 120ms;
+  --motion-duration: 180ms;
+  --motion-duration-slow: 280ms;
+  --motion-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-theme='dark'] {
+  color-scheme: dark;
+  --surface-background: #0c121f;
+  --surface-default: #121a2b;
+  --surface-muted: rgba(18, 26, 43, 0.72);
+  --surface-elevated: rgba(18, 26, 43, 0.92);
+
+  --border-default: rgba(229, 235, 255, 0.12);
+  --border-strong: rgba(229, 235, 255, 0.32);
+
+  --text-primary: #eef2ff;
+  --text-secondary: rgba(238, 242, 255, 0.76);
+  --text-muted: rgba(238, 242, 255, 0.56);
+
+  --accent-50: #1c2346;
+  --accent-100: #28306a;
+  --accent-200: #33408f;
+  --accent-300: #3f4fb3;
+  --accent-400: #4b5fd6;
+  --accent-500: #5f76ff;
+  --accent-600: #93a4ff;
+  --accent-700: #bac7ff;
+  --accent-800: #dbe4ff;
+  --accent-900: #eef2ff;
+
+  --neutral-50: #131827;
+  --neutral-100: #1a2234;
+  --neutral-200: #252f44;
+  --neutral-300: #313c55;
+  --neutral-400: #3f4b67;
+  --neutral-500: #50607e;
+  --neutral-600: #667796;
+  --neutral-700: #8394b5;
+  --neutral-800: #a9b8d1;
+  --neutral-900: #d5dff0;
+
+  --focus-color: rgba(149, 172, 255, 0.8);
+  --focus-ring: rgba(69, 105, 255, 0.4);
+
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.28);
+  --shadow-md: 0 18px 32px -18px rgba(0, 0, 0, 0.48);
+  --shadow-lg: 0 36px 72px -32px rgba(0, 0, 0, 0.56);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-duration-fast: 1ms;
+    --motion-duration: 1ms;
+    --motion-duration-slow: 1ms;
+    --motion-ease: linear;
+  }
+}

--- a/apps/carbon-acx-web/src/views/DatasetView.tsx
+++ b/apps/carbon-acx-web/src/views/DatasetView.tsx
@@ -1,11 +1,14 @@
 import { Suspense } from 'react';
 import { Await, useLoaderData, useParams } from 'react-router-dom';
 
-import type { DatasetSummary, ReferenceSummary } from '../lib/api';
+import type { DatasetDetail, ReferenceSummary } from '../lib/api';
+import VisualizationCanvas, { CanvasSkeleton } from './VisualizationCanvas';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Skeleton } from '../components/ui/skeleton';
+import { useDataset, useReferences } from '../hooks/useDataset';
 
 interface DatasetLoaderData {
-  dataset: Promise<DatasetSummary>;
+  dataset: Promise<DatasetDetail>;
   references: Promise<ReferenceSummary[]>;
 }
 
@@ -13,45 +16,131 @@ export default function DatasetView() {
   const data = useLoaderData() as DatasetLoaderData;
   const params = useParams();
 
+  if (!params.datasetId) {
+    return (
+      <div className="flex flex-col gap-6">
+        <VisualizationCanvas isLoading />
+      </div>
+    );
+  }
+
   return (
     <Suspense fallback={<DatasetSkeleton />}>
       <Await resolve={Promise.all([data.dataset, data.references])}>
         {([dataset, references]) => (
-          <div className="dataset-view">
-            <h3>{dataset.datasetId}</h3>
-            <p>
-              Loaded for sector <strong>{params.sectorId}</strong>. Generated at{' '}
-              {dataset.generatedAt ?? 'unknown time'} with {dataset.figureCount ?? 0} figures.
-            </p>
-            {dataset.manifestPath && (
-              <p>
-                Manifest available at <code>{dataset.manifestPath}</code>
-                {dataset.manifestSha256 && (
-                  <>
-                    {' '}
-                    (sha256: <code>{dataset.manifestSha256}</code>)
-                  </>
-                )}
-              </p>
-            )}
-            <p>
-              {references.length > 0
-                ? 'References are available in the inspector panel.'
-                : 'No references provided for this dataset.'}
-            </p>
-          </div>
+          <DatasetContent
+            datasetId={params.datasetId!}
+            fallbackDataset={dataset}
+            fallbackReferences={references}
+            sectorId={params.sectorId}
+          />
         )}
       </Await>
     </Suspense>
   );
 }
 
+function DatasetContent({
+  datasetId,
+  fallbackDataset,
+  fallbackReferences,
+  sectorId,
+}: {
+  datasetId: string;
+  fallbackDataset: DatasetDetail;
+  fallbackReferences: ReferenceSummary[];
+  sectorId?: string;
+}) {
+  const payload = { dataset: fallbackDataset, references: fallbackReferences };
+  const datasetState = useDataset(datasetId, { fallbackData: payload });
+  const referencesState = useReferences(datasetId, { fallbackData: payload });
+
+  const dataset = datasetState.data ?? fallbackDataset;
+  const references = referencesState.data ?? fallbackReferences;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <VisualizationCanvas
+        dataset={datasetState.data ?? fallbackDataset}
+        isLoading={datasetState.isLoading && !datasetState.data}
+        error={datasetState.error ?? undefined}
+      />
+      <DatasetMetaCard
+        dataset={dataset}
+        referencesCount={references?.length ?? 0}
+        sectorId={sectorId}
+      />
+    </div>
+  );
+}
+
+function DatasetMetaCard({
+  dataset,
+  referencesCount,
+  sectorId,
+}: {
+  dataset: DatasetDetail;
+  referencesCount: number;
+  sectorId?: string;
+}) {
+  return (
+    <Card className="border-border/80 bg-surface/90">
+      <CardHeader>
+        <CardTitle>Dataset overview</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4 text-sm text-text-secondary sm:grid-cols-2">
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">Dataset ID</p>
+          <p className="font-medium text-foreground">{dataset.datasetId}</p>
+          {dataset.title && <p className="text-text-muted">{dataset.title}</p>}
+        </div>
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">Sector</p>
+          <p className="font-medium text-foreground">{sectorId ?? 'Unassigned'}</p>
+          <p className="text-text-muted">{dataset.figureCount ?? 0} visual figures detected.</p>
+        </div>
+        {dataset.manifestPath && (
+          <div className="space-y-1">
+            <p className="text-xs font-medium uppercase tracking-wide text-text-muted">Manifest</p>
+            <p>
+              <code className="rounded bg-neutral-900/5 px-2 py-1 text-xs text-text-secondary">{dataset.manifestPath}</code>
+            </p>
+            {dataset.manifestSha256 && (
+              <p className="text-xs text-text-muted">sha256: {dataset.manifestSha256}</p>
+            )}
+          </div>
+        )}
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">References</p>
+          <p className="font-medium text-foreground">{referencesCount}</p>
+          <p className="text-text-muted">
+            {referencesCount > 0
+              ? 'Open the inspector panel to review citations.'
+              : 'No references supplied for this dataset.'}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 function DatasetSkeleton() {
   return (
-    <div className="dataset-view">
-      <Skeleton style={{ height: '1.75rem', width: '14rem' }} />
-      <Skeleton style={{ height: '1rem', width: '100%' }} />
-      <Skeleton style={{ height: '1rem', width: '70%' }} />
+    <div className="flex flex-col gap-6">
+      <div className="rounded-2xl border border-border bg-surface/80 p-6 shadow-lg">
+        <Skeleton className="mb-4 h-5 w-1/4" />
+        <CanvasSkeleton />
+      </div>
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-12" />
+          ))}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/apps/carbon-acx-web/src/views/HomeView.tsx
+++ b/apps/carbon-acx-web/src/views/HomeView.tsx
@@ -1,6 +1,7 @@
 import { useOutletContext } from 'react-router-dom';
 
 import type { LayoutOutletContext } from './Layout';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 
 export default function HomeView() {
   const { datasets } = useOutletContext<LayoutOutletContext>();
@@ -8,19 +9,23 @@ export default function HomeView() {
 
   return (
     <div className="home-view">
-      <h3>Explore Carbon ACX</h3>
-      <p>Select a sector from the navigation to load profiles and datasets.</p>
+      <h3 className="text-2xl font-semibold text-foreground">Explore Carbon ACX</h3>
+      <p className="text-sm text-text-muted">Select a sector from the navigation to load profiles and datasets.</p>
       {latestDataset && (
-        <div className="home-view__dataset" aria-live="polite">
-          <h4>Latest dataset</h4>
-          <p>
-            <strong>{latestDataset.datasetId}</strong>
-          </p>
-          <p>
-            Generated at {latestDataset.generatedAt ?? 'an unknown time'} with{' '}
-            {latestDataset.figureCount ?? 0} figures available for review.
-          </p>
-        </div>
+        <Card className="home-view__dataset" aria-live="polite">
+          <CardHeader>
+            <CardTitle>Latest dataset</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-left text-sm text-text-secondary">
+            <p>
+              <strong className="text-base text-foreground">{latestDataset.datasetId}</strong>
+            </p>
+            <p>
+              Generated at {latestDataset.generatedAt ?? 'an unknown time'} with{' '}
+              {latestDataset.figureCount ?? 0} figures available for review.
+            </p>
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/apps/carbon-acx-web/src/views/ProfilePicker.tsx
+++ b/apps/carbon-acx-web/src/views/ProfilePicker.tsx
@@ -7,7 +7,8 @@ interface ProfilePickerProps {
 
 export default function ProfilePicker({ activities }: ProfilePickerProps) {
   const hasSelection = Array.isArray(activities);
-  const hasActivities = Boolean(activities && activities.length > 0);
+  const activityList = hasSelection ? activities : [];
+  const hasActivities = activityList.length > 0;
 
   return (
     <section className="profile-picker" aria-labelledby="profile-picker-heading">
@@ -15,13 +16,13 @@ export default function ProfilePicker({ activities }: ProfilePickerProps) {
         <h2 id="profile-picker-heading">Profiles</h2>
         {hasActivities && (
           <span className="profile-picker__count">
-            {activities.length} {activities.length === 1 ? 'profile' : 'profiles'}
+            {activityList.length} {activityList.length === 1 ? 'profile' : 'profiles'}
           </span>
         )}
       </div>
       {hasActivities ? (
         <div className="profile-picker__grid" role="list" aria-label="Profiles">
-          {activities.map((activity) => (
+          {activityList.map((activity) => (
             <span key={activity.id} role="listitem" className="profile-picker__option">
               {activity.name ?? activity.id}
             </span>
@@ -42,20 +43,12 @@ export function ProfilePickerSkeleton() {
   return (
     <section className="profile-picker">
       <div className="profile-picker__header">
-        <Skeleton style={{ height: '1.5rem', width: '8rem' }} />
-        <Skeleton style={{ height: '1rem', width: '4rem' }} />
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-4 w-16" />
       </div>
       <div className="profile-picker__grid">
         {Array.from({ length: 4 }).map((_, index) => (
-          <Skeleton
-            key={index}
-            style={{
-              display: 'inline-block',
-              height: '2rem',
-              width: '6rem',
-              marginRight: '0.5rem',
-            }}
-          />
+          <Skeleton key={index} className="h-8 w-24 rounded-full" />
         ))}
       </div>
     </section>

--- a/apps/carbon-acx-web/src/views/ScopeSelector.tsx
+++ b/apps/carbon-acx-web/src/views/ScopeSelector.tsx
@@ -29,8 +29,8 @@ export default function ScopeSelector({ sector }: ScopeSelectorProps) {
 export function ScopeSelectorSkeleton() {
   return (
     <section className="scope-selector">
-      <Skeleton style={{ height: '1.5rem', width: '8rem', marginBottom: '0.75rem' }} />
-      <Skeleton style={{ height: '1rem', width: '14rem' }} />
+      <Skeleton className="mb-3 h-5 w-32" />
+      <Skeleton className="h-4 w-56" />
     </section>
   );
 }

--- a/apps/carbon-acx-web/src/views/SectorView.tsx
+++ b/apps/carbon-acx-web/src/views/SectorView.tsx
@@ -58,9 +58,9 @@ function SectorDatasetCta({
 function SectorSkeleton() {
   return (
     <div className="sector-view">
-      <Skeleton style={{ height: '1.75rem', width: '12rem' }} />
-      <Skeleton style={{ height: '1rem', width: '100%' }} />
-      <Skeleton style={{ height: '1rem', width: '60%' }} />
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-2/3" />
     </div>
   );
 }

--- a/apps/carbon-acx-web/src/views/VisualizationCanvas.tsx
+++ b/apps/carbon-acx-web/src/views/VisualizationCanvas.tsx
@@ -1,50 +1,72 @@
-import type { PropsWithChildren, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
+import type { BubbleFigure as BubbleFigureShape, DatasetDetail } from '../lib/api';
+import { BubbleFigure } from '../components/charts/BubbleFigure';
 import { Skeleton } from '../components/ui/skeleton';
 
-interface VisualizationCanvasProps extends PropsWithChildren {
-  title?: string;
+interface VisualizationCanvasProps {
+  dataset?: DatasetDetail | null;
+  isLoading?: boolean;
+  error?: Error | null;
   action?: ReactNode;
 }
 
-export default function VisualizationCanvas({ title, action, children }: VisualizationCanvasProps) {
-  const isEmpty = !children;
+export default function VisualizationCanvas({ dataset, isLoading, error, action }: VisualizationCanvasProps) {
+  const bubbleFigure = dataset?.figures.find(
+    (figure): figure is BubbleFigureShape => figure.figureType === 'bubble',
+  );
+
+  let content: ReactNode;
+  if (error) {
+    content = (
+      <div role="alert" className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-text-secondary">
+        <p className="font-medium text-danger">We couldn’t load this visualization.</p>
+        <p className="max-w-sm text-text-muted">{error.message}</p>
+      </div>
+    );
+  } else if (isLoading) {
+    content = <CanvasSkeleton />;
+  } else if (dataset && bubbleFigure) {
+    content = <BubbleFigure figure={bubbleFigure} />;
+  } else {
+    content = (
+      <div role="status" className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-text-muted">
+        <p>No visualization ready yet.</p>
+        <p>Select a dataset with a bubble figure to begin.</p>
+      </div>
+    );
+  }
+
+  const generatedLabel = dataset?.generatedAt
+    ? new Date(dataset.generatedAt).toLocaleString()
+    : 'Unknown generation time';
+
   return (
-    <section className="visualization-canvas">
-      <header className="visualization-canvas__header">
-        <div>
-          <h2>{title ?? 'Visualization'}</h2>
-          <p>Preview datasets and scenario outputs.</p>
+    <section className="flex flex-col gap-6 rounded-2xl border border-border bg-surface/80 p-6 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-surface/70">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">Dataset</p>
+          <h2 className="text-2xl font-semibold text-foreground">
+            {dataset?.title ?? dataset?.datasetId ?? 'Visualization'}
+          </h2>
+          <p className="text-sm text-text-muted">Generated {generatedLabel}</p>
         </div>
-        {action && <div className="visualization-canvas__action">{action}</div>}
+        {action && <div className="flex items-center gap-2">{action}</div>}
       </header>
-      <div className="visualization-canvas__content" role="presentation">
-        {isEmpty ? <EmptyState /> : children}
+      <div className="min-h-[20rem] flex-1" aria-live="polite">
+        {content}
       </div>
     </section>
   );
 }
 
-function EmptyState() {
+export function CanvasSkeleton() {
   return (
-    <div className="visualization-canvas__empty" role="status">
-      <p>No visualization loaded. Select a dataset to view its figures.</p>
+    <div className="flex h-full flex-col gap-4" aria-hidden="true">
+      <Skeleton className="h-6 w-1/3" />
+      <div className="flex-1 rounded-xl border border-dashed border-border/80 bg-muted/40">
+        <Skeleton className="h-full w-full rounded-xl" />
+      </div>
     </div>
-  );
-}
-
-export function VisualizationSkeleton() {
-  return (
-    <section className="visualization-canvas">
-      <div className="visualization-canvas__header">
-        <div>
-          <Skeleton style={{ height: '1.5rem', width: '12rem', marginBottom: '0.5rem' }} />
-          <Skeleton style={{ height: '1rem', width: '16rem' }} />
-        </div>
-      </div>
-      <div className="visualization-canvas__content">
-        <Skeleton style={{ height: '16rem', width: '100%' }} />
-      </div>
-    </section>
   );
 }

--- a/apps/carbon-acx-web/tailwind.config.ts
+++ b/apps/carbon-acx-web/tailwind.config.ts
@@ -1,0 +1,93 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: ['class', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--surface-background)',
+        surface: 'var(--surface-default)',
+        foreground: 'var(--text-primary)',
+        muted: 'var(--surface-muted)',
+        border: 'var(--border-default)',
+        focus: 'var(--focus-color)',
+        text: {
+          primary: 'var(--text-primary)',
+          secondary: 'var(--text-secondary)',
+          muted: 'var(--text-muted)',
+        },
+        accent: {
+          50: 'var(--accent-50)',
+          100: 'var(--accent-100)',
+          200: 'var(--accent-200)',
+          300: 'var(--accent-300)',
+          400: 'var(--accent-400)',
+          500: 'var(--accent-500)',
+          600: 'var(--accent-600)',
+          700: 'var(--accent-700)',
+          800: 'var(--accent-800)',
+          900: 'var(--accent-900)',
+        },
+        neutral: {
+          50: 'var(--neutral-50)',
+          100: 'var(--neutral-100)',
+          200: 'var(--neutral-200)',
+          300: 'var(--neutral-300)',
+          400: 'var(--neutral-400)',
+          500: 'var(--neutral-500)',
+          600: 'var(--neutral-600)',
+          700: 'var(--neutral-700)',
+          800: 'var(--neutral-800)',
+          900: 'var(--neutral-900)',
+        },
+        success: 'var(--accent-success)',
+        warning: 'var(--accent-warning)',
+        danger: 'var(--accent-danger)',
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)', 'system-ui', 'sans-serif'],
+        mono: ['var(--font-mono)', 'ui-monospace', 'SFMono-Regular'],
+      },
+      borderRadius: {
+        base: 'var(--radius-base)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)',
+        full: '9999px',
+      },
+      boxShadow: {
+        sm: 'var(--shadow-sm)',
+        md: 'var(--shadow-md)',
+        lg: 'var(--shadow-lg)',
+        ring: '0 0 0 2px var(--focus-ring)',
+      },
+      spacing: {
+        xs: 'var(--space-xs)',
+        sm: 'var(--space-sm)',
+        md: 'var(--space-md)',
+        lg: 'var(--space-lg)',
+        xl: 'var(--space-xl)',
+        '2xl': 'var(--space-2xl)',
+      },
+      transitionDuration: {
+        default: 'var(--motion-duration)',
+        slow: 'var(--motion-duration-slow)',
+        fast: 'var(--motion-duration-fast)',
+      },
+      transitionTimingFunction: {
+        default: 'var(--motion-ease)',
+      },
+      ringColor: {
+        focus: 'var(--focus-color)',
+      },
+      ringOffsetColor: {
+        surface: 'var(--surface-default)',
+        focus: 'var(--surface-default)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,30 @@ importers:
 
   apps/carbon-acx-web:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.1
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.1.0
+        version: 1.2.10(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.0
+        version: 1.2.3(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.1
+        version: 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.1.2
+        version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      class-variance-authority:
+        specifier: ^0.7.0
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      framer-motion:
+        specifier: ^11.11.17
+        version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -23,6 +47,15 @@ importers:
       react-router-dom:
         specifier: ^6.28.0
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^2.12.7
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      swr:
+        specifier: ^2.3.3
+        version: 2.3.6(react@18.3.1)
+      tailwind-merge:
+        specifier: ^2.5.3
+        version: 2.6.0
     devDependencies:
       '@types/node':
         specifier: ^22.8.5
@@ -33,9 +66,21 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.26)
+      '@types/recharts':
+        specifier: ^2.0.1
+        version: 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@5.4.20(@types/node@22.18.8))
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.4.21(postcss@8.5.6)
+      postcss:
+        specifier: ^8.4.47
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^3.4.14
+        version: 3.4.18(tsx@4.20.6)
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
@@ -652,6 +697,21 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/react-dom@2.1.6':
+    resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@formatjs/ecma402-abstract@2.3.5':
     resolution: {integrity: sha512-1HTESOq1IUa23g1lFZEGIXsfZKZOwWmB9RROwGn+xariiQnd++wwTMvlRAbZ8wtXRHFUamJPxsKcxpSzeCvFWQ==}
 
@@ -958,6 +1018,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
@@ -1002,6 +1075,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -1009,6 +1095,41 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-id@1.1.1':
@@ -1022,6 +1143,32 @@ packages:
 
   '@radix-ui/react-label@2.1.7':
     resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1120,6 +1267,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-toggle-group@1.1.11':
     resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
     peerDependencies:
@@ -1159,6 +1319,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -1186,6 +1359,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
@@ -1204,6 +1386,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
@@ -1212,6 +1403,22 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@remix-run/router@1.23.0':
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
@@ -1492,6 +1699,33 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1538,6 +1772,10 @@ packages:
 
   '@types/react@18.3.26':
     resolution: {integrity: sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==}
+
+  '@types/recharts@2.0.1':
+    resolution: {integrity: sha512-/cFs7oiafzByUwBSWA1IzE6FW+ppPwQAWsDTadSgVOwzveY9MESpyLHyyHY0SfPPKLW4+4qVNYHPXd0rFiC8vg==}
+    deprecated: This is a stub types definition. recharts provides its own type definitions, so you do not need this installed.
 
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
@@ -1718,6 +1956,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
@@ -1999,6 +2241,50 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -2030,6 +2316,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -2065,6 +2354,13 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   devtools-protocol@0.0.1507524:
     resolution: {integrity: sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==}
 
@@ -2098,6 +2394,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dompurify@3.2.7:
     resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
@@ -2266,6 +2565,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
@@ -2284,6 +2586,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.3.2:
+    resolution: {integrity: sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==}
+    engines: {node: '>=6.0.0'}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -2345,6 +2651,20 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  framer-motion@11.18.2:
+    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -2381,6 +2701,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -2532,6 +2856,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@10.7.17:
     resolution: {integrity: sha512-0Ugaf65B2J76rb31drgNF1l6bGEDkbIiYc2Glx6jaZINHnwa5kDRGy8KXYuA+/8P4G0c9prAFhfVhQJJfzUuvQ==}
@@ -2843,6 +3171,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
@@ -2945,6 +3276,12 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  motion-dom@11.18.1:
+    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
+
+  motion-utils@11.18.1:
+    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3277,6 +3614,26 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.1:
+    resolution: {integrity: sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-router-dom@6.30.1:
     resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
     engines: {node: '>=14.0.0'}
@@ -3289,6 +3646,28 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
+
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react-window@1.8.11:
     resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==}
@@ -3307,6 +3686,16 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -3566,6 +3955,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.3.6:
+    resolution: {integrity: sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -3607,6 +4001,9 @@ packages:
 
   third-party-web@0.27.0:
     resolution: {integrity: sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3726,6 +4123,26 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -3733,6 +4150,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -4270,6 +4690,23 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@formatjs/ecma402-abstract@2.3.5':
     dependencies:
       '@formatjs/fast-memoize': 2.2.7
@@ -4660,6 +5097,15 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
   '@radix-ui/react-checkbox@1.3.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4700,11 +5146,63 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.26
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.26)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.1(@types/react@18.3.26)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
   '@radix-ui/react-direction@1.1.1(@types/react@18.3.26)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.26
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.26)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.26
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
 
   '@radix-ui/react-id@1.1.1(@types/react@18.3.26)(react@18.3.1)':
     dependencies:
@@ -4716,6 +5214,34 @@ snapshots:
   '@radix-ui/react-label@2.1.7(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.26)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -4806,6 +5332,22 @@ snapshots:
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
 
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.26)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4847,6 +5389,26 @@ snapshots:
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
 
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.26)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.26)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -4868,6 +5430,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.26
 
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.26)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.26)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.26
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.26)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -4880,12 +5449,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.26
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.26)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.26
+
   '@radix-ui/react-use-size@1.1.1(@types/react@18.3.26)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.26)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.26
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+      '@types/react-dom': 18.3.7(@types/react@18.3.26)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@remix-run/router@1.23.0': {}
 
@@ -5148,6 +5735,30 @@ snapshots:
     dependencies:
       '@types/node': 24.7.0
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -5206,6 +5817,13 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
+
+  '@types/recharts@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      recharts: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@types/shimmer@1.2.0': {}
 
@@ -5431,6 +6049,10 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.1.3:
     dependencies:
@@ -5735,6 +6357,44 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-uri-to-buffer@6.0.2: {}
@@ -5765,6 +6425,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -5817,6 +6479,10 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
+  detect-node-es@1.1.0: {}
+
   devtools-protocol@0.0.1507524: {}
 
   devtools-protocol@0.0.1508733: {}
@@ -5842,6 +6508,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      csstype: 3.1.3
 
   dompurify@3.2.7:
     optionalDependencies:
@@ -6185,6 +6856,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   events-universal@1.0.1:
     dependencies:
       bare-events: 2.7.0
@@ -6221,6 +6894,8 @@ snapshots:
       - supports-color
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.3.2: {}
 
   fast-fifo@1.3.2: {}
 
@@ -6288,6 +6963,15 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  framer-motion@11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      motion-dom: 11.18.1
+      motion-utils: 11.18.1
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
@@ -6326,6 +7010,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -6490,6 +7176,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   intl-messageformat@10.7.17:
     dependencies:
@@ -6875,6 +7563,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.21: {}
+
   loglevel@1.9.2: {}
 
   lookup-closest-locale@6.2.0: {}
@@ -6962,6 +7652,12 @@ snapshots:
       ufo: 1.6.1
 
   module-details-from-path@1.0.4: {}
+
+  motion-dom@11.18.1:
+    dependencies:
+      motion-utils: 11.18.1
+
+  motion-utils@11.18.1: {}
 
   ms@2.1.3: {}
 
@@ -7294,6 +7990,25 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.26)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.26)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.26
+
+  react-remove-scroll@2.7.1(@types/react@18.3.26)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.26)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.26)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.26)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.26)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.26
+
   react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.0
@@ -7305,6 +8020,31 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.23.0
       react: 18.3.1
+
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.3.2
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-style-singleton@2.2.3(@types/react@18.3.26)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.26
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-window@1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -7324,6 +8064,23 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   redent@3.0.0:
     dependencies:
@@ -7666,6 +8423,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.3.6(react@18.3.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.0: {}
@@ -7744,6 +8507,8 @@ snapshots:
       any-promise: 1.3.0
 
   third-party-web@0.27.0: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -7866,11 +8631,43 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  use-callback-ref@1.3.3(@types/react@18.3.26)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.26
+
+  use-sidecar@1.1.3(@types/react@18.3.26)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.26
+
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@1.6.1(@types/node@24.7.0):
     dependencies:


### PR DESCRIPTION
## Summary
- define cohesive design tokens and Tailwind utilities for light/dark themes with motion preferences
- add shadcn/ui primitives, SWR data hooks, and bubble chart rendering for datasets
- refresh layout, navigation accessibility, and visualization canvas with loading and error states

## Testing
- pnpm --filter carbon-acx-web... build

------
https://chatgpt.com/codex/tasks/task_e_68e7de8cabac832c9c642ba0d7c8e011