### PR TITLE
chore(web): Complete language reframing Phase 2+3 - literacy not guilt

### DIFF
--- a/apps/carbon-acx-web/src/components/OnboardingWizard.tsx
+++ b/apps/carbon-acx-web/src/components/OnboardingWizard.tsx
@@ -187,7 +187,7 @@ function WelcomeStep({ onChoosePath }: { onChoosePath: (path: PathChoice) => voi
               </li>
               <li className="flex items-start gap-2">
                 <CheckCircle2 className="h-3.5 w-3.5 text-green-600 dark:text-green-400 mt-0.5 flex-shrink-0" />
-                <span>Activity-level tracking and scenario comparison</span>
+                <span>Activity-level analysis and scenario comparison</span>
               </li>
               <li className="flex items-start gap-2">
                 <CheckCircle2 className="h-3.5 w-3.5 text-green-600 dark:text-green-400 mt-0.5 flex-shrink-0" />
@@ -309,7 +309,7 @@ function DetailedStep1({ onNext, onBack }: { onNext: () => void; onBack: () => v
           Understanding Activities
         </h2>
         <p className="text-text-secondary text-sm max-w-lg mx-auto">
-          Activities are the building blocks of your carbon footprint
+          Activities are the building blocks of emission profiles
         </p>
       </div>
 

--- a/apps/carbon-acx-web/src/views/NavSidebar.tsx
+++ b/apps/carbon-acx-web/src/views/NavSidebar.tsx
@@ -187,7 +187,7 @@ export default function NavSidebar({ sectors, onOpenSettings }: NavSidebarProps)
             );
             })}
                 {filtered.length === 0 && (
-                  <li className="nav-sidebar__empty">No sectors match your search.</li>
+                  <li className="nav-sidebar__empty">No sectors match the search.</li>
                 )}
               </ul>
             </ScrollArea>

--- a/apps/carbon-acx-web/src/views/ProfilePicker.tsx
+++ b/apps/carbon-acx-web/src/views/ProfilePicker.tsx
@@ -147,7 +147,7 @@ export default function ProfilePicker({ profiles, sectorId, activities }: Profil
       showToast(
         'success',
         'Profile loaded as new layer!',
-        `${layerActivities.length} activities added. You can now compare this with other profiles or manual activities.`,
+        `${layerActivities.length} activities added. Compare with other profiles or manual activities on the dashboard.`,
         6000
       );
     } catch (error) {

--- a/apps/carbon-acx-web/src/views/SectorView.tsx
+++ b/apps/carbon-acx-web/src/views/SectorView.tsx
@@ -81,7 +81,7 @@ export default function SectorView() {
                     </CardTitle>
                     <div className="mt-2 space-y-2">
                       <p className="text-xs text-text-muted">
-                        Select activities to add to your profile.
+                        Select activities to add to profile.
                       </p>
 
                       {/* Collapsible help for mental model explanation */}
@@ -99,8 +99,8 @@ export default function SectorView() {
                             </p>
                             <ul className="text-xs text-text-secondary space-y-1 pl-4">
                               <li>• Each activity = one emissions source (e.g., "12oz coffee")</li>
-                              <li>• Select 5-20 activities that match your operations</li>
-                              <li>• You'll specify quantities next (e.g., "100 coffees/day")</li>
+                              <li>• Select 5-20 activities that match the operations</li>
+                              <li>• Specify quantities next (e.g., "100 coffees/day")</li>
                             </ul>
                             <p className="text-xs italic text-text-secondary">
                               Example: Coffee shop might select "Brewed coffee", "Espresso", "Milk steaming", "Electricity", "Commute"
@@ -158,7 +158,7 @@ export default function SectorView() {
                 >
                   <div className="mb-2">
                     <h3 className="text-sm font-semibold text-foreground">Sector Trend</h3>
-                    <p className="text-xs text-text-muted">Demo data: 12-month sector tracking</p>
+                    <p className="text-xs text-text-muted">Demo data: 12-month sector observation</p>
                   </div>
                   <TimeSeriesChart
                     data={getSectorEmissionsTrend(sector.id)}


### PR DESCRIPTION
## Summary

Completes Phase 2 (Consistency) and Phase 3 (Terminology) of the language reframing initiative to transform Carbon ACX from a "guilt machine" to a "literacy tool".

**Phase 1** (PR #239): Removed high-priority guilt language from main user flows
**Phase 2** (this PR): Polish remaining possessive language in supporting components  
**Phase 3** (this PR): Replace "tracking" terminology with neutral observation language

## Changes

### Phase 2: Consistency (4 files, 6 changes)

**SectorView.tsx**
- Line 84: "to your profile" → "to profile"
- Line 102: "match your operations" → "match the operations"  
- Line 103: "You'll specify" → "Specify"

**ProfilePicker.tsx**
- Line 150: "You can now compare this" → "Compare with other profiles on the dashboard"

**NavSidebar.tsx**
- Line 190: "your search" → "the search"

**OnboardingWizard.tsx**
- Line 123: "your carbon footprint" → "emission profiles"

### Phase 3: Terminology (2 files, 2 changes)

**OnboardingWizard.tsx**
- Line 190: "Activity-level tracking" → "Activity-level analysis"

**SectorView.tsx**
- Line 161: "12-month sector tracking" → "12-month sector observation"

## Testing

- ✅ **Grep audit**: Zero instances of guilt language patterns
- ✅ **TypeScript**: No compilation errors
- ✅ **Build**: Successful (2.44s)
- ✅ **Text-only**: Zero logic modifications

## Verification

```bash
# Confirmed zero guilt language remains
grep -r "your footprint\|Your footprint\|your emissions" apps/carbon-acx-web/src/ --include="*.tsx"
# (no results)

grep -r "tracking\|Tracking" apps/carbon-acx-web/src/ --include="*.tsx"
# (no results)
```

## Related Documentation

- **ACX079.md**: Language reframing strategy and principles
- **PR #239**: Phase 1 implementation (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)