### PR TITLE
Fix home loader usage and clean Cloudflare build output

### DIFF
--- a/apps/carbon-acx-web/package.json
+++ b/apps/carbon-acx-web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && tsc --project tsconfig.node.json --noEmit && vite build",
+    "build": "node -e \"fs=require('fs');fs.rmSync('dist',{recursive:true,force:true});\" && tsc --noEmit && tsc --project tsconfig.node.json --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:unit": "vitest run",

--- a/apps/carbon-acx-web/src/views/HomeView.tsx
+++ b/apps/carbon-acx-web/src/views/HomeView.tsx
@@ -1,17 +1,21 @@
 import { Suspense } from 'react';
-import { Await, useLoaderData } from 'react-router-dom';
+import { Await, useRouteLoaderData } from 'react-router-dom';
 
 import HeroSection from '../components/HeroSection';
 import type { DatasetSummary, SectorSummary } from '../lib/api';
 import { Skeleton } from '../components/ui/skeleton';
 
-interface HomeLoaderData {
+interface LayoutLoaderData {
   sectors: Promise<SectorSummary[]>;
   datasets: Promise<DatasetSummary[]>;
 }
 
 export default function HomeView() {
-  const data = useLoaderData() as HomeLoaderData;
+  const data = useRouteLoaderData('layout') as LayoutLoaderData | undefined;
+
+  if (!data) {
+    throw new Error('Layout loader data is unavailable');
+  }
 
   return (
     <div className="home-view space-y-12 -mt-6">


### PR DESCRIPTION
## Summary
- update the home view to read sector and dataset promises from the layout loader to avoid runtime crashes
- cleanly remove the existing dist directory before running the Cloudflare Pages build so deployments always start from a fresh output path

## Testing
- pnpm --filter carbon-acx-web run build *(fails: existing TypeScript errors complaining about missing lucide-react types and strictness issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ebd9ba02ac832c8cf281708b1747c2