### PR TITLE
Connect 3D visualization to manifest API

### DIFF
--- a/apps/carbon-acx-web/src/app/explore/3d/page.tsx
+++ b/apps/carbon-acx-web/src/app/explore/3d/page.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react'
 import Link from 'next/link'
-import type { Activity } from '@/components/viz/DataUniverse'
+import type { Activity, ManifestInfo } from '@/components/viz/DataUniverse'
 
 // Force dynamic rendering (no static generation)
 // Required because Three.js needs browser APIs (WebGL)
@@ -94,6 +94,7 @@ export default function ThreeDVisualizationPage() {
   const [selectedActivity, setSelectedActivity] = React.useState<string | null>(null)
   const [DataUniverse, setDataUniverse] = React.useState<React.ComponentType<any> | null>(null)
   const [isClient, setIsClient] = React.useState(false)
+  const [manifest, setManifest] = React.useState<ManifestInfo | null>(null)
 
   // Client-side only mount
   React.useEffect(() => {
@@ -102,6 +103,25 @@ export default function ThreeDVisualizationPage() {
     import('@/components/viz/DataUniverse').then((mod) => {
       setDataUniverse(() => mod.DataUniverse)
     })
+  }, [])
+
+  // Fetch manifest data from API
+  React.useEffect(() => {
+    fetch('/api/manifests')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.manifests && data.manifests.length > 0) {
+          const m = data.manifests[0]
+          setManifest({
+            datasetId: m.id,
+            title: m.figure_id,
+            manifestPath: m.manifest_path,
+            manifestSha256: m.hash_prefix,
+            generatedAt: m.generated_at,
+          })
+        }
+      })
+      .catch((err) => console.error('Failed to load manifest:', err))
   }, [])
 
   // Calculate total emissions
