### PR TITLE
feat: finalize new ui rollout tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Carbon ACX
 
+![New UI Preview](https://img.shields.io/badge/New%20UI-Preview-blueviolet)
+
 > **Current dataset version:** v1.2【F:calc/outputs/sprint_status.txt†L1-L18】
 
 Carbon ACX is an open reference stack for trustworthy carbon accounting. It turns auditable CSV inputs into a reproducible dataset, then ships the same disclosures through interactive Dash tooling, a static React experience, and Cloudflare delivery surfaces so teams can communicate climate performance with confidence.【F:calc/derive.py†L52-L92】【F:app/app.py†L12-L158】【F:site/src/App.tsx†L1-L160】【F:functions/carbon-acx/[[path]].ts†L1-L160】【F:workers/compute/index.ts†L1-L123】

--- a/apps/carbon-acx-web/package.json
+++ b/apps/carbon-acx-web/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && tsc --project tsconfig.node.json --noEmit && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.1",
@@ -14,6 +17,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.2",
+    "@tanstack/react-virtual": "^3.0.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "framer-motion": "^11.11.17",
@@ -25,6 +29,8 @@
     "tailwind-merge": "^2.5.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.0",
+    "@testing-library/react": "^14.2.1",
     "@types/node": "^22.8.5",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
@@ -34,6 +40,8 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "~5.5.4",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vite-plugin-compression": "^0.5.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/carbon-acx-web/playwright.config.ts
+++ b/apps/carbon-acx-web/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    viewport: { width: 1280, height: 720 },
+    extraHTTPHeaders: {
+      'x-acx-ui': 'new',
+    },
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev -- --host 127.0.0.1 --port 5173',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    env: {
+      ACX_NEW_UI: '1',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/apps/carbon-acx-web/public/_headers
+++ b/apps/carbon-acx-web/public/_headers
@@ -1,0 +1,8 @@
+/*
+  Cache-Control: public, max-age=600
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+  Content-Type: auto

--- a/apps/carbon-acx-web/src/NewApp.tsx
+++ b/apps/carbon-acx-web/src/NewApp.tsx
@@ -1,0 +1,1 @@
+export { default } from './App';

--- a/apps/carbon-acx-web/src/components/charts/BubbleFigure.tsx
+++ b/apps/carbon-acx-web/src/components/charts/BubbleFigure.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo } from 'react';
+import { memo, useId, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import {
   CartesianGrid,
@@ -19,7 +19,7 @@ interface BubbleFigureProps {
   className?: string;
 }
 
-export function BubbleFigure({ figure, className }: BubbleFigureProps) {
+export const BubbleFigure = memo(function BubbleFigure({ figure, className }: BubbleFigureProps) {
   const chartId = useId();
   const descriptionId = `${chartId}-description`;
 
@@ -108,7 +108,7 @@ export function BubbleFigure({ figure, className }: BubbleFigureProps) {
       </dl>
     </motion.section>
   );
-}
+});
 
 function axisLabel(axis: { label: string; unit?: string | null }) {
   return axis.unit ? `${axis.label} (${axis.unit})` : axis.label;

--- a/apps/carbon-acx-web/src/components/ui/scroll-area.tsx
+++ b/apps/carbon-acx-web/src/components/ui/scroll-area.tsx
@@ -3,22 +3,35 @@ import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 
 import { cn } from '../../lib/cn';
 
+interface ScrollAreaProps extends React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
+  viewportClassName?: string;
+  viewportRef?: React.Ref<HTMLDivElement>;
+  viewportProps?: React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Viewport>;
+}
+
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
-    ref={ref}
-    className={cn('relative overflow-hidden', className)}
-    {...props}
-  >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-md">
-      {children}
-    </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
-    <ScrollAreaPrimitive.Corner className="bg-transparent" />
-  </ScrollAreaPrimitive.Root>
-));
+  ScrollAreaProps
+>(({ className, children, viewportClassName, viewportRef, viewportProps, ...props }, ref) => {
+  const { className: inheritedViewportClassName, ...restViewportProps } = viewportProps ?? {};
+  return (
+    <ScrollAreaPrimitive.Root
+      ref={ref}
+      className={cn('relative overflow-hidden', className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        ref={viewportRef as React.Ref<HTMLDivElement>}
+        className={cn('h-full w-full rounded-md', viewportClassName, inheritedViewportClassName)}
+        {...restViewportProps}
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner className="bg-transparent" />
+    </ScrollAreaPrimitive.Root>
+  );
+});
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 const ScrollBar = React.forwardRef<

--- a/apps/carbon-acx-web/src/hooks/__tests__/useDataset.test.tsx
+++ b/apps/carbon-acx-web/src/hooks/__tests__/useDataset.test.tsx
@@ -1,0 +1,108 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDataset, useReferences } from '../useDataset';
+import type { DatasetDetail, ReferenceSummary } from '../../lib/api';
+import { loadDataset } from '../../lib/api';
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api');
+  return {
+    ...actual,
+    loadDataset: vi.fn(actual.loadDataset),
+  };
+});
+
+describe('useDataset hooks', () => {
+  const dataset: DatasetDetail = {
+    datasetId: 'dataset-001',
+    generatedAt: '2024-10-01T12:00:00Z',
+    figureCount: 2,
+    manifestPath: '/manifests/dataset-001.json',
+    manifestSha256: 'abc123',
+    title: 'Test dataset',
+    description: 'A dataset for testing',
+    figures: [],
+  };
+  const references: ReferenceSummary[] = [
+    {
+      referenceId: 'ref-1',
+      text: 'Reference one',
+      citation: 'Example 2024',
+      url: 'https://example.com/1',
+      year: 2024,
+      layer: 'baseline',
+    },
+    {
+      referenceId: 'ref-2',
+      text: 'Reference two',
+      citation: null,
+      url: 'https://example.com/2',
+      year: 2023,
+      layer: 'scenario',
+    },
+  ];
+
+  const payload = { dataset, references };
+  const mockedLoadDataset = vi.mocked(loadDataset);
+
+  const createWrapper = (cache = new Map()) =>
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <SWRConfig value={{ provider: () => cache, dedupingInterval: 0, errorRetryInterval: 10 }}>
+          {children}
+        </SWRConfig>
+      );
+    };
+
+  beforeEach(() => {
+    mockedLoadDataset.mockResolvedValue(payload);
+  });
+
+  afterEach(() => {
+    mockedLoadDataset.mockReset();
+  });
+
+  it('reuses cached dataset payload across related hooks', async () => {
+    const cache = new Map();
+    const wrapper = createWrapper(cache);
+
+    const { result: datasetResult } = renderHook(() => useDataset('dataset-001'), { wrapper });
+    await waitFor(() => expect(datasetResult.current.data).toEqual(dataset));
+    expect(mockedLoadDataset).toHaveBeenCalledTimes(1);
+
+    const { result: referencesResult } = renderHook(() => useReferences('dataset-001'), { wrapper });
+    await waitFor(() => expect(referencesResult.current.data).toEqual(references));
+    expect(mockedLoadDataset).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes errors returned by the dataset loader', async () => {
+    const error = new Error('boom');
+    mockedLoadDataset.mockReset();
+    mockedLoadDataset.mockRejectedValue(error);
+
+    const { result } = renderHook(() => useDataset('broken'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toContain('boom');
+  });
+
+  it('honours fallback data without revalidation when requested', async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useDataset('dataset-001', {
+          fallbackData: payload,
+          revalidateOnMount: false,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.data).toEqual(dataset);
+    expect(mockedLoadDataset).not.toHaveBeenCalled();
+  });
+});

--- a/apps/carbon-acx-web/src/legacy/LegacyApp.tsx
+++ b/apps/carbon-acx-web/src/legacy/LegacyApp.tsx
@@ -1,0 +1,67 @@
+import { useMemo, useState } from 'react';
+
+import '../index.css';
+
+const DEFAULT_LEGACY_PATH = '/legacy';
+
+function resolveLegacyUrl(): string {
+  const configured = (import.meta.env.ACX_LEGACY_ORIGIN ?? import.meta.env.VITE_ACX_LEGACY_ORIGIN)?.toString().trim();
+  if (!configured) {
+    return DEFAULT_LEGACY_PATH;
+  }
+  try {
+    return new URL(configured, window.location.href).toString();
+  } catch (error) {
+    console.warn('Invalid ACX legacy origin provided. Falling back to default path.', error);
+    return DEFAULT_LEGACY_PATH;
+  }
+}
+
+export default function LegacyApp() {
+  const [hasError, setHasError] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const legacyUrl = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_LEGACY_PATH;
+    }
+    return resolveLegacyUrl();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background text-text-primary">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 p-6">
+        <header className="flex flex-col gap-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-text-muted">Carbon ACX</p>
+          <h1 className="text-3xl font-semibold">Legacy experience</h1>
+          <p className="max-w-2xl text-sm text-text-secondary">
+            The legacy interface is still available for teams that have not migrated to the refreshed Carbon ACX
+            workspace. If this frame does not load, verify that the deployment exposes the legacy bundle under the
+            expected <code>ACX_LEGACY_ORIGIN</code> location.
+          </p>
+        </header>
+        <div className="relative flex-1 overflow-hidden rounded-2xl border border-border bg-surface/80 shadow-lg">
+          {!isLoaded && !hasError && (
+            <div className="absolute inset-0 flex items-center justify-center text-sm text-text-muted">
+              Loading the legacy workspace…
+            </div>
+          )}
+          {hasError && (
+            <div className="absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-danger" role="alert">
+              We were unable to load the legacy workspace from {legacyUrl}. Check that the asset is still published or
+              update <code>ACX_LEGACY_ORIGIN</code>.
+            </div>
+          )}
+          <iframe
+            title="Carbon ACX legacy interface"
+            src={legacyUrl}
+            className="h-[70vh] w-full border-0"
+            loading="lazy"
+            onLoad={() => setIsLoaded(true)}
+            onError={() => setHasError(true)}
+            allow="clipboard-write; fullscreen"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/carbon-acx-web/src/main.tsx
+++ b/apps/carbon-acx-web/src/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
-import App from './App';
 import './index.css';
 
 const rootElement = document.getElementById('root');
@@ -9,8 +8,17 @@ if (!rootElement) {
   throw new Error('Root element not found');
 }
 
-ReactDOM.createRoot(rootElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+const enableNewUi = (import.meta.env.ACX_NEW_UI ?? import.meta.env.VITE_ACX_NEW_UI) === '1';
+
+const loadApp = enableNewUi ? () => import('./NewApp') : () => import('./legacy/LegacyApp');
+
+async function bootstrap() {
+  const { default: App } = await loadApp();
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}
+
+void bootstrap();

--- a/apps/carbon-acx-web/src/styles/layout.css
+++ b/apps/carbon-acx-web/src/styles/layout.css
@@ -6,6 +6,20 @@
   min-height: 100vh;
 }
 
+.route-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 12rem;
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  border: 1px dashed var(--border-default);
+  background: rgba(53, 88, 255, 0.04);
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  text-align: center;
+}
+
 @media (min-width: 1024px) {
   .app-layout {
     grid-template-columns: 320px minmax(0, 1fr) 360px;
@@ -253,13 +267,23 @@
   gap: var(--space-sm);
 }
 
+.reference-panel__viewport {
+  padding-right: 0.25rem;
+}
+
 .reference-panel__list {
-  list-style: decimal inside;
+  list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
+  position: relative;
+}
+
+.reference-panel__list:not(.reference-panel__list--virtualized) .reference-panel__item + .reference-panel__item {
+  margin-top: var(--space-md);
+}
+
+.reference-panel__list--virtualized {
+  position: relative;
 }
 
 .reference-panel__item {
@@ -268,6 +292,32 @@
   border-radius: var(--radius-lg);
   border: 1px solid rgba(53, 88, 255, 0.16);
   box-shadow: var(--shadow-sm);
+}
+
+.reference-panel__item-content {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-sm);
+  align-items: flex-start;
+}
+
+.reference-panel__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: rgba(53, 88, 255, 0.16);
+  color: var(--accent-700);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.reference-panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .reference-panel__item p {

--- a/apps/carbon-acx-web/src/test/setup.ts
+++ b/apps/carbon-acx-web/src/test/setup.ts
@@ -1,0 +1,6 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});

--- a/apps/carbon-acx-web/tests/e2e/smoke.spec.ts
+++ b/apps/carbon-acx-web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('new UI smoke flow', () => {
+  test('loads sectors, opens a dataset, and renders references', async ({ page }) => {
+    await page.setViewportSize({ width: 960, height: 720 });
+    await page.goto('/');
+
+    const navigation = page.getByLabel('Sector navigation');
+    await expect(navigation).toBeVisible();
+
+    const firstSector = navigation.getByRole('option').first();
+    await firstSector.click();
+
+    const datasetLink = page.getByRole('link', { name: /view dataset/i });
+    await expect(datasetLink).toBeVisible();
+    await datasetLink.click();
+
+    await page.waitForURL('**/datasets/**');
+
+    const chartImage = page.getByRole('img', { name: /bubble chart/i });
+    await expect(chartImage).toBeVisible();
+
+    const toggle = page.getByRole('button', { name: /references/i });
+    if ((await toggle.count()) > 0) {
+      const expanded = await toggle.first().getAttribute('aria-expanded');
+      if (expanded !== 'true') {
+        await toggle.first().click();
+      }
+    }
+
+    const sheet = page.getByRole('dialog');
+    if ((await sheet.count()) > 0) {
+      await expect(sheet).toBeVisible();
+      await expect(sheet.getByRole('listitem').first()).toBeVisible();
+    } else {
+      const referencesPanel = page.getByRole('complementary', { name: /references/i });
+      await expect(referencesPanel).toBeVisible();
+      await expect(referencesPanel.getByRole('listitem').first()).toBeVisible();
+    }
+  });
+});

--- a/apps/carbon-acx-web/vitest.config.ts
+++ b/apps/carbon-acx-web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    exclude: ['tests/e2e/**', 'playwright.config.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+    },
+  },
+});

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -1,0 +1,33 @@
+# Carbon ACX theming guidelines
+
+The new workspace is powered by CSS custom properties defined in `apps/carbon-acx-web/src/styles/tokens.css`. The tokens provide
+a consistent palette across light/dark themes and map directly to Tailwind aliases for rapid prototyping.
+
+## Core tokens
+
+| Category | Token | Notes |
+| --- | --- | --- |
+| Typography | `--font-sans`, `--font-mono` | Applied to Tailwind `fontFamily.sans` and `fontFamily.mono`. |
+| Surfaces | `--surface-*` | Background layers for shell, cards, and overlays. |
+| Borders | `--border-default`, `--border-strong` | Used by structural dividers and focus rings. |
+| Text | `--text-primary`, `--text-secondary`, `--text-muted` | Aligns text colors with semantic emphasis. |
+| Accent | `--accent-50` – `--accent-900` | Gradient for primary brand tone and interactive states. |
+| Neutral | `--neutral-50` – `--neutral-900` | Supporting grayscale for outlines and backgrounds. |
+| Feedback | `--accent-success`, `--accent-warning`, `--accent-danger` | Reinforces system feedback. |
+| Motion | `--motion-duration-*`, `--motion-ease` | Shared timing for animations and transitions. |
+| Radius & spacing | `--radius-*`, `--space-*` | Standardises card shapes and layout rhythm. |
+
+Dark mode overrides live under `[data-theme='dark']`, mirroring the token structure for near drop-in parity.
+
+## Using tokens in components
+
+1. Prefer Tailwind classes (e.g. `text-foreground`, `bg-surface`) whenever possible—the config in
+   `apps/carbon-acx-web/tailwind.config.ts` aliases Tailwind utilities back to the design tokens.
+2. When Tailwind cannot express a value, reference the token directly (e.g. `style={{ color: 'var(--text-muted)' }}`).
+3. Respect `prefers-reduced-motion`; token overrides in `tokens.css` collapse animation durations when users request it.
+
+## Legacy iframe shell
+
+The legacy bridge (`LegacyApp`) reuses the same global CSS import so typography and surface colours remain on-brand even while the
+iframe loads the older bundle. If the legacy app needs bespoke overrides, append them in `src/legacy` with tokens instead of raw
+hex values to avoid divergence.

--- a/docs/UX-IA.md
+++ b/docs/UX-IA.md
@@ -1,0 +1,34 @@
+# Carbon ACX new workspace IA
+
+The refreshed Carbon ACX workspace introduces a three-pane layout optimised for rapid exploration of sectors, datasets, and
+their associated evidence. The navigation sidebar is now search-forward, the central canvas focuses on scope and figures, and
+the inspector tracks references without blocking the main task flow. Route-level code splitting keeps the first paint focused on
+the navigation shell and defers heavier dataset bundles until a user drills in.
+
+![Workspace overview](../artifacts/new-ui-overview.png)
+
+## Interaction flow
+
+1. **Sector selection** – the left rail lists available sectors with keyboard focus management and live filtering.
+2. **Scope + profiles** – the central column guides analysts through scope context, available profiles, and the most recent
+dataset call-to-action.
+3. **Dataset inspection** – datasets open inline and render chart figures with memoised, animated components to stay responsive.
+4. **Reference review** – references stream into the inspector with windowed virtualisation so long bibliographies stay smooth on
+modest devices.
+
+![Dataset detail view](../artifacts/new-ui-dataset.png)
+
+## Migration guard rails
+
+The UI ships behind an `ACX_NEW_UI` environment flag. This allows staging environments to roll out progressively while keeping
+the legacy shell accessible through the legacy iframe bridge. When the flag is enabled, only the new bundles are imported, so the
+legacy assets are not downloaded by mistake.
+
+## Performance tactics
+
+- React Router routes now lazy-load with a shared suspense fallback to trim the initial payload.
+- Heavy chart components are wrapped in `React.memo` to avoid unnecessary work when state updates in other panes.
+- Reference lists render through `@tanstack/react-virtual`, ensuring the inspector remains responsive even with hundreds of
+citations.
+- The build pipeline generates Brotli and Gzip assets via `vite-plugin-compression`, and `_headers` enforces long-term caching for
+fingerprinted bundles.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.2
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.0.1
+        version: 3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -57,6 +60,12 @@ importers:
         specifier: ^2.5.3
         version: 2.6.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.56.0
+        version: 1.56.0
+      '@testing-library/react':
+        specifier: ^14.2.1
+        version: 14.3.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^22.8.5
         version: 22.18.8
@@ -87,6 +96,12 @@ importers:
       vite:
         specifier: ^5.4.8
         version: 5.4.20(@types/node@22.18.8)
+      vite-plugin-compression:
+        specifier: ^0.5.1
+        version: 0.5.1(vite@5.4.20(@types/node@22.18.8))
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@22.18.8)(jsdom@24.1.3)
 
   site:
     dependencies:
@@ -1001,6 +1016,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.56.0':
+    resolution: {integrity: sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/instrumentation@6.11.1':
     resolution: {integrity: sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==}
@@ -2665,8 +2685,17 @@ packages:
       react-dom:
         optional: true
 
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3118,6 +3147,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3478,6 +3510,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.56.0:
+    resolution: {integrity: sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.56.0:
+    resolution: {integrity: sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4111,6 +4153,10 @@ packages:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
@@ -4158,6 +4204,11 @@ packages:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-plugin-compression@0.5.1:
+    resolution: {integrity: sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==}
+    peerDependencies:
+      vite: '>=2.0.0'
 
   vite@5.4.20:
     resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
@@ -5071,6 +5122,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.56.0':
+    dependencies:
+      playwright: 1.56.0
 
   '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6972,7 +7027,16 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -7477,6 +7541,12 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -7851,6 +7921,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  playwright-core@1.56.0: {}
+
+  playwright@1.56.0:
+    dependencies:
+      playwright-core: 1.56.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8616,6 +8694,8 @@ snapshots:
 
   universalify@0.2.0: {}
 
+  universalify@2.0.1: {}
+
   update-browserslist-db@1.1.3(browserslist@4.26.3):
     dependencies:
       browserslist: 4.26.3
@@ -8669,6 +8749,24 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@1.6.1(@types/node@22.18.8):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.20(@types/node@22.18.8)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@1.6.1(@types/node@24.7.0):
     dependencies:
       cac: 6.7.14
@@ -8687,6 +8785,15 @@ snapshots:
       - supports-color
       - terser
 
+  vite-plugin-compression@0.5.1(vite@5.4.20(@types/node@22.18.8)):
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      vite: 5.4.20(@types/node@22.18.8)
+    transitivePeerDependencies:
+      - supports-color
+
   vite@5.4.20(@types/node@22.18.8):
     dependencies:
       esbuild: 0.21.5
@@ -8704,6 +8811,41 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.7.0
       fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@22.18.8)(jsdom@24.1.3):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@22.18.8)
+      vite-node: 1.6.1(@types/node@22.18.8)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.8
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@1.6.1(@types/node@24.7.0)(jsdom@24.1.3):
     dependencies:


### PR DESCRIPTION
## Summary
- gate the new Carbon ACX workspace behind the `ACX_NEW_UI` flag while keeping a legacy iframe bridge available
- split application routes and heavy visuals to improve perceived performance, and add compression plus caching headers for build outputs
- document the IA/theming rationale and add Vitest + Playwright coverage for dataset hooks and the smoke flow

## Testing
- pnpm --filter carbon-acx-web test:unit
- pnpm --filter carbon-acx-web test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e7ebc6df88832c890124c45e438c9b