### PR TITLE
fix: TypeScript error in ActivityBadgeGrid list view onClick handler

### DIFF
--- a/apps/carbon-acx-web/src/components/ActivityBadgeGrid.tsx
+++ b/apps/carbon-acx-web/src/components/ActivityBadgeGrid.tsx
@@ -280,34 +280,32 @@ export default function ActivityBadgeGrid({
                   onClick={() => handleActivityClick(activity)}
                 >
                   {/* Icon */}
-                  <ActivityBadge
-                    name={activity.name || activity.id}
-                    emissions={impact}
-                    iconUrl={activity.iconUrl}
-                    iconType={iconType}
-                    badgeColor={activity.badgeColor}
-                    isSelected={isSelected}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleActivityClick(activity);
-                    }}
-                    onValueSubmit={(value) => {
-                      const carbonIntensity = impact / 1000;
-                      const annualEmissions = carbonIntensity * value;
-                      addActivity({
-                        id: activity.id,
-                        sectorId,
-                        name: activity.name || activity.id,
-                        category: activity.category,
-                        quantity: value,
-                        unit: activity.defaultUnit || 'unit',
-                        carbonIntensity,
-                        annualEmissions,
-                      });
-                    }}
-                    size="sm"
-                    showEmissions={false}
-                  />
+                  <div onClick={(e) => e.stopPropagation()}>
+                    <ActivityBadge
+                      name={activity.name || activity.id}
+                      emissions={impact}
+                      iconUrl={activity.iconUrl}
+                      iconType={iconType}
+                      badgeColor={activity.badgeColor}
+                      isSelected={isSelected}
+                      onValueSubmit={(value) => {
+                        const carbonIntensity = impact / 1000;
+                        const annualEmissions = carbonIntensity * value;
+                        addActivity({
+                          id: activity.id,
+                          sectorId,
+                          name: activity.name || activity.id,
+                          category: activity.category,
+                          quantity: value,
+                          unit: activity.defaultUnit || 'unit',
+                          carbonIntensity,
+                          annualEmissions,
+                        });
+                      }}
+                      size="sm"
+                      showEmissions={false}
+                    />
+                  </div>
 
                   {/* Activity details */}
                   <div className="flex-1 min-w-0">


### PR DESCRIPTION
Wrapped ActivityBadge in list view with a div to handle stopPropagation, removing the onClick prop that was causing TypeScript error. The parent motion.div already handles the click event for activity selection.

Fixes build failure in deployment after PR #233 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Traceability
Implements (spec): ACX###
Prompt (execution): CDX###
Related issues/tickets: #

## Summary
- What changed:
- Why:

## Data/Sources
- New sources.csv rows? (y/n)
- IEEE references added/updated:

## Citations
- [ ] Citation present for every numeric claim
- [ ] Scope/horizon/region/vintage set for new or changed data
- [ ] IEEE references added or updated in calc/references
- [ ] Artifact References.txt files regenerated

## Tests
- [ ] make validate passes
- [ ] pytest passes