@@ -192,6 +212,7 @@ export default function ThreeDVisualizationPage() {
           <DataUniverse
             totalEmissions={totalEmissions}
             activities={SAMPLE_ACTIVITIES}
+            manifest={manifest || undefined}
             onActivityClick={handleActivityClick}
             enableIntroAnimation={true}
             enableClickToFly={true}

--- a/apps/carbon-acx-web/src/components/viz/DataUniverse.tsx
+++ b/apps/carbon-acx-web/src/components/viz/DataUniverse.tsx
@@ -34,9 +34,19 @@ export interface Activity {
   manifestId?: string // NEW: Link to manifest
 }
 
+export interface ManifestInfo {
+  datasetId?: string
+  title?: string
+  manifestPath?: string
+  manifestSha256?: string
+  generatedAt?: string
+  description?: string
+}
+
 export interface DataUniverseProps {
   totalEmissions: number // kg CO₂
   activities: Activity[]
+  manifest?: ManifestInfo
   onActivityClick?: (activity: Activity) => void
   enableIntroAnimation?: boolean
   enableClickToFly?: boolean
@@ -61,6 +71,7 @@ interface CameraAnimationState {
 export function DataUniverse({
   totalEmissions,
   activities,
+  manifest,
   onActivityClick,
   enableIntroAnimation = false,
   enableClickToFly = true,
@@ -68,6 +79,7 @@ export function DataUniverse({
   const [isReady, setIsReady] = React.useState(false)
   const [selectedActivityId, setSelectedActivityId] = React.useState<string | null>(null)
   const [hoveredActivityId, setHoveredActivityId] = React.useState<string | null>(null)
+  const [isManifestPanelOpen, setIsManifestPanelOpen] = React.useState(false)
 
   // Only render after client-side mount
   React.useEffect(() => {
@@ -168,6 +180,148 @@ export function DataUniverse({
           )}
         </Canvas>
       </ErrorBoundary>
+
+      {/* Floating Manifest Info Panel */}
+      {manifest && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '20px',
+            right: '20px',
+            zIndex: 1000,
+          }}
+        >
+          {/* Manifest Button */}
+          <button
+            onClick={() => setIsManifestPanelOpen(!isManifestPanelOpen)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              padding: '12px 16px',
+              backgroundColor: 'rgba(10, 14, 39, 0.9)',
+              color: 'white',
+              border: '1px solid rgba(255, 255, 255, 0.2)',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '14px',
+              fontWeight: '600',
+              transition: 'all 0.2s',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = 'rgba(10, 14, 39, 1)'
+              e.currentTarget.style.borderColor = 'rgba(255, 255, 255, 0.4)'
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'rgba(10, 14, 39, 0.9)'
+              e.currentTarget.style.borderColor = 'rgba(255, 255, 255, 0.2)'
+            }}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="16" y1="13" x2="8" y2="13" />
+              <line x1="16" y1="17" x2="8" y2="17" />
+              <polyline points="10 9 9 9 8 9" />
+            </svg>
+            Data Manifest
+            <span
+              style={{
+                transform: isManifestPanelOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+                transition: 'transform 0.2s',
+              }}
+            >
+              ▼
+            </span>
+          </button>
+
+          {/* Expandable Panel */}
+          {isManifestPanelOpen && (
+            <div
+              style={{
+                marginTop: '8px',
+                padding: '16px',
+                backgroundColor: 'rgba(10, 14, 39, 0.95)',
+                color: 'white',
+                border: '1px solid rgba(255, 255, 255, 0.2)',
+                borderRadius: '8px',
+                fontSize: '13px',
+                minWidth: '320px',
+                maxWidth: '400px',
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4)',
+              }}
+            >
+              <div style={{ marginBottom: '12px', paddingBottom: '12px', borderBottom: '1px solid rgba(255, 255, 255, 0.1)' }}>
+                <div style={{ fontSize: '11px', textTransform: 'uppercase', opacity: 0.6, marginBottom: '4px' }}>
+                  Dataset ID
+                </div>
+                <div style={{ fontWeight: '600', fontFamily: 'monospace' }}>
+                  {manifest.datasetId || 'N/A'}
+                </div>
+              </div>
+
+              {manifest.title && (
+                <div style={{ marginBottom: '12px', paddingBottom: '12px', borderBottom: '1px solid rgba(255, 255, 255, 0.1)' }}>
+                  <div style={{ fontSize: '11px', textTransform: 'uppercase', opacity: 0.6, marginBottom: '4px' }}>
+                    Title
+                  </div>
+                  <div style={{ fontWeight: '500' }}>
+                    {manifest.title}
+                  </div>
+                </div>
+              )}
+
+              <div style={{ marginBottom: '12px', paddingBottom: '12px', borderBottom: '1px solid rgba(255, 255, 255, 0.1)' }}>
+                <div style={{ fontSize: '11px', textTransform: 'uppercase', opacity: 0.6, marginBottom: '4px' }}>
+                  Manifest Path
+                </div>
+                <div style={{ fontWeight: '500', fontFamily: 'monospace', fontSize: '12px', color: '#10b981', wordBreak: 'break-all' }}>
+                  {manifest.manifestPath || 'N/A'}
+                </div>
+              </div>
+
+              <div style={{ marginBottom: '12px', paddingBottom: '12px', borderBottom: '1px solid rgba(255, 255, 255, 0.1)' }}>
+                <div style={{ fontSize: '11px', textTransform: 'uppercase', opacity: 0.6, marginBottom: '4px' }}>
+                  SHA-256 Hash
+                </div>
+                <div style={{ fontWeight: '500', fontFamily: 'monospace', fontSize: '12px', color: '#f59e0b', wordBreak: 'break-all' }}>
+                  {manifest.manifestSha256 || 'N/A'}
+                </div>
+              </div>
+
+              <div>
+                <div style={{ fontSize: '11px', textTransform: 'uppercase', opacity: 0.6, marginBottom: '4px' }}>
+                  Generated At
+                </div>
+                <div style={{ fontWeight: '500', fontFamily: 'monospace', fontSize: '12px' }}>
+                  {manifest.generatedAt ? new Date(manifest.generatedAt).toLocaleString() : 'N/A'}
+                </div>
+              </div>
+
+              {manifest.description && (
+                <div style={{ marginTop: '12px', paddingTop: '12px', borderTop: '1px solid rgba(255, 255, 255, 0.1)' }}>
+                  <div style={{ fontSize: '11px', textTransform: 'uppercase', opacity: 0.6, marginBottom: '4px' }}>
+                    Description
+                  </div>
+                  <div style={{ fontSize: '12px', opacity: 0.8, lineHeight: '1.5' }}>
+                    {manifest.description}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Add floating manifest info panel to 3D DataUniverse visualization.

Changes:
- Add ManifestInfo interface to DataUniverse component
- Implement floating 'Data Manifest' button with expandable panel
- Display dataset ID, manifest path, SHA-256 hash, timestamp
- Connect to /api/manifests endpoint for real manifest data
- Color-coded fields: green (path), amber (hash)
- Non-intrusive UI with inline styles (bottom-right floating)

Technical:
- Client-side manifest loading via fetch('/api/manifests')
- Graceful error handling for missing manifest data
- Maintains SSR safety (client-side only rendering)
- No CSS conflicts with 3D canvas

Resolves ACX093 Phase 4 requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Traceability
Implements (spec): ACX###
Prompt (execution): CDX###
Related issues/tickets: #

## Summary
- What changed:
- Why:

## Data/Sources
- New sources.csv rows? (y/n)
- IEEE references added/updated:

## Citations
- [ ] Citation present for every numeric claim
- [ ] Scope/horizon/region/vintage set for new or changed data
- [ ] IEEE references added or updated in calc/references
- [ ] Artifact References.txt files regenerated

## Tests
- [ ] make validate passes
- [ ] pytest passes
