### PR TITLE
chore: workspace optimization - config cleanup and documentation restructuring

### DIFF
--- a/.claude/skills.json
+++ b/.claude/skills.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0.0",
+  "description": "Carbon ACX skills configuration with template references",
+  "templates": {
+    "schema-linter": {
+      "source": "~/dev/.claude/skill-templates/schema-linter",
+      "enabled": true,
+      "filePatterns": ["**/*.{json,yaml,yml,toml}"],
+      "excludePatterns": ["node_modules/**", "dist/**", ".venv/**"]
+    },
+    "dependency-audit": {
+      "source": "~/dev/.claude/skill-templates/dependency-audit",
+      "enabled": true,
+      "filePatterns": ["package.json", "pyproject.toml", "poetry.lock", "package-lock.json"],
+      "triggerOnChange": true
+    },
+    "ci-troubleshooter": {
+      "source": "~/dev/.claude/skill-templates/ci-troubleshooter",
+      "enabled": true,
+      "filePatterns": [".github/workflows/**/*.yml"],
+      "lazyLoad": true
+    },
+    "test-analyzer": {
+      "source": "~/dev/.claude/skill-templates/test-analyzer",
+      "enabled": true,
+      "filePatterns": ["tests/**/*", "**/*.test.ts", "**/*.test.py"],
+      "lazyLoad": true
+    },
+    "doc-standards": {
+      "source": "~/dev/.claude/skill-templates/doc-standards",
+      "enabled": true,
+      "filePatterns": ["docs/acx/**/*.{md,mdx}"],
+      "lazyLoad": true
+    }
+  },
+  "projectSkills": {
+    "location": ".claude/skills/project",
+    "description": "Project-specific skills unique to Carbon ACX"
+  }
+}

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,44 @@
+# Archive directories
+docs/*/archive/
+.claude/archive/
+
+# Dependencies
+node_modules/
+.pnp/
+.pnp.js
+
+# Build outputs
+dist/
+build/
+out/
+.next/
+.turbo/
+target/
+
+# Test coverage
+coverage/
+.nyc_output/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Draft files
+*.draft.md
+*.draft.*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor directories
+.vscode/
+.idea/
+
+# Temporary files
+tmp/
+temp/
+*.tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,6 +330,25 @@ import { ActivityManagement } from '../components/domain/ActivityManagement';
 
 ---
 
+## Documentation Indexing
+
+**Active Documentation:**
+- `docs/acx/` — All files matching `ACX[0-9]{3,4}.(md|mdx)` pattern
+- `docs/acx/INDEX.md` — Active documentation catalog and next document number
+- `README.md`, `AGENTS.md`, and other root-level docs
+
+**Excluded from Indexing:**
+- `docs/acx/archive/**` — Archived documentation (180+ days old)
+- `docs/deprecated/**` — Deprecated documentation
+- `*.draft.md` — Draft documents
+
+**Archival Policy:**
+- Documents older than 90 days are automatically moved to `docs/acx/archive/` via `~/dev/scripts/archive-old-docs.sh`
+- Run manually: `bash ~/dev/scripts/archive-old-docs.sh carbon-acx ACX`
+- Archived docs remain accessible but are excluded from active indexing
+
+---
+
 ## Monorepo Structure
 
 **pnpm workspaces:**
@@ -386,5 +405,25 @@ make sbom                   # Software bill of materials
 
 ---
 
-**Version:** 2.1
-**Last Updated:** 2025-10-27
+## Skill Loading (Context-Aware)
+
+Skills are lazy-loaded based on file patterns to reduce context overhead:
+
+**Template-Based Skills** (from `~/dev/.claude/skill-templates/`):
+- **schema.linter** → `**/*.{json,yaml,yml,toml}` (excludes node_modules, dist, .venv)
+- **dependency.audit** → `package.json`, `pyproject.toml`, lockfiles (triggers on change)
+- **ci.troubleshooter** → `.github/workflows/**/*.yml` (lazy-loaded)
+- **test.analyzer** → `tests/**/*`, `**/*.test.{ts,py}` (lazy-loaded)
+- **doc.standards** → `docs/acx/**/*.{md,mdx}` (lazy-loaded)
+
+**Skip Skills For:**
+- Quick edits (<5 min, single file changes)
+- Read-only exploration
+- Docs-only sessions without code changes
+
+**Config:** See `.claude/skills.json` for file pattern mappings and template references.
+
+---
+
+**Version:** 2.2
+**Last Updated:** 2025-10-30

--- a/docs/acx/INDEX.md
+++ b/docs/acx/INDEX.md
@@ -1,0 +1,56 @@
+# ACX Documentation Index
+
+**Prefix:** ACX (Carbon ACX)  
+**Next Available Number:** ACX091
+
+## Active Documentation
+
+Current, frequently-referenced documents. See individual files for full titles.
+
+Recent documents (ACX075-ACX090):
+- [ACX075](./ACX075.md)
+- [ACX076](./ACX076.md)
+- [ACX077](./ACX077.md)
+- [ACX078](./ACX078.md)
+- [ACX079](./ACX079.md)
+- [ACX080](./ACX080.md) — Phase 1 rebuild strategy (superseded by ACX084)
+- [ACX081](./ACX081.md)
+- [ACX082](./ACX082.md)
+- [ACX083](./ACX083.md)
+- [ACX084](./ACX084.md) — 3D Universe Foundation Sprint (current architecture)
+- [ACX085](./ACX085.md)
+- [ACX086](./ACX086.md)
+- [ACX087](./ACX087.md)
+- [ACX088](./ACX088.md)
+- [ACX089](./ACX089.md)
+- [ACX090](./ACX090.md)
+
+For complete list, see: `ls -1 docs/acx/ACX*.md`
+
+## Archived Documentation
+
+Documents older than 180 days (moved to `archive/` subdirectory):
+
+**Total Archived:** 62 documents (ACX000-ACX074)
+
+Archive highlights:
+- ACX000-010: Initial planning, architecture (v1.1 Toronto/Canada pilot)
+- ACX011-048: Layer development, data sources, competitive analysis
+- ACX049-074: Sprint reports, audit reports, redesign specifications
+
+View archived docs: `ls -1 docs/ACX/archive/`
+
+## Archive Policy
+
+- Documents older than 180 days are automatically archived
+- Run: `~/dev/scripts/archive-old-docs.sh carbon-acx ACX`
+- Archived docs remain accessible in `docs/acx/archive/`
+- Claude Code excludes archived docs from context to optimize token usage
+
+## Creating New Documents
+
+1. Use next available number: **ACX091**
+2. Follow naming pattern: `ACX091 Title Here.md` or `ACX091.md`
+3. Use IEEE citation style for references
+4. Update this INDEX.md with the new document
+5. Increment "Next Available Number" above


### PR DESCRIPTION
# Workspace Optimization - carbon-acx

Part of workspace-wide cleanup (Sprints 0-6.9) to reduce Claude Code token overhead and improve maintainability.

## Changes in This Repo

### CLAUDE.md
- Updated from 390 → 430 lines (minimal growth, focused additions)
- Added **Documentation Indexing** section explaining active vs. archived docs
- Added **Skill Loading (Context-Aware)** section for lazy-loading patterns
- Updated version to 2.2 and date to 2025-10-30
- All additions support better context management

### New Documentation
- **docs/acx/INDEX.md** - Active documentation catalog with next document number tracking

### Configuration Updates
- Added **.claudeignore** to exclude archives, build artifacts, and temporary files from context
- Added **.claude/skills.json** for template-based lazy-loading (schema-linter, dependency-audit, ci-troubleshooter, test-analyzer, doc-standards)

### Impact

**Token Efficiency:**
- Lazy-loading skills reduce baseline context overhead (~50-100 tokens per skill not loaded)
- Documentation loaded on-demand via INDEX.md references  
- Archival exclusion prevents stale docs from polluting context
- Estimated ~100-150 tokens saved per session through these optimizations

**Maintainability:**
- Clear documentation lifecycle (active → archive after 90 days)
- Consistent with workspace-wide patterns (PREFIX naming, INDEX.md catalog)
- Skills only load when file patterns match (config files → schema-linter, etc.)
- Easier to discover relevant information

## Testing

- [x] Validated with ~/dev/scripts/validate-config-hierarchy.sh
- [x] No broken references in CLAUDE.md
- [x] New sections logically integrated
- [x] .claudeignore properly excludes archives and build artifacts
- [x] skills.json follows workspace template pattern

## Related

- Part of workspace-wide optimization across carbon-acx, hotbox, orpheus-sdk, wordbird
- Supersedes PR#244 (clean rebase from main after PR#242 merged)
- Sprint documentation: ~/dev/docs/workspace-optimization/

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)