### PR TITLE
Add spacing below profile picker empty message

### DIFF
--- a/apps/carbon-acx-web/src/styles/layout.css
+++ b/apps/carbon-acx-web/src/styles/layout.css
@@ -222,6 +222,7 @@
 .profile-picker__empty {
   color: var(--text-muted);
   font-size: 0.9rem;
+  margin-bottom: 0.75rem;
 }
 
 .home-view,

--- a/apps/carbon-acx-web/src/views/ScopeSelector.tsx
+++ b/apps/carbon-acx-web/src/views/ScopeSelector.tsx
@@ -7,12 +7,7 @@ interface ScopeSelectorProps {
 
 export default function ScopeSelector({ sector }: ScopeSelectorProps) {
   if (!sector) {
-    return (
-      <section className="scope-selector">
-        <h2>Choose a sector</h2>
-        <p>Select a sector from the navigation to explore its datasets.</p>
-      </section>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Summary
- remove the ScopeSelector placeholder copy so the page no longer shows the "Choose a sector" message when no sector is selected
- add spacing beneath the profile picker empty-state message for better separation from the list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed0b5c9654832ca01c974309f29a30