### PR TITLE
fix(web): eliminate horizontal scrolling on mobile

### DIFF
--- a/apps/carbon-acx-web/src/components/LayerToggle.tsx
+++ b/apps/carbon-acx-web/src/components/LayerToggle.tsx
@@ -67,7 +67,7 @@ export default function LayerToggle() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
               transition={{ duration: 0.15 }}
-              className="absolute left-0 top-full mt-2 z-50 w-[calc(100vw-2rem)] max-w-md bg-surface border border-border rounded-lg shadow-lg"
+              className="absolute left-0 top-full mt-2 z-50 w-full max-w-md bg-surface border border-border rounded-lg shadow-lg"
             >
               {/* Header */}
               <div className="p-3 border-b border-border">

--- a/apps/carbon-acx-web/src/index.css
+++ b/apps/carbon-acx-web/src/index.css
@@ -11,12 +11,19 @@
     box-sizing: border-box;
   }
 
+  html,
+  #root {
+    overflow-x: hidden;
+  }
+
   html {
     font-family: var(--font-sans);
     background-color: var(--surface-background);
     color: var(--text-primary);
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
 
   body {
@@ -24,6 +31,9 @@
     min-height: 100vh;
     background: var(--surface-background);
     color: var(--text-primary);
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-width: 100vw;
   }
 
   :focus-visible {

--- a/apps/carbon-acx-web/src/styles/layout.css
+++ b/apps/carbon-acx-web/src/styles/layout.css
@@ -4,6 +4,8 @@
   gap: var(--space-md);
   padding: var(--space-md);
   min-height: 100vh;
+  max-width: 100vw;
+  box-sizing: border-box;
 }
 
 .route-fallback {


### PR DESCRIPTION
Fixes horizontal scrolling issues on mobile by:
- Adding overflow-x: hidden to html, body, and #root elements
- Constraining body max-width to 100vw
- Updating LayerToggle dropdown from w-[calc(100vw-2rem)] to w-full
- Adding max-width and box-sizing constraints to app-layout

The previous 100vw-based width calculation could cause horizontal scroll when padding is present, especially on mobile viewports. Using w-full makes the dropdown width relative to its container instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Traceability
Implements (spec): ACX###
Prompt (execution): CDX###
Related issues/tickets: #

## Summary
- What changed:
- Why:

## Data/Sources
- New sources.csv rows? (y/n)
- IEEE references added/updated:

## Citations
- [ ] Citation present for every numeric claim
- [ ] Scope/horizon/region/vintage set for new or changed data
- [ ] IEEE references added or updated in calc/references
- [ ] Artifact References.txt files regenerated

## Tests
- [ ] make validate passes
- [ ] pytest passes
